### PR TITLE
Survivor API rework

### DIFF
--- a/R2API.MonoMod/R2API.MonoMod.csproj
+++ b/R2API.MonoMod/R2API.MonoMod.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Assembly-CSharp.R2API.mm</AssemblyName>
+        <RootNamespace>RoR2</RootNamespace>
+        <LangVersion>7.1</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>..\R2API\libs\Assembly-CSharp.dll</HintPath>
+            <Private>False</Private>
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </Reference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\R2API\R2API.csproj">
+        </ProjectReference>
+    </ItemGroup>
+
+</Project>

--- a/R2API.MonoMod/SurvivorAPI.cs
+++ b/R2API.MonoMod/SurvivorAPI.cs
@@ -1,0 +1,7 @@
+﻿namespace RoR2 {
+    internal class patch_SurvivorCatalog {
+        public static SurvivorDef GetSurvivorDef(SurvivorIndex survivorIndex) {
+            return R2API.SurvivorAPI.GetSurvivorDef(survivorIndex);
+        }
+    }
+}

--- a/R2API.sln
+++ b/R2API.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.572
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API", "R2API\R2API.csproj", "{2F8A40CC-6D15-486D-B689-0A7A472DB89E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.MonoMod", "R2API.MonoMod\R2API.MonoMod.csproj", "{EA7A07AF-BCF5-48C1-BEFB-B569785743FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{2F8A40CC-6D15-486D-B689-0A7A472DB89E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F8A40CC-6D15-486D-B689-0A7A472DB89E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F8A40CC-6D15-486D-B689-0A7A472DB89E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA7A07AF-BCF5-48C1-BEFB-B569785743FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA7A07AF-BCF5-48C1-BEFB-B569785743FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA7A07AF-BCF5-48C1-BEFB-B569785743FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA7A07AF-BCF5-48C1-BEFB-B569785743FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -163,7 +163,7 @@ namespace R2API {
             });
 
             SurvivorCatalog.survivorMaxCount =
-                Math.Max((int) SurvivorDefinitions.Select(x => x.survivorIndex).Max() + 1, 10);
+                Math.Max((int) SurvivorDefinitions.Select(x => x.survivorIndex).Max() + (GetSurvivorDef(SurvivorIndex.Count) != null ? 1 : 0), 10);
             SurvivorCatalog.idealSurvivorOrder = SurvivorDefinitions.Select(x => x.survivorIndex).ToArray();
 
             // Only contains not null survivors

--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -154,9 +154,9 @@ namespace R2API {
 
         private static void ReconstructSurvivors() {
             SurvivorDefinitions.GroupBy(x => x.survivorIndex).Where(x => x.Count() > 1).ToList().ForEach(x => {
-                Debug.LogError($"{CenterText("!ERROR!")}");
-                Debug.LogError($"{CenterText($"One of your mods assigns a duplicate SurvivorIndex for \"{x.Key}\"")}");
-                Debug.LogError($"{CenterText("Please ask the author to fix their mod.")}");
+                R2API.Logger.LogError($"{CenterText("!ERROR!")}");
+                R2API.Logger.LogError($"{CenterText($"One of your mods assigns a duplicate SurvivorIndex for \"{x.Key}\"")}");
+                R2API.Logger.LogError($"{CenterText("Please ask the author to fix their mod.")}");
             });
 
             SurvivorCatalog.survivorMaxCount =
@@ -210,9 +210,9 @@ namespace R2API {
             if (overLimit == null || SurvivorCatalog.GetSurvivorDef(overLimit.survivorIndex) != null)
                 return;
 
-            Debug.LogError($"{CenterText("!ERROR!")}");
-            Debug.LogError($"{CenterText("MonoMod component of R2API is not installed correctly!")}");
-            Debug.LogError($"{CenterText("Please copy Assembly-CSharp.R2API.mm.dll to BepInEx/monomod.")}");
+            R2API.Logger.LogError($"{CenterText("!ERROR!")}");
+            R2API.Logger.LogError($"{CenterText("MonoMod component of R2API is not installed correctly!")}");
+            R2API.Logger.LogError($"{CenterText("Please copy Assembly-CSharp.R2API.mm.dll to BepInEx/monomod.")}");
         }
 
         private static string CenterText(string text = "", int width = 80) =>

--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -29,14 +29,12 @@ namespace R2API {
 
             detour.Apply();
 
-            // TODO: this does not work at all.
+            // TODO: this does not work at all due to inlining.
             On.RoR2.SurvivorCatalog.GetSurvivorDef += (orig, survivorIndex) => GetSurvivorDef(survivorIndex);
         }
 
-        public static SurvivorDef GetSurvivorDef(SurvivorIndex survivorIndex) {
-            Debug.Log("Custom GetSurvivorDef called, thank god.");
-            return SurvivorDefinitions.FirstOrDefault(x => x.survivorIndex == survivorIndex);
-        }
+        public static SurvivorDef GetSurvivorDef(SurvivorIndex survivorIndex) =>
+            SurvivorDefinitions.FirstOrDefault(x => x.survivorIndex == survivorIndex);
 
         /// <summary>
         /// Add a SurvivorDef to the list of available survivors. Use on SurvivorCatalogReady event.


### PR DESCRIPTION
Complete rework of `SurvivorAPI.ReconstructSurvivors`, addition of `SurvivorAPI.AddSurvivor` and `SurvivorAPI.AddSurvivorOnReady` for hassle-free insertion of survivors, addition of a MonoMod component instead of a hook because `RoR2.SurvivorCatalog.GetSurvivorDef` gets inlined.