### PR TITLE
use reflection for private method

### DIFF
--- a/R2API/Utils/CommandHelper.cs
+++ b/R2API/Utils/CommandHelper.cs
@@ -106,7 +106,8 @@ namespace R2API.Utils {
                 foreach (FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)) {
                     if (field.FieldType.IsSubclassOf(typeof(BaseConVar))) {
                         if (field.IsStatic) {
-                            console.RegisterConVarInternal((BaseConVar)field.GetValue(null));//TODO: Use reflection here instead because publicize can fail for some people if I understand correctly. This method may be cached until the submodule is unloaded.
+                            console.InvokeMethod("RegisterConVarInternal", (BaseConVar)field.GetValue(null));
+                            //console.RegisterConVarInternal((BaseConVar)field.GetValue(null));//This line fails on Release.
                             customVars.Add((BaseConVar) field.GetValue(null));
                         }
                         else if (CustomAttributeExtensions.GetCustomAttribute<CompilerGeneratedAttribute>(type) == null)
@@ -123,3 +124,4 @@ namespace R2API.Utils {
         }
     }
 }
+//


### PR DESCRIPTION
Current version breaks when building for Release, I did not account for this when I submitted my previous PR.
Switching to reflection instead of just using a private method works.
Thanks @paddywaan for reporting this.