### PR TITLE
Remove "[MOD]" from server title

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -78,7 +78,6 @@ namespace R2API {
 
             // Make sure that modded dedicated servers are recognizable from the server browser
             On.RoR2.SteamworksServerManager.UpdateHostName += (orig, self, hostname) => {
-                orig(self, $"[MOD] {hostname}");
                 var server = ((SteamworksServerManager)self).GetFieldValue<Server>("steamworksServer");
                 server.GameTags = "mod," + server.GameTags;
             };


### PR DESCRIPTION
Tags will be client visible, meaning we don't have to enforce the title anymore.