### PR TITLE
Removed extra isModded = true;

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -33,11 +33,6 @@ namespace R2API {
 
             RoR2Application.isModded = true;
 
-            On.RoR2.DisableIfGameModded.OnEnable += (orig, self) => {
-                RoR2Application.isModded = true;
-                orig(self);
-            };
-
             On.RoR2.RoR2Application.OnLoad += (orig, self) => {
                 orig(self);
 


### PR DESCRIPTION
Setting it once is enough. If people are going to modify their game to make it appear as unmodded, there are far easier ways to do it that aren't stopped by this override. The way things are now, this only stops legitimate mods from enabling mod-only matchmaking with minimal effort.