### PR TITLE
ItemDropAPI: Allow public removal of items from the default drop lists

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -107,11 +107,9 @@ namespace R2API {
                 R2API.Logger.LogInfo($"Custom Equipment: {customEquipment.EquipmentDef.nameToken} added");
             }
 
-            var equipments = EquipmentDefinitions.Where(c => c.EquipmentDef.canDrop && !c.EquipmentDef.isLunar).Select(x => x.EquipmentDef.equipmentIndex).ToArray();
-            var lunarEquipments = EquipmentDefinitions.Where(c => c.EquipmentDef.canDrop && c.EquipmentDef.isLunar).Select(x => x.EquipmentDef.equipmentIndex).ToList();
+            var equipments = EquipmentDefinitions.Where(c => c.EquipmentDef.canDrop).Select(x => x.EquipmentDef.equipmentIndex).ToArray();
 
             ItemDropAPI.AddToDefaultEquipment(equipments);
-            ItemDropAPI.AddDrops(ItemDropLocation.LunarChest, lunarEquipments.ToSelection());
 
             _equipmentCatalogInitialized = true;
         }

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -13,6 +13,7 @@ namespace R2API {
     public class PickupSelection {
         public List<PickupIndex> Pickups { get; set; }
         public float DropChance { get; set; } = 1.0f;
+        public bool IsDefaults { get; internal set; } = false;
     }
 
     public static class DefaultItemDrops {
@@ -38,6 +39,10 @@ namespace R2API {
                 eq.ToSelection(ItemDropAPI.DefaultShrineEquipmentWeight)
             };
 
+            foreach (var sel in shrineSelections)
+                sel.IsDefaults = true;
+
+            RemoveDefaultDrops(ItemDropLocation.Shrine);
             ItemDropAPI.AddDrops(ItemDropLocation.Shrine, shrineSelections);
         }
 
@@ -83,6 +88,17 @@ namespace R2API {
                 ItemDropAPI.GetDefaultDropList(ItemTier.Lunar).ToSelection(ItemDropAPI.DefaultScavBackpackLunarDropChance),
             };
 
+            var allSelections = new[] {chestSelections, lockboxSelections, utilitySelections, damageSelections, healingSelections, scavSelections};
+            foreach (var selGroup in allSelections)
+                foreach (var sel in selGroup)
+                    sel.IsDefaults = true;
+
+            var allLocations = new[] {ItemDropLocation.UtilityChest, ItemDropLocation.DamageChest, ItemDropLocation.HealingChest,
+                ItemDropLocation.Lockbox, ItemDropLocation.SmallChest, ItemDropLocation.MediumChest, ItemDropLocation.LargeChest, ItemDropLocation.ScavBackPack};
+
+            foreach (var selLoc in allLocations)
+                RemoveDefaultDrops(selLoc);
+
             ItemDropAPI.AddDrops(ItemDropLocation.UtilityChest, utilitySelections);
             ItemDropAPI.AddDrops(ItemDropLocation.DamageChest, damageSelections);
             ItemDropAPI.AddDrops(ItemDropLocation.HealingChest, healingSelections);
@@ -97,12 +113,21 @@ namespace R2API {
         public static void AddEquipmentChestDefaultDrops() {
             var eq = ItemDropAPI.GetDefaultEquipmentDropList();
 
+            var equipmentSelections = eq.ToSelection();
+            equipmentSelections.IsDefaults = true;
+
+            RemoveDefaultDrops(ItemDropLocation.EquipmentChest);
             ItemDropAPI.AddDrops(ItemDropLocation.EquipmentChest, eq.ToSelection());
         }
 
         public static void AddLunarChestDefaultDrops() {
             var lun = ItemDropAPI.GetDefaultLunarDropList();
-            ItemDropAPI.AddDrops(ItemDropLocation.LunarChest, lun.ToSelection());
+
+            var lunarSelections = lun.ToSelection();
+            lunarSelections.IsDefaults = true;
+
+            RemoveDefaultDrops(ItemDropLocation.LunarChest);
+            ItemDropAPI.AddDrops(ItemDropLocation.LunarChest, lunarSelections);
         }
 
         public static void AddBossDefaultDrops() {
@@ -110,7 +135,16 @@ namespace R2API {
 
             var t2 = ItemDropAPI.GetDefaultDropList(ItemTier.Tier2);
 
-            ItemDropAPI.AddDrops(ItemDropLocation.Boss, t2.ToSelection());
+            var t2selections = t2.ToSelection();
+            t2selections.IsDefaults = true;
+
+            RemoveDefaultDrops(ItemDropLocation.Boss);
+            ItemDropAPI.AddDrops(ItemDropLocation.Boss, t2selections);
+        }
+
+        private static void RemoveDefaultDrops(ItemDropLocation location) {
+            if (ItemDropAPI.Selection.ContainsKey(location))
+                ItemDropAPI.RemoveDrops(location, ItemDropAPI.Selection[location].Where(sel => sel.IsDefaults).ToArray());
         }
     }
 

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -290,13 +290,6 @@ namespace R2API {
             cursor.Emit(OpCodes.Call, typeof(PickupIndex).GetMethodCached("get_itemIndex"));
         }
 
-        public static void AddDrops(ItemDropLocation dropLocation, PickupSelection pickups) {
-            if (!Selection.ContainsKey(dropLocation)) {
-                Selection[dropLocation] = new List<PickupSelection>();
-            }
-            Selection[dropLocation].Add(pickups);
-        }
-
         public static void AddDrops(ItemDropLocation dropLocation, params PickupSelection[] pickups) {
             if (!Selection.ContainsKey(dropLocation)) {
                 Selection[dropLocation] = new List<PickupSelection>();

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -477,6 +477,9 @@ namespace R2API {
             }
 
             list.AddRange(AdditionalTierItems[ItemTier.Lunar].Select(x => PickupCatalog.FindPickupIndex(x)));
+            list.AddRange(AdditionalEquipment
+                .Where(x => EquipmentCatalog.GetEquipmentDef(x).isLunar)
+                .Select(x => PickupCatalog.FindPickupIndex(x)));
             return list;
         }
 
@@ -495,7 +498,7 @@ namespace R2API {
                 }
             }
 
-            list.AddRange(AdditionalEquipment);
+            list.AddRange(AdditionalEquipment.Where(x => !EquipmentCatalog.GetEquipmentDef(x).isLunar));
             return list;
         }
 

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -144,7 +144,10 @@ namespace R2API {
 
         private static void RemoveDefaultDrops(ItemDropLocation location) {
             if (ItemDropAPI.Selection.ContainsKey(location))
-                ItemDropAPI.RemoveDrops(location, ItemDropAPI.Selection[location].Where(sel => sel.IsDefaults).ToArray());
+                ItemDropAPI.RemoveDrops(location,
+                    ItemDropAPI.Selection[location]
+                    .Where(sel => sel.IsDefaults)
+                    .ToArray());
         }
     }
 

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -174,15 +174,15 @@ namespace R2API {
         public static Dictionary<ItemDropLocation, List<PickupSelection>> Selection { get; set; } =
             new Dictionary<ItemDropLocation, List<PickupSelection>>();
 
-        private static readonly Dictionary<ItemTier, List<ItemIndex>> AdditionalTierItems = new Dictionary<ItemTier, List<ItemIndex>> {
-            { ItemTier.Tier1, new List<ItemIndex>() },
-            { ItemTier.Tier2, new List<ItemIndex>() },
-            { ItemTier.Tier3, new List<ItemIndex>() },
-            { ItemTier.Boss, new List<ItemIndex>() },
-            { ItemTier.Lunar, new List<ItemIndex>() }
+        private static readonly Dictionary<ItemTier, HashSet<ItemIndex>> AdditionalTierItems = new Dictionary<ItemTier, HashSet<ItemIndex>> {
+            { ItemTier.Tier1, new HashSet<ItemIndex>() },
+            { ItemTier.Tier2, new HashSet<ItemIndex>() },
+            { ItemTier.Tier3, new HashSet<ItemIndex>() },
+            { ItemTier.Boss, new HashSet<ItemIndex>() },
+            { ItemTier.Lunar, new HashSet<ItemIndex>() }
         };
 
-        private static readonly List<EquipmentIndex> AdditionalEquipment = new List<EquipmentIndex>();
+        private static readonly HashSet<EquipmentIndex> AdditionalEquipment = new HashSet<EquipmentIndex>();
 
         [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
         internal static void SetHooks() {
@@ -310,7 +310,7 @@ namespace R2API {
                 return;
             }
 
-            AdditionalTierItems[itemTier].AddRange(items);
+            AdditionalTierItems[itemTier].UnionWith(items);
         }
         
         public static void RemoveFromDefaultByTier(ItemTier itemTier, params ItemIndex[] items) {
@@ -318,8 +318,7 @@ namespace R2API {
                 return;
             }
 
-            foreach (var item in items)
-                AdditionalTierItems[itemTier].RemoveAll(i => i.Equals(item));
+            AdditionalTierItems[itemTier].ExceptWith(items);
         }
 
         public static void AddToDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
@@ -339,12 +338,11 @@ namespace R2API {
         }
 
         public static void AddToDefaultEquipment(params EquipmentIndex[] equipment) {
-            AdditionalEquipment.AddRange(equipment);
+            AdditionalEquipment.UnionWith(equipment);
         }
 
         public static void RemoveFromDefaultEquipment(params EquipmentIndex[] equipments) {
-            foreach (var equipment in equipments)
-                AdditionalEquipment.RemoveAll(e => e.Equals(equipment));
+            AdditionalEquipment.ExceptWith(equipments);
         }
 
         public static void ReplaceDrops(ItemDropLocation dropLocation,

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -321,7 +321,7 @@ namespace R2API {
             AdditionalTierItems[itemTier].ExceptWith(items);
         }
 
-        public static void AddToDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+        public static void AddToDefaultByTier(params KeyValuePair<ItemIndex, ItemTier>[] items) {
             foreach (var list in AdditionalTierItems)
                 AddToDefaultByTier(list.Key,
                     items.Where(item => list.Key == item.Value)
@@ -329,7 +329,7 @@ namespace R2API {
                     .ToArray());
         }
 
-        public static void RemoveFromDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+        public static void RemoveFromDefaultByTier(params KeyValuePair<ItemIndex, ItemTier>[] items) {
             foreach (var list in AdditionalTierItems)
                 RemoveFromDefaultByTier(list.Key,
                     items.Where(item => list.Key == item.Value)

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -319,7 +319,7 @@ namespace R2API {
             }
 
             foreach (var item in items)
-                AdditionalTierItems[itemTier].Remove(item);
+                AdditionalTierItems[itemTier].RemoveAll(i => i.Equals(item));
         }
 
         public static void AddToDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
@@ -344,7 +344,7 @@ namespace R2API {
 
         public static void RemoveFromDefaultEquipment(params EquipmentIndex[] equipments) {
             foreach (var equipment in equipments)
-                AdditionalEquipment.Remove(equipment);
+                AdditionalEquipment.RemoveAll(e => e.Equals(equipment));
         }
 
         public static void ReplaceDrops(ItemDropLocation dropLocation,

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -329,6 +329,21 @@ namespace R2API {
                 AdditionalTierItems[itemTier].Remove(item);
         }
 
+        public static void AddToDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+            foreach (var list in AdditionalTierItems)
+                AddToDefaultByTier(list.Key,
+                    items.Where(item => list.Key == item.Value)
+                    .Select(item => item.Key)
+                    .ToArray());
+        }
+
+        public static void RemoveFromDefaultAllTiers(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+            foreach (var list in AdditionalTierItems)
+                RemoveFromDefaultByTier(list.Key,
+                    items.Where(item => list.Key == item.Value)
+                    .Select(item => item.Key)
+                    .ToArray());
+        }
 
         public static void AddToDefaultEquipment(params EquipmentIndex[] equipment) {
             AdditionalEquipment.AddRange(equipment);

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -304,6 +304,14 @@ namespace R2API {
             Selection[dropLocation].AddRange(pickups);
         }
 
+        public static void RemoveDrops(ItemDropLocation dropLocation, params PickupSelection[] pickups) {
+            if (!Selection.ContainsKey(dropLocation))
+                return;
+
+            foreach (var pickup in pickups)
+                Selection[dropLocation].Remove(pickup);
+        }
+
         public static void AddToDefaultByTier(ItemTier itemTier, params ItemIndex[] items) {
             if (itemTier == ItemTier.NoTier) {
                 return;
@@ -311,9 +319,24 @@ namespace R2API {
 
             AdditionalTierItems[itemTier].AddRange(items);
         }
+        
+        public static void RemoveFromDefaultByTier(ItemTier itemTier, params ItemIndex[] items) {
+            if (itemTier == ItemTier.NoTier) {
+                return;
+            }
+
+            foreach (var item in items)
+                AdditionalTierItems[itemTier].Remove(item);
+        }
+
 
         public static void AddToDefaultEquipment(params EquipmentIndex[] equipment) {
             AdditionalEquipment.AddRange(equipment);
+        }
+
+        public static void RemoveFromDefaultEquipment(params EquipmentIndex[] equipments) {
+            foreach (var equipment in equipments)
+                AdditionalEquipment.Remove(equipment);
         }
 
         public static void ReplaceDrops(ItemDropLocation dropLocation,


### PR DESCRIPTION
Fixes: items removed from `Run.availableItems` and/or from `Run.available...DropList` (during a hook on `On.RoR2.Run.BuildDropTable`) still drop from chance shrines iff ItemDropAPI is loaded. This fix is performed by adding new public methods to remove items from the internal default drop tables (previously, only addition could be performed).

Fixes: calling `Run.instance.BuildDropTable()` mid-run causes duplicates of the default lists to be added, which in turn skews drop chances in favor of those items. This fix is performed by adding a new IsDefaults flag to PickupSelection. During all `DefaultItemDrops.AddDefault...Drops` methods, IsDefaults is set to true on all added PickupSelections; all existing entries with IsDefaults=true are removed before adding the new ones.

Adds overloads for AddToDefaultByTier/RemoveFromDefaultByTier which take `KeyValuePair<ItemIndex,ItemTier>[]` as params and affect all tiers at once. 

Changes the private members AdditionalEquipment and AdditionalTierItems from Lists to HashSets, as duplicate items are not useful and order is not important for these lists.