### PR TITLE
Fixed double sending bugs in NetworkAPI

### DIFF
--- a/R2API/Networking/Interfaces/INetCommand.cs
+++ b/R2API/Networking/Interfaces/INetCommand.cs
@@ -20,15 +20,16 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
+                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                            continue;
+                        }
 
                         using (Writer netWriter = NetworkingAPI.GetWriter(NetworkingAPI.CommandIndex, conn, QosType.Reliable)) {
                             NetworkWriter writer = netWriter;
                             writer.Write(header);
                         }
                     }
-                }
-                
-                if (NetworkClient.active) {
+                } else if (NetworkClient.active) {
                     using (var netWriter = NetworkingAPI.GetWriter(NetworkingAPI.CommandIndex, ClientScene.readyConnection, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);

--- a/R2API/Networking/Interfaces/INetMessage.cs
+++ b/R2API/Networking/Interfaces/INetMessage.cs
@@ -7,6 +7,7 @@ namespace R2API.Networking.Interfaces {
 
     public static class NetMessageExtensions {
         public static void Send(this INetMessage message, NetworkDestination destination) {
+
             if (destination.ShouldRun()) {
                 message.OnReceived();
             }
@@ -20,6 +21,9 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
+                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                            continue;
+                        }
 
                         using (Writer netWriter = NetworkingAPI.GetWriter(NetworkingAPI.MessageIndex, conn, QosType.Reliable)) {
                             NetworkWriter writer = netWriter;
@@ -27,9 +31,7 @@ namespace R2API.Networking.Interfaces {
                             writer.Write(message);
                         }
                     }
-                }
-
-                if (NetworkClient.active) {
+                } else if (NetworkClient.active) {
                     using (Writer netWriter = NetworkingAPI.GetWriter(NetworkingAPI.MessageIndex, ClientScene.readyConnection, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);

--- a/R2API/Networking/Interfaces/INetRequest.cs
+++ b/R2API/Networking/Interfaces/INetRequest.cs
@@ -30,6 +30,9 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
+                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                            continue;
+                        }
 
                         using (Writer netWriter = NetworkingAPI.GetWriter(NetworkingAPI.RequestIndex, conn, QosType.Reliable)) {
                             NetworkWriter writer = netWriter;
@@ -37,9 +40,7 @@ namespace R2API.Networking.Interfaces {
                             writer.Write(request);
                         }
                     }
-                }
-
-                if (NetworkClient.active) {
+                } else if (NetworkClient.active) {
                     using (Writer netWriter = NetworkingAPI.GetWriter(NetworkingAPI.RequestIndex, ClientScene.readyConnection, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);

--- a/R2API/Networking/NetworkingAPI.cs
+++ b/R2API/Networking/NetworkingAPI.cs
@@ -236,12 +236,12 @@ namespace R2API.Networking {
                     if (i == receivedFrom) {
                         continue;
                     }
+                    
 
                     NetworkConnection conn = NetworkServer.connections[i];
                     if (conn == null) {
                         continue;
                     }
-
                     using (Writer netWriter = GetWriter(MessageIndex, conn, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);


### PR DESCRIPTION
Fixed a few bugs that allowed messages to be executed multiple times when sent from a client that was hosting.