### PR TITLE
Fix Reply/Request Messages for NetworkingAPI and minor NetworkCompatibility fix

### DIFF
--- a/R2API/Networking/Interfaces/INetCommand.cs
+++ b/R2API/Networking/Interfaces/INetCommand.cs
@@ -20,7 +20,8 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
-                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+
+                        if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
                             continue;
                         }
 

--- a/R2API/Networking/Interfaces/INetMessage.cs
+++ b/R2API/Networking/Interfaces/INetMessage.cs
@@ -21,7 +21,8 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
-                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+
+                        if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
                             continue;
                         }
 

--- a/R2API/Networking/Interfaces/INetRequest.cs
+++ b/R2API/Networking/Interfaces/INetRequest.cs
@@ -30,7 +30,8 @@ namespace R2API.Networking.Interfaces {
                         if (conn == null) {
                             continue;
                         }
-                        if(NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+
+                        if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
                             continue;
                         }
 

--- a/R2API/Networking/NetworkingAPI.cs
+++ b/R2API/Networking/NetworkingAPI.cs
@@ -199,12 +199,16 @@ namespace R2API.Networking {
                         continue;
                     }
 
-                    NetworkConnection targetConn = NetworkServer.connections[i];
-                    if (targetConn == null) {
+                    NetworkConnection conn = NetworkServer.connections[i];
+                    if (conn == null) {
                         continue;
                     }
 
-                    using (Writer netWriter = GetWriter(CommandIndex, targetConn, QosType.Reliable)) {
+                    if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                        continue;
+                    }
+
+                    using (Writer netWriter = GetWriter(CommandIndex, conn, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);
                     }
@@ -237,11 +241,15 @@ namespace R2API.Networking {
                         continue;
                     }
                     
-
                     NetworkConnection conn = NetworkServer.connections[i];
                     if (conn == null) {
                         continue;
                     }
+
+                    if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                        continue;
+                    }
+
                     using (Writer netWriter = GetWriter(MessageIndex, conn, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);
@@ -286,6 +294,10 @@ namespace R2API.Networking {
                         continue;
                     }
 
+                    if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
+                        continue;
+                    }
+
                     using (Writer netWriter = GetWriter(RequestIndex, conn, QosType.Reliable)) {
                         NetworkWriter writer = netWriter;
                         writer.Write(header);
@@ -319,6 +331,10 @@ namespace R2API.Networking {
 
                     NetworkConnection conn = NetworkServer.connections[i];
                     if (conn == null) {
+                        continue;
+                    }
+
+                    if (NetworkServer.localClientActive && NetworkServer.localConnections.Contains(conn)) {
                         continue;
                     }
 

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using R2API.MiscHelpers;
 using R2API.Networking;
 using RoR2;
+using Console = System.Console;
 
 namespace R2API.Utils {
     /// <summary>
@@ -72,8 +73,8 @@ namespace R2API.Utils {
         }
 
         private void ScanPluginsForNetworkCompat(object _, EventArgs __) {
-            try {
-                foreach (var (_, pluginInfo) in BepInEx.Bootstrap.Chainloader.PluginInfos) {
+            foreach (var (_, pluginInfo) in BepInEx.Bootstrap.Chainloader.PluginInfos) {
+                try {
                     var pluginAssembly = pluginInfo.Instance.GetType().Assembly;
                     var modGuid = pluginInfo.Metadata.GUID;
                     var modVer = pluginInfo.Metadata.Version;
@@ -93,15 +94,13 @@ namespace R2API.Utils {
                             : modGuid);
                     }
                 }
+                catch (Exception e) {
+                    R2API.Logger.LogDebug($"Exception in ScanPluginsForNetworkCompat while scanning plugin {pluginInfo.Metadata.GUID} : {e}");
+                }
+            }
 
-                AddToNetworkModList();
-            }
-            catch (Exception e) {
-                R2API.Logger.LogDebug($"Exception in ScanPluginsForNetworkCompat : {e}");
-            }
-            finally {
-                R2API.R2APIStart -= ScanPluginsForNetworkCompat;
-            }
+            AddToNetworkModList();
+            R2API.R2APIStart -= ScanPluginsForNetworkCompat;
         }
 
         private static bool AssemblyHasManualRegistration(Assembly assembly) {

--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using R2API.MiscHelpers;
@@ -95,7 +96,11 @@ namespace R2API.Utils {
                     }
                 }
                 catch (Exception e) {
-                    R2API.Logger.LogDebug($"Exception in ScanPluginsForNetworkCompat while scanning plugin {pluginInfo.Metadata.GUID} : {e}");
+                    R2API.Logger.LogError($"Exception in ScanPluginsForNetworkCompat while scanning plugin {pluginInfo.Metadata.GUID}");
+                    R2API.Logger.LogError("R2API Failed to properly scan the assembly." + Environment.NewLine +
+                                          "Please make sure you are compiling against net standard 2.0 " +
+                                          "and not anything else when making a plugin for Risk of Rain 2 !" +
+                                          Environment.NewLine + e);
                 }
             }
 


### PR DESCRIPTION
- Reply / Request message types for networking api were causing a potential infinite loop : the NetworkServer would forward the request to its Client connection equivalent even though it already handled the request fine.
- NetworkCompatibility can throw if the scanned assembly is compiled against a different net standard version. R2API and all other plugins should be using 2.0 as it was the Unity backend is the closest to. With Cecil scanning this error cannot happen but it showed to be fragile. I'm still unsure how the scanning should be done, either with classic Reflection or Cecil, in case we want to go back the git commits still have the old version saved. For now the issue is minor and can be very easily fixed by the mod makers by simply switching their net standard version to match `2.0`. Worst case scenario is that their mod get added to the synchronized mod list. An error get logged in the log and the console if such case happen.