### PR TITLE
Fix/update for ModListAPI

### DIFF
--- a/R2API/ModlistAPI.cs
+++ b/R2API/ModlistAPI.cs
@@ -14,6 +14,9 @@ using UnityEngine.Networking;
 
 namespace R2API {
     // ReSharper disable once InconsistentNaming
+    /// <summary>
+    /// An API for sending and retreiving a list of mods (and config settings) in multiplayer.
+    /// </summary>
     [R2APISubmodule]
     public static class ModListAPI {
         //This needs to be active at all times, rather than enabled as a submodule.

--- a/R2API/ModlistAPI.cs
+++ b/R2API/ModlistAPI.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 using BepInEx;
 using BepInEx.Configuration;
 using R2API.Utils;
@@ -123,16 +124,14 @@ namespace R2API {
 
         #region Actually do networking stuff
         private static Dictionary<NetworkConnection, ModList> tempConnectionInfo = new Dictionary<NetworkConnection, ModList>();
-        //private static Dictionary<CSteamID, ModList> connectedModLists = new Dictionary<CSteamID, ModList>();
         private static ModList localModList;
-        //private static ModList serverModList;
         private static ModList tempServerModList;
 
         private static void ServersideConnect( UnityEngine.Networking.NetworkConnection connection ) {
             try {
                 ModListMessage msg = new ModListMessage( localModList, true );
                 connection.SendByChannel( messageIndex, msg, QosChannelIndex.defaultReliable.intVal );
-                R2API.instance.StartCoroutine( MessageWaitServer( connection, messageWaitTimeServer ) );
+                MessageWaitServerAsync( connection, messageWaitTimeServer );
             } catch (Exception e ) {
                 Fail( e, "ServersideConnect" );
             }
@@ -141,14 +140,15 @@ namespace R2API {
             try {
                 ModListMessage msg = new ModListMessage( localModList, false );
                 connection.SendByChannel( messageIndex, msg, QosChannelIndex.defaultReliable.intVal );
-                R2API.instance.StartCoroutine( MessageWaitClient( connection, messageWaitTimeClient ) );
+                MessageWaitClientAsync( connection, messageWaitTimeClient );
             } catch (Exception e ){
                 Fail( e, "ClientsideConnect" );
             }
         }
 
-        private static IEnumerator MessageWaitServer( NetworkConnection conn, float duration ) {
-            yield return new WaitForSeconds( duration );
+        private static async void MessageWaitServerAsync( NetworkConnection conn, float duration ) {
+            await Task.Delay( TimeSpan.FromSeconds( duration ) );
+
             ModList list = null;
             if( tempConnectionInfo.ContainsKey( conn ) ) {
                 list = tempConnectionInfo[conn];
@@ -163,8 +163,8 @@ namespace R2API {
             }
         }
 
-        private static IEnumerator MessageWaitClient( NetworkConnection conn, float duration ) {
-            yield return new WaitForSeconds( duration );
+        private static async void MessageWaitClientAsync( NetworkConnection conn, float duration ) {
+            await Task.Delay( TimeSpan.FromSeconds( duration ) );
 
             ModList list = null;
             if( tempServerModList != null ) {
@@ -495,6 +495,7 @@ namespace R2API {
                 var typeString = reader.ReadString();
                 var objString = reader.ReadString();
                 var type = GetIndexType( typeString );
+                if( type == null ) return new ConfigOption( typeof( int ), -999 );
                 var obj = TomlTypeConverter.GetConverter( type ).ConvertToObject( objString, type);
                 return new ConfigOption( type, obj );
             }
@@ -512,8 +513,9 @@ namespace R2API {
 
             private static Type GetIndexType( string index ) {
                 if( typeIndexMap == null || indexTypeMap == null ) BuildTypeIndexMap();
+                if( indexTypeMap.ContainsKey( index ) ) return indexTypeMap[index];
 
-                return indexTypeMap[index];
+                return null;
             }
 
             private static void BuildTypeIndexMap() {

--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -28,12 +28,10 @@ namespace R2API {
 
         internal static DetourModManager ModManager;
 
-        internal static R2API instance;
 
         public R2API() {
             Logger = base.Logger;
             ModManager = new DetourModManager();
-            instance = this;
             AddHookLogging();
             CheckForIncompatibleAssemblies();
 


### PR DESCRIPTION
Switched to async await for network message handling. No longer needs static R2API ref for coroutines.
Fixed a bug with config file serialization that occured with some cases of custom bepinex typeconverters.

Edit: Also did quite a bit of stress testing on ModlistAPI.