### PR TITLE
Removed a line in RoR2's constructor that caused R2API builds to fail.

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -87,8 +87,6 @@ namespace R2API {
                 var server = ((SteamworksServerManager)self).GetFieldValue<Server>("steamworksServer");
                 server.GameTags = "mod," + server.GameTags;
             };
-
-            SurvivorAPI.SafetyCheck();
         }
 
         public void Start() {


### PR DESCRIPTION
To be specific, the changes to SurvivorAPI (https://github.com/risk-of-thunder/R2API/pull/162) made a method into standard hook. However, the old method was still being called by R2API's constructor, thus causing builds to fail. I've removed the line that called the method in my pull request.
