### PR TITLE
Fix r2api plugin dependency of MonoMod patcher file

### DIFF
--- a/R2API.MonoMod/R2API.MonoMod.csproj
+++ b/R2API.MonoMod/R2API.MonoMod.csproj
@@ -8,18 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-	  <Reference Include="Mono.Cecil">
-		<HintPath>..\R2API\libs\Mono.Cecil.dll</HintPath>
-		<Private>false</Private>
-	  </Reference>
-	  <Reference Include="MonoMod.RuntimeDetour">
-		<HintPath>..\R2API\libs\MonoMod.RuntimeDetour.dll</HintPath>
-		<Private>false</Private>
-	  </Reference>
-	  <Reference Include="MonoMod.Utils">
-		<HintPath>..\R2API\libs\MonoMod.Utils.dll</HintPath>
-		<Private>false</Private>
-	  </Reference>
+      <PackageReference Include="Mono.Cecil" Version="0.11.2" />
+      <PackageReference Include="MonoMod" Version="20.3.5.1" />
+      <PackageReference Include="MonoMod.Utils" Version="20.3.5.1" />
+    </ItemGroup>
+
+    <ItemGroup>
 	  <Reference Include="MonoMod.Utils">
 		<HintPath>..\R2API\libs\MonoMod.exe</HintPath>
 		<Private>false</Private>
@@ -28,11 +22,6 @@
             <HintPath>..\R2API\libs\Assembly-CSharp.dll</HintPath>
             <Private>false</Private>
         </Reference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference PrivateAssets="all" Include="..\R2API\R2API.csproj">
-        </ProjectReference>
     </ItemGroup>
 
 </Project>

--- a/R2API.MonoMod/SearchableAttributeScanFix.cs
+++ b/R2API.MonoMod/SearchableAttributeScanFix.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using MonoMod;
-using R2API.Utils;
 
 namespace RoR2 {
     internal class patch_SearchableAttribute : Attribute {
@@ -167,7 +166,7 @@ namespace RoR2 {
                 "Assembly"
             };
             try {
-                typeof(SearchableAttribute).InvokeMethod("Scan");
+                typeof(SearchableAttribute).GetMethod("Scan", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).Invoke(null,null);
             }
             catch (Exception ex) {
                 System.Console.WriteLine(ex.Message);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The most recent changelog can always be found on the [Github](https://github.com
 
 **Current**
 
+* [Fix r2api plugin dependency of MonoMod patcher file](https://github.com/risk-of-thunder/R2API/pull/140)
 * [Remove faulty hook around chests' item rolling.](https://github.com/risk-of-thunder/R2API/pull/138)
 * [Remove savety hooks for userporfile as RoR2 does that now out of the box](https://github.com/risk-of-thunder/R2API/pull/135)
 * [Seperate BuffAPI and EliteAPI from ItemAPI](https://github.com/risk-of-thunder/R2API/pull/135)


### PR DESCRIPTION
This causes the preloader to crash when r2api is removed from the plugins folder.
This might fix rare cases in which 2 r2api.dlls are located in the plugin folder. Maybe.