### PR TITLE
[LanguageAPI] load from file fix

### DIFF
--- a/R2API/LanguageAPI.cs
+++ b/R2API/LanguageAPI.cs
@@ -64,14 +64,23 @@ namespace R2API {
                     return;
                 }
 
-                var languageTokens = jsonNode.Keys;
-                foreach (var language in languageTokens) {
-                    JSONNode generic = jsonNode[language];
-                    if (generic == null) {
+                var genericsAdded = false;
+                var languages = jsonNode.Keys;
+                foreach (var language in languages) {
+                    JSONNode languageTokens = jsonNode[language];
+                    if (languageTokens == null) {
                         return;
                     }
-                    foreach (string text in generic.Keys) {
-                        Add(text, generic[text].Value);
+
+                    if (!genericsAdded) {
+                        foreach (string text in languageTokens.Keys) {
+                            Add(text, languageTokens[text].Value);
+                        }
+                        genericsAdded = true;
+                    }
+
+                    foreach (string text in languageTokens.Keys) {
+                        Add(text, languageTokens[text].Value, language);
                     }
                 }
             }


### PR DESCRIPTION
Current implementation adds all languages to GenericTokens because of that, only last language will be stored.
I've fixed it so now tokens are added to specific languages (how it's described in the comment).
Also, the first available language will be added to generics, so that it will be used when no language-specific tokens found.