### PR TITLE
Hotfix for the NetworkCompatibility handler and ItemDropAPI

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -133,6 +133,16 @@ namespace R2API {
                 return ItemIndex.None;
             }
 
+            if (item.ItemDef == null) {
+                R2API.Logger.LogError("Your ItemDef is null ! Can't add your item.");
+                return ItemIndex.None;
+            }
+
+            if (string.IsNullOrEmpty(item.ItemDef.name)) {
+                R2API.Logger.LogError("Your ItemDef.name is null ! Can't add your item.");
+                return ItemIndex.None;
+            }
+
             bool xmlSafe = false;
             try {
                 XElement element = new XElement(item.ItemDef.name);
@@ -164,6 +174,16 @@ namespace R2API {
 
             if (_equipmentCatalogInitialized) {
                 R2API.Logger.LogError($"Too late ! Tried to add equipment item: {item.EquipmentDef.nameToken} after the equipment list was created");
+                return EquipmentIndex.None;
+            }
+
+            if (item.EquipmentDef == null) {
+                R2API.Logger.LogError("Your EquipmentDef is null ! Can't add your Equipment.");
+                return EquipmentIndex.None;
+            }
+
+            if (string.IsNullOrEmpty(item.EquipmentDef.name)) {
+                R2API.Logger.LogError("Your EquipmentDef.name is null ! Can't add your Equipment.");
                 return EquipmentIndex.None;
             }
 

--- a/R2API/ItemDropAPI.cs
+++ b/R2API/ItemDropAPI.cs
@@ -413,7 +413,8 @@ namespace R2API {
                 if (!Run.instance.availableItems.HasItem(itemIndex))
                     continue;
 
-                if (ItemCatalog.GetItemDef(itemIndex).tier == itemTier) {
+                var itemDef = ItemCatalog.GetItemDef(itemIndex);
+                if (itemDef.tier == itemTier && itemDef.DoesNotContainTag(ItemTag.WorldUnique)) {
                     list.Add(itemIndex);
                 }
             }
@@ -431,7 +432,7 @@ namespace R2API {
                     continue;
 
                 var itemDef = ItemCatalog.GetItemDef(itemIndex);
-                if (itemDef.tier == itemTier && itemDef.ContainsTag(requiredTag)) {
+                if (itemDef.tier == itemTier && itemDef.ContainsTag(requiredTag) && itemDef.DoesNotContainTag(ItemTag.WorldUnique)) {
                     list.Add(itemIndex);
                 }
             }
@@ -460,7 +461,8 @@ namespace R2API {
                 if (!Run.instance.availableItems.HasItem(itemIndex))
                     continue;
 
-                if (ItemCatalog.GetItemDef(itemIndex).tier == ItemTier.Lunar) {
+                var itemDef = ItemCatalog.GetItemDef(itemIndex);
+                if (itemDef.tier == ItemTier.Lunar && itemDef.DoesNotContainTag(ItemTag.WorldUnique)) {
                     list.Add(PickupCatalog.FindPickupIndex(itemIndex));
                 }
             }


### PR DESCRIPTION
the NetworkCompatibilityHandler wasn't properly checking for the ManualNetworkRegistration attribute, now fixed
ItemDropAPI was allowing items with the WorldUnique tag to be on the drop tables, now fixed.