### PR TITLE
EliteAPI fix, NetworkCompatiblity fix and more

### DIFF
--- a/R2API/EliteAPI.cs
+++ b/R2API/EliteAPI.cs
@@ -57,7 +57,6 @@ namespace R2API {
         private static void AddEliteAction(List<EliteDef> eliteDefinitions) {
             foreach (var customElite in EliteDefinitions) {
                 eliteDefinitions.Add(customElite.EliteDef);
-
                 var currentEliteTiers = GetCombatDirectorEliteTiers();
                 if (customElite.EliteTier == 1) {
                     var index = currentEliteTiers[1].eliteTypes.Length;
@@ -69,7 +68,7 @@ namespace R2API {
                     var eliteTierIndex = customElite.EliteTier + 1;
                     var eliteTypeIndex = currentEliteTiers[eliteTierIndex].eliteTypes.Length;
                     Array.Resize(ref currentEliteTiers[eliteTierIndex].eliteTypes, eliteTypeIndex + 1);
-                    currentEliteTiers[1].eliteTypes[eliteTypeIndex] = customElite.EliteDef.eliteIndex;
+                    currentEliteTiers[eliteTierIndex].eliteTypes[eliteTypeIndex] = customElite.EliteDef.eliteIndex;
                 }
                 OverrideCombatDirectorEliteTiers(currentEliteTiers);
 

--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -243,7 +243,7 @@ namespace R2API {
         private static void CheckR2APIMonomodPatch() {
             var isHere = AppDomain.CurrentDomain.GetAssemblies().Any(assembly => assembly.FullName.ToLower().Contains("r2api.mm.monomodrules"));
 
-            if (isHere) {
+            if (!isHere) {
                 var message = new List<string> {
                     "The Monomod patch of R2API seems to be missing",
                     "Please make sure that a file called:",

--- a/R2API/Utils/APISubmodule.cs
+++ b/R2API/Utils/APISubmodule.cs
@@ -53,7 +53,7 @@ namespace R2API.Utils {
         private readonly int _build;
         private readonly ManualLogSource _logger;
         private HashSet<string> _moduleSet;
-        private HashSet<string> LoadedModules;
+        private static HashSet<string> LoadedModules;
 
         internal APISubmoduleHandler(int build, ManualLogSource logger = null) {
             _build = build;
@@ -64,7 +64,7 @@ namespace R2API.Utils {
         /// Return true if the specified submodule is loaded.
         /// </summary>
         /// <param name="submodule">nameof the submodule</param>
-        public bool IsLoaded(string submodule) => LoadedModules.Contains(submodule);
+        public static bool IsLoaded(string submodule) => LoadedModules.Contains(submodule);
 
         internal HashSet<string> LoadRequested(PluginScanner pluginScanner) {
             _moduleSet = new HashSet<string>();

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -146,13 +146,16 @@ namespace R2API.Utils {
 
         private static void TryGetNetworkCompatibilityArguments(IList<CustomAttributeArgument> attributeArguments,
             out CompatibilityLevel compatibilityLevel, out VersionStrictness versionStrictness) {
-            if (attributeArguments[0].Value is int && attributeArguments[1].Value is int) {
-                compatibilityLevel = (CompatibilityLevel)attributeArguments[0].Value;
-                versionStrictness = (VersionStrictness)attributeArguments[1].Value;
-            }
-            else {
-                compatibilityLevel = CompatibilityLevel.EveryoneMustHaveMod;
-                versionStrictness = VersionStrictness.EveryoneNeedSameModVersion;
+            compatibilityLevel = CompatibilityLevel.EveryoneMustHaveMod;
+            versionStrictness = VersionStrictness.EveryoneNeedSameModVersion;
+
+            if (attributeArguments != null && attributeArguments.Count > 0) {
+                if (attributeArguments[0].Value is int) {
+                    compatibilityLevel = (CompatibilityLevel)attributeArguments[0].Value;
+                }
+                if (attributeArguments[1].Value is int) {
+                    versionStrictness = (VersionStrictness)attributeArguments[1].Value;
+                }
             }
         }
     }

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -4,11 +4,13 @@ using System.ComponentModel;
 using System.Linq;
 using BepInEx;
 using Mono.Cecil;
+using R2API.Networking;
 using RoR2;
 
 namespace R2API.Utils {
     /// <summary>
     /// Enum used for telling whether or not the mod should be needed by everyone in multiplayer games.
+    /// Also can specify if the mod does not work in multiplayer.
     /// </summary>
     public enum CompatibilityLevel {
         NoNeedForSync,
@@ -139,6 +141,9 @@ namespace R2API.Utils {
 
             void CallWhenAssembliesAreScanned() {
                 if (modList.Count != 0) {
+                    if (IsR2APIAffectingNetwork()) {
+                        modList.Add(R2API.PluginGUID + ModGuidAndModVersionSeparator + R2API.PluginVersion);
+                    }
                     var sortedModList = modList.ToList();
                     sortedModList.Sort();
                     R2API.Logger.LogInfo("[NetworkCompatibility] Adding to the networkModList : ");
@@ -148,6 +153,10 @@ namespace R2API.Utils {
                     }
                 }
             }
+        }
+
+        internal static bool IsR2APIAffectingNetwork() {
+            return APISubmoduleHandler.IsLoaded(nameof(NetworkingAPI));
         }
 
         private static void TryGetNetworkCompatibilityArguments(IList<CustomAttributeArgument> attributeArguments,

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -12,7 +12,8 @@ namespace R2API.Utils {
     /// </summary>
     public enum CompatibilityLevel {
         NoNeedForSync,
-        EveryoneMustHaveMod
+        EveryoneMustHaveMod,
+        BreaksMultiplayer
     }
 
     /// <summary>
@@ -83,8 +84,13 @@ namespace R2API.Utils {
                     // By default, any plugins that don't have the NetworkCompatibility attribute and
                     // don't have the ManualNetworkRegistration attribute are added to the networked mod list
                     if (!haveNetworkCompatAttribute) {
-                        if (bepinPluginAttribute != null && !haveManualRegistrationAttribute) {
-                            modList.Add(modGuid + ModGuidAndModVersionSeparator + modVersion);
+                        if (bepinPluginAttribute != null){
+                            if (!haveManualRegistrationAttribute) {
+                                modList.Add(modGuid + ModGuidAndModVersionSeparator + modVersion);
+                            }
+                            else {
+                                R2API.Logger.LogDebug($"Found {nameof(ManualNetworkRegistrationAttribute)} type. Ignoring.");
+                            }
                         }
                         else {
                             R2API.Logger.LogDebug($"Found {nameof(BaseUnityPlugin)} type but no {nameof(BepInPlugin)} attribute");

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -15,7 +15,7 @@ namespace R2API.Utils {
     public enum CompatibilityLevel {
         NoNeedForSync,
         EveryoneMustHaveMod,
-        BreaksMultiplayer
+        //BreaksMultiplayer //todo
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ namespace R2API.Utils {
     /// you want to specify if the mod should be installed by everyone in multiplayer games or not.
     /// If the mod is required to be installed by everyone, you'll need to also specify if the same mod version should be used by everyone or not.
     /// By default, it's supposed that everyone needs the mod and the same version.
-    /// e.g: [NetworkCompatibility(CompatibilityLevel.NoNeedForSync, VersionStrictness.DifferentModVersionsAreOk)]
+    /// e.g: [NetworkCompatibility(CompatibilityLevel.NoNeedForSync)]
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class NetworkCompatibility : Attribute {


### PR DESCRIPTION
- Fix an oob array exception with EliteAPI that was adding incorrectly custom elites of tier 2 and above.
-  Better display of missing mods for end users when a mod mismatch happens
- Better log message if the monomod patch of r2api is missing
- R2API now adds itself to the networked mod list for syncing purposes when NetworkingAPI is active (the message classes from that API could be different across r2api versions and cause problems for example)
- Fix a rare bug ( computer specific ? ) where the NetworkCompatiblityHandler wasnt correctly retrieving the arguments of the NetworkCompatibility attribute
- Better detection of duplicate assemblies that could be sitting in the plugins folder of an end user