### PR TITLE
Master

### DIFF
--- a/R2API/DirectorAPIinternal.cs
+++ b/R2API/DirectorAPIinternal.cs
@@ -39,7 +39,7 @@ namespace R2API {
             if( !info ) return stageInfo;
             SceneDef scene = info.sceneDef;
             if( !scene ) return stageInfo;
-            switch( scene.sceneName ) {
+            switch( scene.baseSceneName ) {
                 case "golemplains":
                     stageInfo.stage = Stage.TitanicPlains;
                     break;
@@ -69,7 +69,7 @@ namespace R2API {
                     break;
                 default:
                     stageInfo.stage = Stage.Custom;
-                    stageInfo.customStageName = scene.sceneName;
+                    stageInfo.customStageName = scene.baseSceneName;
                     break;
             }
             return stageInfo;

--- a/R2API/EffectAPI.cs
+++ b/R2API/EffectAPI.cs
@@ -17,7 +17,7 @@ namespace R2API {
         /// <param name="effect">The prefab of the effect to be added</param>
         /// <returns>True if the effect was added</returns>
         public static bool AddEffect(GameObject effect) {
-            List<GameObject> effects = EffectManager.instance.GetFieldValue<List<GameObject>>("effectPrefabsList");
+            /*List<GameObject> effects = EffectManager.instance.GetFieldValue<List<GameObject>>("effectPrefabsList");
             Dictionary<GameObject, uint> effectLookup = EffectManager.instance.GetFieldValue<Dictionary<GameObject, uint>>("effectPrefabToIndexMap");
 
             if(!effect) {
@@ -29,7 +29,11 @@ namespace R2API {
             effects.Add( effect );
             effectLookup.Add( effect, (uint)index );
 
-            return true;
+            return true;*/
+
+            R2API.Logger.LogError("EffectAPI is currently broken for now");
+
+            return false;
         }
     }
 }

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -34,12 +34,6 @@ namespace R2API {
         #region ModHelper Events and Hooks
         [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
         internal static void SetHooks() {
-            // Temporary fix as the getter from the buffCount propriety doesnt retrieve from BuffCatalog.buffDefs.Length directly
-            On.RoR2.BuffCatalog.Init += orig => {
-                orig();
-                typeof(BuffCatalog).SetPropertyValue("buffCount", typeof(BuffCatalog).GetFieldValue<BuffDef[]>("buffDefs").Length);
-            };
-
             IL.RoR2.ItemCatalog.DefineItems += il => {
                 var cursor = new ILCursor(il);
 
@@ -67,7 +61,7 @@ namespace R2API {
                 );
             };
 
-            IL.RoR2.EliteCatalog.cctor += il => {
+            IL.RoR2.EliteCatalog.Init += il => {
                 var cursor = new ILCursor(il);
 
                 cursor.GotoNext(

--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using BepInEx;
 using BepInEx.Logging;
+using Facepunch.Steamworks;
 using MonoMod.RuntimeDetour;
 using MonoMod.RuntimeDetour.HookGen;
 using R2API.Utils;
@@ -21,7 +22,7 @@ namespace R2API {
         public const string PluginVersion = "0.0.1";
 
 
-        private const int GameBuild = 4233443;
+        private const int GameBuild = 4478858;
 
         internal new static ManualLogSource Logger { get; set; }
 
@@ -38,7 +39,7 @@ namespace R2API {
 
             On.RoR2.RoR2Application.UnitySystemConsoleRedirector.Redirect += orig => { };
             var submoduleHandler = new APISubmoduleHandler(GameBuild, Logger);
-            submoduleHandler.LoadAll();
+            submoduleHandler.LoadRequested();
 
             RoR2Application.isModded = true;
 
@@ -50,13 +51,14 @@ namespace R2API {
                 self.gameObject.SetActive(false);
             };
 
-            On.RoR2.RoR2Application.OnLoad += (orig, self) => {
-                orig(self);
+            SteamworksClientManager.onLoaded += () => {
+                var buildId =
+                    SteamworksClientManager.instance.GetFieldValue<Client>("steamworksClient").BuildId;
 
-                if (GameBuild == self.steamworksClient.BuildId)
+                if (GameBuild == buildId)
                     return;
 
-                Logger.LogWarning($"This version of R2API was built for build id \"{GameBuild}\", you are running \"{self.steamworksClient.BuildId}\".");
+                Logger.LogWarning($"This version of R2API was built for build id \"{GameBuild}\", you are running \"{buildId}\".");
                 Logger.LogWarning("Should any problems arise, please check for a new version before reporting issues.");
             };
         }


### PR DESCRIPTION
- Fix DirectorAPI : SceneDef had a field rename.
- EffectAPI is disabled for now as the game went through a huge refactor for the EffectManager.
- APISubmodule now only load requested submodules. It goes through the plugins folder of BepinEx and look for any plugins that has a Submodule Attribute in it.
- ItemAPI : Fix hook for EliteCatalog. Removed temporary fix for buff count as it is now fixed.
R2API.cs : Now has an Action event hook for checking Game Build ID instead as they did some refactoring too (dedicated server)

! MMHOOK.dll and Assembly-CSharp still need to be updated / stripped