### PR TITLE
Names collide by default, fixed that. Not ideal but allows you to use…

### DIFF
--- a/R2API/ReflectionCache.cs
+++ b/R2API/ReflectionCache.cs
@@ -14,60 +14,60 @@ namespace R2API
 
 		private const BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
 
-		public static FieldInfo GetField<T>(string name, BindingFlags bindingFlags = _bindingFlags)
+		public static FieldInfo CGetField<T>(string name, BindingFlags bindingFlags = _bindingFlags)
 		{
-			return GetField(typeof(T), name, bindingFlags);
+			return CGetField(typeof(T), name, bindingFlags);
 		}
 
-		public static FieldInfo GetField(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
+		public static FieldInfo CGetField(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var key = new KeyValuePair<Type, string>(T, name);
 			if (fieldCache.ContainsKey(key)) {
 				return fieldCache[key];
 			}
 
-			var fieldInfo = T.GetField(name, bindingFlags);
+			var fieldInfo = T.CGetField(name, bindingFlags);
 			fieldCache[key] = fieldInfo;
 			return fieldInfo;
 		}
 
-		public static void SetFieldValue<T>(this object instance, string name, T value, BindingFlags bindingFlags = _bindingFlags)
+		public static void CSetFieldValue<T>(this object instance, string name, T value, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var type = instance.GetType();
-			GetField(type, name, bindingFlags).SetValue(instance, value);
+			CGetField(type, name, bindingFlags).SetValue(instance, value);
 		}
 
-		public static T GetFieldValue<T>(this object instance, string name, BindingFlags bindingFlags = _bindingFlags)
+		public static T CGetFieldValue<T>(this object instance, string name, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var type = instance.GetType();
-			return (T)GetField(type, name, bindingFlags).GetValue(instance);
+			return (T)CGetField(type, name, bindingFlags).GetValue(instance);
 		}
 
-		public static MethodInfo GetMethod<T>(string name, BindingFlags bindingFlags = _bindingFlags)
+		public static MethodInfo CGetMethod<T>(string name, BindingFlags bindingFlags = _bindingFlags)
 		{
-			return GetMethod(typeof(T), name, bindingFlags);
+			return CGetMethod(typeof(T), name, bindingFlags);
 		}
 
-		public static MethodInfo GetMethod(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
+		public static MethodInfo CGetMethod(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var key = new KeyValuePair<Type, string>(T, name);
 			if (methodCache.ContainsKey(key)) {
 				return methodCache[key];
 			}
 
-			var methodInfo = T.GetMethod(name, bindingFlags);
+			var methodInfo = T.CGetMethod(name, bindingFlags);
 			methodCache[key] = methodInfo;
 			return methodInfo;
 		}
 
-		public static MethodInfo GetMethod(this Type T, string name, Type[] argumentTypes, BindingFlags bindingFlags = _bindingFlags)
+		public static MethodInfo CGetMethod(this Type T, string name, Type[] argumentTypes, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var key = new Tuple<Type, string, Type[]>(T, name, argumentTypes);
 			if (overloadedMethodCache.ContainsKey(key)) {
 				return overloadedMethodCache[key];
 			}
 
-			var methodInfo = T.GetMethod(name, bindingFlags);
+			var methodInfo = T.CGetMethod(name, bindingFlags);
 			overloadedMethodCache[key] = methodInfo;
 			return methodInfo;
 		}
@@ -75,43 +75,43 @@ namespace R2API
 		public static T InvokeMethod<T>(this object instance, string name, BindingFlags bindingFlags = _bindingFlags, params object[] args)
 		{
 			var type = instance.GetType();
-			return (T)GetMethod(type, name, bindingFlags).Invoke(instance, args);
+			return (T)CGetMethod(type, name, bindingFlags).Invoke(instance, args);
 		}
 
 		public static T InvokeMethod<T>(this object instance, string name, Type[] argumentTypes, BindingFlags bindingFlags = _bindingFlags, params object[] args)
 		{
 			var type = instance.GetType();
-			return (T)GetMethod(type, name, argumentTypes, bindingFlags).Invoke(instance, args);
+			return (T)CGetMethod(type, name, argumentTypes, bindingFlags).Invoke(instance, args);
 		}
 
 
-		public static PropertyInfo GetProperty<T>(string name, BindingFlags bindingFlags = _bindingFlags)
+		public static PropertyInfo CGetProperty<T>(string name, BindingFlags bindingFlags = _bindingFlags)
 		{
-			return GetProperty(typeof(T), name, bindingFlags);
+			return CGetProperty(typeof(T), name, bindingFlags);
 		}
 
-		public static PropertyInfo GetProperty(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
+		public static PropertyInfo CGetProperty(this Type T, string name, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var key = new KeyValuePair<Type, string>(T, name);
 			if (propertyCache.ContainsKey(key)) {
 				return propertyCache[key];
 			}
 
-			var propertyInfo = T.GetProperty(name, bindingFlags);
+			var propertyInfo = T.CGetProperty(name, bindingFlags);
 			propertyCache[key] = propertyInfo;
 			return propertyInfo;
 		}
 
-		public static T GetPropertyValue<T>(this object instance, string name, BindingFlags bindingFlags = _bindingFlags)
+		public static T CGetPropertyValue<T>(this object instance, string name, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var type = instance.GetType();
-			return (T)GetProperty(type, name, bindingFlags).GetValue(instance);
+			return (T)CGetProperty(type, name, bindingFlags).GetValue(instance);
 		}
 
-		public static void SetPropertyValue<T>(this object instance, string name, T value, BindingFlags bindingFlags = _bindingFlags)
+		public static void CSetPropertyValue<T>(this object instance, string name, T value, BindingFlags bindingFlags = _bindingFlags)
 		{
 			var type = instance.GetType();
-			GetProperty(type, name, bindingFlags).SetValue(instance, value);
+			CGetProperty(type, name, bindingFlags).SetValue(instance, value);
 		}
 	}
 }


### PR DESCRIPTION
… it now. Prefixed with `C` to indicate `Cached`. Maybe just add `Cached` to the end.