### PR TITLE
Fixed bug with ConvertToFullpath by enforcing that ModPrefix start with @.

### DIFF
--- a/R2API.Test/UnbundledResourcesProviderTests.cs
+++ b/R2API.Test/UnbundledResourcesProviderTests.cs
@@ -7,7 +7,7 @@ namespace R2API.Test {
         private readonly UnbundledResourcesProvider _provider;
 
         public UnbundledResourcesProviderTests() {
-            this._provider = new UnbundledResourcesProvider("test");
+            this._provider = new UnbundledResourcesProvider("@test");
         }
 
         [Fact]

--- a/R2API.Test/UnbundledResourcesProviderTests.cs
+++ b/R2API.Test/UnbundledResourcesProviderTests.cs
@@ -1,13 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
+using R2API.Utils;
 using UnityEngine;
 using Xunit;
 
 namespace R2API.Test {
-    public class UnbundledResourcesProviderTests {
+    public class UnbundledResourcesProviderTests : IClassFixture<UnbundledResourcesProviderFixture>, IDisposable {
         private readonly UnbundledResourcesProvider _provider;
 
-        public UnbundledResourcesProviderTests() {
-            this._provider = new UnbundledResourcesProvider("@test");
+        public UnbundledResourcesProviderTests(UnbundledResourcesProviderFixture fixture) {
+            this._provider = fixture.Provider;
+        }
+
+        public void Dispose() {
+            this._provider.InvokeMethod("Clear");
         }
 
         [Fact]
@@ -31,5 +37,24 @@ namespace R2API.Test {
             Assert.Same(inputTexture2D, outputTexture2D);
             Assert.Same(inputTexture3D, outputTexture3D);
         }
+
+        [Fact]
+        public void TestStoringAndLoadingAssetsFromResourcesAPI() {
+            var inputTexture = new Texture2D(0, 0);
+            var path = this._provider.Store("test", inputTexture);
+            var outputTexure = typeof(ResourcesAPI).InvokeMethod<Texture2D>("ModResourcesLoad", path, typeof(Texture2D));
+
+            Assert.Same(inputTexture, outputTexure);
+        }
+    }
+
+    public class UnbundledResourcesProviderFixture {
+        public UnbundledResourcesProvider Provider { get; }
+
+        public UnbundledResourcesProviderFixture() {
+            this.Provider = new UnbundledResourcesProvider("@test");
+            ResourcesAPI.AddProvider(this.Provider);
+        }
+
     }
 }

--- a/R2API/UnbundledResourcesProvider.cs
+++ b/R2API/UnbundledResourcesProvider.cs
@@ -142,6 +142,11 @@ namespace R2API {
             }
         }
 
+        // For use in unit tests
+        private void Clear() {
+            typedResources.Clear();
+        }
+
         private string ConvertToFullpath(string key) {
             if (!IsValidKey(key)) throw new ArgumentException("Must not contain an @ or :", nameof(key));
             return $"{ModPrefix}:{key}";

--- a/R2API/UnbundledResourcesProvider.cs
+++ b/R2API/UnbundledResourcesProvider.cs
@@ -15,10 +15,14 @@ namespace R2API {
         public string ModPrefix { get; }
 
         public UnbundledResourcesProvider(string modPrefix) {
+            if (!modPrefix.StartsWith("@"))
+                throw new ArgumentException("Mod prefix must start with @");
             ModPrefix = modPrefix;
         }
 
         public UnbundledResourcesProvider(string modPrefix, params (string key, UnityObject resource)[] resources) {
+            if (!modPrefix.StartsWith("@"))
+                throw new ArgumentException("Mod prefix must start with @");
             ModPrefix = modPrefix;
             foreach (var (key, resource) in resources)
             {
@@ -140,7 +144,7 @@ namespace R2API {
 
         private string ConvertToFullpath(string key) {
             if (!IsValidKey(key)) throw new ArgumentException("Must not contain an @ or :", nameof(key));
-            return $"@{ModPrefix}:{key}";
+            return $"{ModPrefix}:{key}";
         }
 
         private bool IsValidFullPath(string fullPath) {


### PR DESCRIPTION
Context: Anytime UnbundledAssetProvider.Store is called using just a key instead of a full path, an additional "@" is appended to the modPrefix which breaks ResourcesAPI.ModResourcesLoad.

Fix: Enforce that modPrefix must have "@" at the start of its name so it can be removed from the ConvertToFullpath format string.