### PR TITLE
Adds the DifficultyAPI

### DIFF
--- a/R2API.MonoMod/NoInlinePatches.cs
+++ b/R2API.MonoMod/NoInlinePatches.cs
@@ -7,4 +7,9 @@ namespace RoR2 {
         [MonoModIgnore] [NoInlining]
         public static extern SurvivorDef GetSurvivorDef(SurvivorIndex survivorIndex);
     }
+
+    internal class patch_DifficultyCatalog {
+        [MonoModIgnore] [NoInlining]
+        public static extern DifficultyDef GetDifficultyDef(DifficultyIndex difficultyIndex);
+    }
 }

--- a/R2API/DifficultyAPI.cs
+++ b/R2API/DifficultyAPI.cs
@@ -80,7 +80,6 @@ namespace R2API {
             ruleChoices.choices.Sort(delegate(RuleChoiceDef x, RuleChoiceDef y){
                 var xDiffValue = getScalingValue(x);
                 var yDiffValue = getScalingValue(y);
-                Debug.Log($"Comparing {x.localName}.{xDiffValue} to {y.localName}.{yDiffValue}");
                 return xDiffValue.CompareTo(yDiffValue);            
             });
             return ruleChoices;

--- a/R2API/DifficultyAPI.cs
+++ b/R2API/DifficultyAPI.cs
@@ -1,0 +1,82 @@
+using R2API.Utils;
+using RoR2;
+using System;
+using System.Collections.ObjectModel;
+
+namespace R2API {
+    [R2APISubmodule]
+    public class DifficultyAPI{
+
+        private static bool difficultyAlreadyAdded = false;
+
+        public static event EventHandler difficultyCatalogReady;
+
+        public static ObservableCollection<DifficultyDef> difficultyDefinitions = new ObservableCollection<DifficultyDef>();
+        /// <summary>
+        /// Add a DifficultyDef to the list of available difficulties.
+        /// This must be called before the DifficultyCatalog inits, so before plugin.Start()
+        /// Value for DifficultyDef.index is set by r2api, so, you'll get your new index returned.
+        /// If this is called after the DifficultyCatalog inits then this will return -1 and ignore the difficulty
+        /// </summary>
+        /// <param name="difficulty">The difficulty to add.</param>
+        /// <returns>-1 if it fails. Your index otherwise.</returns>
+        public static int AddDifficulty(DifficultyDef difficulty) {
+            if (difficultyAlreadyAdded) {
+                R2API.Logger.LogError($"Tried to add difficulty: {difficulty.nameToken} after survivor list was created");
+                return -1;
+            }
+
+            difficultyDefinitions.Add(difficulty);
+
+            return 2+difficultyDefinitions.Count;
+        }
+
+
+        [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
+        internal static void SetHooks() {
+            difficultyCatalogReady?.Invoke(null, null);
+            difficultyAlreadyAdded = true;
+            On.RoR2.DifficultyCatalog.GetDifficultyDef += DifficultyCatalog_GetDifficultyDef;
+            On.RoR2.RuleDef.FromDifficulty += RuleDef_FromDifficulty;
+        }
+
+        [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
+        internal static void UnsetHooks() {
+            On.RoR2.DifficultyCatalog.GetDifficultyDef -= DifficultyCatalog_GetDifficultyDef;
+            On.RoR2.RuleDef.FromDifficulty -= RuleDef_FromDifficulty;
+        }
+
+        private static DifficultyDef DifficultyCatalog_GetDifficultyDef(On.RoR2.DifficultyCatalog.orig_GetDifficultyDef orig, DifficultyIndex difficultyIndex)
+        {
+            int index = (int) difficultyIndex;
+            if(index >= DifficultyCatalog.difficultyDefs.Length && index < difficultyDefinitions.Count+2){
+                return difficultyDefinitions[index-2];
+            }
+            return orig(difficultyIndex);
+        }
+        private static RuleDef RuleDef_FromDifficulty(On.RoR2.RuleDef.orig_FromDifficulty orig)
+        {
+            RuleDef ruleChoices = orig();
+            for( int i =0; i<difficultyDefinitions.Count;i++){
+                DifficultyDef difficultyDef = difficultyDefinitions[i];
+                RuleChoiceDef choice = ruleChoices.AddChoice(Language.GetString(difficultyDef.nameToken), null, false);
+                choice.spritePath = difficultyDef.iconPath;
+                choice.tooltipNameToken = difficultyDef.nameToken;
+                choice.tooltipNameColor = difficultyDef.color;
+                choice.tooltipBodyToken = difficultyDef.descriptionToken;
+                choice.difficultyIndex = (DifficultyIndex) i+2;
+                }
+            ruleChoices.choices.Sort((x,y)=>{
+                return DifficultyCatalog
+                        .GetDifficultyDef(x.difficultyIndex)
+                        .scalingValue
+                        .CompareTo(
+                            DifficultyCatalog
+                            .GetDifficultyDef(y.difficultyIndex)
+                            .scalingValue
+                            );
+            });
+            return ruleChoices;
+        }
+    }
+}


### PR DESCRIPTION
Used for adding difficulties. This design can probably be generalized to all rule sections.
Because the Difficulty array is in static class as a static readonly array, modifying it is hard. Future patches might change this to a nonreadonly array, as said by Ghor. I'll keep an eye out.
Use:
```csharp
DifficultyDef myDifficultyDef = new DifficultyDef(myScalingFactor /*(1f=drizzle,2f=rainstorm,3f=monsoon)*/, myNameToken, myIconPath, myDescriptionToken, hoverOverColor);
DifficultyIndex myDifficultyIndex = R2API.DifficultyAPI.AddDifficulty(myDifficultyDef);//pretend this is actual declared inside the valid scope
// Then at any point later you can 
if(Run.Instance && Run.Instance.selectedDifficulty == myDifficultyIndex)
{
//cool code that only happens in your difficulty here.
}
```