### PR TITLE
Allow custom survivors to define display rules for custom items & improve code quality of display rules

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -28,6 +28,8 @@ namespace R2API {
 
         internal static DetourModManager ModManager;
 
+        internal static event EventHandler R2APIStart;
+
 
         public R2API() {
             Logger = base.Logger;
@@ -74,7 +76,7 @@ namespace R2API {
         }
 
         public void Start() {
-            ModListAPI.BuildModList();
+            R2APIStart.Invoke(this, null);
         }
 
         private static void AddHookLogging() {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note that such builds may be **unstable**.
 The most recent changelog can always be found on the [Github](https://github.com/risk-of-thunder/R2API/commits/master). In this readme, only the most recent *minor* version will have a changelog.
 
 **2.3.XX**
-
+* [Allow custom survivors to define display rules for custom items & improve code quality of display rules](https://github.com/risk-of-thunder/R2API/pull/116)
 * [Allow custom items to define display rules for individual models](https://github.com/risk-of-thunder/R2API/pull/115)
 * [Added more overloads for Direct Messages](https://github.com/risk-of-thunder/R2API/pull/114)
 * [Rewrote the readme](https://github.com/risk-of-thunder/R2API/pull/113)


### PR DESCRIPTION
* added internal event for R2API start.
* No longer runs on each charactermodel start, but only once on game start.
* Custom survivors may have definitions for custom items defined, and r2api no longer overwrites them if the custom item doesn't have it's own case for it.