### PR TITLE
Fixed being unable to have assets with the same path but different type in UnbundledResourceProvider.

### DIFF
--- a/R2API.Test/UnbundledResourcesProviderTests.cs
+++ b/R2API.Test/UnbundledResourcesProviderTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using UnityEngine;
+using Xunit;
+
+namespace R2API.Test {
+    public class UnbundledResourcesProviderTests {
+        private readonly UnbundledResourcesProvider _provider;
+
+        public UnbundledResourcesProviderTests() {
+            this._provider = new UnbundledResourcesProvider("test");
+        }
+
+        [Fact]
+        public void TestStoringAndLoadingAsset() {
+            var inputTexture = new Texture2D(0, 0);
+            var path = this._provider.Store("test", inputTexture);
+            var outputTexure = this._provider.Load(path, typeof(Texture2D));
+
+            Assert.Same(inputTexture, outputTexure);
+        }
+
+        [Fact]
+        public void TestStoringAndLoadingAssetsWithSamePathButDifferentType() {
+            var inputTexture2D = new Texture2D(0, 0);
+            var inputTexture3D = new Texture3D(0, 0, 0, TextureFormat.R8, false);
+            var texture2DPath = this._provider.Store("test", inputTexture2D);
+            var texture3DPath = this._provider.Store("test", inputTexture3D);
+            var outputTexture2D = this._provider.Load(texture2DPath, typeof(Texture2D));
+            var outputTexture3D = this._provider.Load(texture3DPath, typeof(Texture3D));
+            Assert.Equal(texture2DPath, texture3DPath);
+            Assert.Same(inputTexture2D, outputTexture2D);
+            Assert.Same(inputTexture3D, outputTexture3D);
+        }
+    }
+}

--- a/R2API/UnbundledResourcesProvider.cs
+++ b/R2API/UnbundledResourcesProvider.cs
@@ -123,7 +123,7 @@ namespace R2API {
 
         public UnityObject[] LoadAll(Type type) {
             return typedResources
-                .Where(kv => kv.Key == type || kv.Key.IsSubclassOf(type))
+                .Where(kv => kv.Key == type || kv.Key.IsAssignableFrom(type))
                 .SelectMany(kv => kv.Value.Values).ToArray();
         }
 

--- a/R2API/UnbundledResourcesProvider.cs
+++ b/R2API/UnbundledResourcesProvider.cs
@@ -10,7 +10,7 @@ namespace R2API {
     /// This class allows loading of resources not stored in an assetbundle with Resources.Load. Primary use would be for generating an item icon in code.
     /// </summary>
     public sealed class UnbundledResourcesProvider : IResourceProvider {
-        private readonly Dictionary<string, UnityObject> resources = new Dictionary<string, UnityObject>();
+        private readonly Dictionary<Type, Dictionary<string, UnityObject>> typedResources = new Dictionary<Type, Dictionary<string, UnityObject>>();
 
         public string ModPrefix { get; }
 
@@ -20,13 +20,16 @@ namespace R2API {
 
         public UnbundledResourcesProvider(string modPrefix, params (string key, UnityObject resource)[] resources) {
             ModPrefix = modPrefix;
-            for (var i = 0; i < resources.Length; i++) {
-                var (key, resource) = resources[i];
+            foreach (var (key, resource) in resources)
+            {
                 _ = Store(key, resource, resource.GetType());
             }
         }
 
         public UnityObject Load(string path, Type type) {
+            if (!typedResources.TryGetValue(type, out var resources)) {
+                throw new KeyNotFoundException($"type: {type.FullName} was not found");
+            }
             var key = ConvertToKey(path);
             return resources[key];
         }
@@ -38,6 +41,10 @@ namespace R2API {
         public string Store(string path, UnityObject resource, Type type) {
             string key;
             string fullPath;
+
+            if (!typedResources.TryGetValue(type, out var resources)) {
+                typedResources[type] = resources = new Dictionary<string, UnityObject>();
+            }
 
             if (IsValidKey(path)) {
                 key = path;
@@ -59,7 +66,15 @@ namespace R2API {
             return fullPath;
         }
 
-        public void Remove(string path) {
+        public void Remove<TResource>(string path) {
+            Remove(path, typeof(TResource));
+        }
+
+        public void Remove(string path, Type type) {
+            if (!typedResources.TryGetValue(type, out var resources)) {
+                throw new KeyNotFoundException($"type: {type.FullName} was not found");
+            }
+
             string key;
             if (IsValidKey(path)) {
                 key = path;
@@ -72,12 +87,18 @@ namespace R2API {
             resources.Remove(key);
         }
 
-        public void Remove(UnityObject resource) {
+        public void Remove<TResource>(TResource resource) where TResource : UnityObject {
+            if (!typedResources.TryGetValue(typeof(TResource), out var resources)) {
+                throw new KeyNotFoundException($"type: {typeof(TResource).FullName} was not found");
+            }
             var fullPath = GetPathForResource(resource);
             resources.Remove(ConvertToKey(fullPath));
         }
 
-        public string GetPathForResource(UnityObject resource) {
+        public string GetPathForResource<TResource>(TResource resource) where TResource : UnityObject {
+            if (!typedResources.TryGetValue(typeof(TResource), out var resources)) {
+                throw new KeyNotFoundException($"type: {typeof(TResource).FullName} was not found");
+            }
             return $"{ModPrefix}:{resources.First((kvp) => kvp.Value == resource).Key}";
         }
 
@@ -101,7 +122,9 @@ namespace R2API {
         }
 
         public UnityObject[] LoadAll(Type type) {
-            return resources.Values.Where((obj) => obj.GetType() == type || obj.GetType().IsSubclassOf(type)).ToArray();
+            return typedResources
+                .Where(kv => kv.Key == type || kv.Key.IsSubclassOf(type))
+                .SelectMany(kv => kv.Value.Values).ToArray();
         }
 
         private string ConvertToKey(string fullPath) {


### PR DESCRIPTION
For context, the class RoR2.ItemDef has the field pickupIconPath which both pickupIconSprite and pickupIconTexture use to load their assets based on their type. Previously, UnbundledResourceProvider didn't track the stored types so it wasn't possible to handle this.