### PR TITLE
Fix the SurvivorAPI for the Skills 2.0 Game Update

### DIFF
--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -33,8 +33,6 @@ namespace R2API {
             detour.Apply();
 
             On.RoR2.SurvivorCatalog.GetSurvivorDef += (orig, index) => GetSurvivorDef(index);
-            On.RoR2.SurvivorCatalog.GetSurvivorIndexFromBodyIndex += (orig, index) => GetSurvivorIndexFromBodyIndex(index);
-            On.RoR2.SurvivorCatalog.GetBodyIndexFromSurvivorIndex += (orig, index) => GetBodyIndexFromSurvivorIndex(index);
 
             // TODO: THIS IS A HOTFIX, WHY IS THE FIRST CHARACTERBODY NULL
             On.RoR2.UI.LogBook.LogBookController.BuildCategories += orig => {
@@ -48,14 +46,6 @@ namespace R2API {
 
         public static SurvivorDef GetSurvivorDef(SurvivorIndex survivorIndex) =>
             SurvivorDefinitions.FirstOrDefault(x => x.survivorIndex == survivorIndex);
-
-        public static SurvivorIndex GetSurvivorIndexFromBodyIndex(int bodyIndex) {
-            return typeof(SurvivorCatalog).GetFieldValue<SurvivorIndex[]>("bodyIndexToSurvivorIndex")[bodyIndex];
-        }
-
-        public static int GetBodyIndexFromSurvivorIndex(SurvivorIndex survivorIndex) {
-            return typeof(SurvivorCatalog).GetFieldValue<int[]>("survivorIndexToBodyIndex")[(int)survivorIndex];
-        }
 
         /// <summary>
         /// Add a SurvivorDef to the list of available survivors. Use on SurvivorCatalogReady event.

--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -217,10 +217,9 @@ namespace R2API {
             );
 
             var bodyIndexToSurvivorIndex = new SurvivorIndex[BodyCatalog.bodyCount];
-            var survivorIndexToBodyIndex = new int[SurvivorDefinitions.Count];
+            var survivorIndexToBodyIndex = new int[SurvivorCatalog.survivorMaxCount];
 
-            foreach (var survivorDef in SurvivorDefinitions)
-            {
+            foreach (var survivorDef in SurvivorDefinitions) {
                 int bodyIndex = survivorDef.bodyPrefab.GetComponent<CharacterBody>().bodyIndex;
                 bodyIndexToSurvivorIndex[bodyIndex] = survivorDef.survivorIndex;
                 survivorIndexToBodyIndex[(int)survivorDef.survivorIndex] = bodyIndex;

--- a/R2API/SurvivorAPI.cs
+++ b/R2API/SurvivorAPI.cs
@@ -217,7 +217,7 @@ namespace R2API {
             );
 
             var bodyIndexToSurvivorIndex = new SurvivorIndex[BodyCatalog.bodyCount];
-            var survivorIndexToBodyIndex = new int[(int)SurvivorIndex.Count];
+            var survivorIndexToBodyIndex = new int[SurvivorDefinitions.Count];
 
             foreach (var survivorDef in SurvivorDefinitions)
             {


### PR DESCRIPTION
1.The SurvivorCatalog now has 2 new arrays : 
`SurvivorIndex[] bodyIndexToSurvivorIndex`
`int[] survivorIndexToBodyIndex`
Making sure they are updated each time a new survivor is added in `ReconstructSurvivors()`.

2. Adding the Loader SurvivorDef