### PR TITLE
Add Warning when monomod patch is missing

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -34,6 +34,7 @@ namespace R2API {
             AddHookLogging();
 
             CheckForIncompatibleAssemblies();
+            CheckR2APIMonomodPatch();
 
             Environment.SetEnvironmentVariable("MONOMOD_DMD_TYPE", "Cecil");
 
@@ -61,10 +62,11 @@ namespace R2API {
                 Logger.LogWarning($"This version of R2API was built for build id \"{GameBuild}\", you are running \"{buildId}\".");
                 Logger.LogWarning("Should any problems arise, please check for a new version before reporting issues.");
             };
+
             On.RoR2.SteamworksServerManager.UpdateHostName += (orig, self, hostname) => {
                 orig(self, $"[MOD] {hostname}");
-                Server server = ((SteamworksServerManager)self).GetFieldValue<Server>("steamworksServer");
-                server.GameTags = "mod,"+ server.GameTags;
+                var server = ((SteamworksServerManager)self).GetFieldValue<Server>("steamworksServer");
+                server.GameTags = "mod," + server.GameTags;
             };
         }
 
@@ -118,6 +120,21 @@ namespace R2API {
                 return;
 
             Logger.LogBlockError(info);
+        }
+
+        // ReSharper disable once InconsistentNaming
+        private static void CheckR2APIMonomodPatch() {
+            var isHere = AppDomain.CurrentDomain.GetAssemblies().Any(assembly => assembly.FullName.ToLower().Contains("r2api.mm.monomodrules"));
+
+            if (!isHere) {
+                var message = new List<string> {
+                    "The Monomod patch of R2API seems to be missing",
+                    "Please make sure that a file called:",
+                    "Assembly-CSharp.R2API.mm.dll",
+                    "is present in the Risk of Rain 2\\BepInEx\\monomod\\ folder",
+                };
+                Logger.LogBlockError(message);
+            }
         }
     }
 }

--- a/R2API/Utils/APISubmodule.cs
+++ b/R2API/Utils/APISubmodule.cs
@@ -48,7 +48,7 @@ namespace R2API.Utils {
         }
 
         public void LoadRequested() {
-            Assembly[] getAssemblies() {
+            Assembly[] GetAssemblies() {
                 var assemblies = new List<Assembly>();
 
                 var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -58,7 +58,7 @@ namespace R2API.Utils {
                 }
 
                 foreach (string dll in Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories)) {
-                    if (!dll.ToLower().Contains("r2api") || !dll.ToLower().Contains("mmhook")) {
+                    if (!dll.ToLower().Contains("r2api") && !dll.ToLower().Contains("mmhook")) {
                         try // bepis code
                         {
                             assemblies.Add(Assembly.LoadFile(dll));
@@ -72,7 +72,7 @@ namespace R2API.Utils {
                 return assemblies.ToArray();
             }
 
-            var allTypes = getAssemblies()
+            var allTypes = GetAssemblies()
                 .SelectMany(assembly => {
                     try {
                         return assembly.GetTypes();
@@ -98,7 +98,7 @@ namespace R2API.Utils {
                 R2API.Logger.LogInfo($"Requested R2API Submodule: {module}");
             }
 
-            var moduleTypes = allTypes.Where(APISubmoduleFilter);
+            var moduleTypes = Assembly.GetExecutingAssembly().GetTypes().Where(APISubmoduleFilter).ToList();
 
             foreach (var moduleType in moduleTypes) {
                 R2API.Logger.LogInfo($"Found and Enabling R2API Submodule: {moduleType.FullName}");


### PR DESCRIPTION
- Add a method that warn the users if the r2api monomod patch is missing.
- fix a bug where the submodules can be loaded twice if a user have a duplicate r2api.dll in their plugins/ folder