### PR TITLE
Adds the possibility for mods to register convars

### DIFF
--- a/R2API/Utils/CommandHelper.cs
+++ b/R2API/Utils/CommandHelper.cs
@@ -3,8 +3,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using System.Runtime.CompilerServices;
 using RoR2;
+using RoR2.ConVar;
+using UnityEngine;
 
 namespace R2API.Utils {
     /*
@@ -36,6 +38,37 @@ namespace R2API.Utils {
 
                     catalog[attribute.commandName.ToLower()] = conCommand;
                 }
+            }
+        }
+
+        public static void RegisterConVars(RoR2.Console self) {
+            var assembly = Assembly.GetCallingAssembly();
+            if(assembly==null) {
+                return;
+            }
+
+            if (self.allConVars == null) {
+                Debug.LogErrorFormat("Can't register the convars from mod {0} before the game does. Try doing it after initConvars!",assembly.FullName);
+            }
+
+            List<BaseConVar> customVars = new List<BaseConVar>();
+            foreach (Type type in assembly.GetTypes()) {
+                foreach (FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)) {
+                    if (field.FieldType.IsSubclassOf(typeof(BaseConVar))) {
+                        if (field.IsStatic) {
+                            self.RegisterConVarInternal((BaseConVar)field.GetValue(null));
+                            customVars.Add((BaseConVar) field.GetValue(null));
+                        }
+                        else if (CustomAttributeExtensions.GetCustomAttribute<CompilerGeneratedAttribute>(type) == null)
+                            Debug.LogErrorFormat("ConVar defined as {0} in {1}. {2} could not be registered. ConVars must be static fields.", type.Name, assembly.FullName, field.Name);
+                    }
+                }
+            }
+            foreach (BaseConVar baseConVar in customVars) {
+                if ((baseConVar.flags & ConVarFlags.Engine) != ConVarFlags.None)
+                    baseConVar.defaultValue = baseConVar.GetString();
+                else if (baseConVar.defaultValue != null)
+                    baseConVar.SetString(baseConVar.defaultValue);
             }
         }
     }

--- a/R2API/Utils/CommandHelper.cs
+++ b/R2API/Utils/CommandHelper.cs
@@ -9,14 +9,13 @@ using RoR2.ConVar;
 using UnityEngine;
 
 namespace R2API.Utils {
-    /*
-         This code belongs to Wildbook. 
-         https://github.com/wildbook/R2Mods/blob/develop/Utilities/CommandHelper.cs
-         Credit goes to Wildbook.         
-             */
-
     public class CommandHelper {
         public static void RegisterCommands(RoR2.Console self) {
+                /*
+            This code belongs to Wildbook. 
+            https://github.com/wildbook/R2Mods/blob/develop/Utilities/CommandHelper.cs
+            Credit goes to Wildbook.         
+                */
             var types = Assembly.GetCallingAssembly()?.GetTypes();
             if (types == null) {
                 return;

--- a/R2API/Utils/CommandHelper.cs
+++ b/R2API/Utils/CommandHelper.cs
@@ -48,7 +48,8 @@ namespace R2API.Utils {
             }
 
             if (self.allConVars == null) {
-                Debug.LogErrorFormat("Can't register the convars from mod {0} before the game does. Try doing it after initConvars!",assembly.FullName);
+                Debug.LogErrorFormat("Can't register the convars from mod {0} before the game does. Try doing it after initConvars!",assembly.GetName().Name);
+                return;
             }
 
             List<BaseConVar> customVars = new List<BaseConVar>();


### PR DESCRIPTION
Detects fields derived from `RoR2.Convar.BaseConvar` in an assembly and adds it to the console.
The assembly itself needs to call `RegisterConVars` anytime after `initConvars` happens in the game.