### PR TITLE
Disabled modded entries sorting

### DIFF
--- a/R2API.MonoMod/CatalogModHelperFix.cs
+++ b/R2API.MonoMod/CatalogModHelperFix.cs
@@ -17,7 +17,6 @@ namespace RoR2 {
             List<TEntry> moddedEntries = new List<TEntry>();
             getAdditionalEntries?.Invoke(moddedEntries);
 
-            moddedEntries.Sort((a, b) => StringComparer.Ordinal.Compare(nameGetter(a), nameGetter(b)));
             Array.Resize(ref entries, vanillaEntriesLength + moddedEntries.Count);
 
             for (int i = vanillaEntriesLength; i < moddedEntries.Count + vanillaEntriesLength; i++) {


### PR DESCRIPTION
The CatalogModHelper currently sort each new Modded Entries by their name, which mess up our manual retrieval of their index, we don't need it : but because of that, we have also to make sure people playing with the same set of mods have the same plugins loading orders (folder structure may change it). Something that the next BepinEx release on thunderstore will take care of