### PR TITLE
Merged in ItemDropAPIFixes.

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -98,6 +98,12 @@ namespace R2API {
             ItemDropAPI.AddToDefaultByTier(ItemTier.Lunar, lunarItems);
             ItemDropAPI.AddToDefaultByTier(ItemTier.Boss, bossItems);
 
+            MonsterItemsAPI.AddToDefaultByTier(ItemTier.Tier1, t1Items);
+            MonsterItemsAPI.AddToDefaultByTier(ItemTier.Tier2, t2Items);
+            MonsterItemsAPI.AddToDefaultByTier(ItemTier.Tier3, t3Items);
+            MonsterItemsAPI.AddToDefaultByTier(ItemTier.Lunar, lunarItems);
+            MonsterItemsAPI.AddToDefaultByTier(ItemTier.Boss, bossItems);
+
             _itemCatalogInitialized = true;
         }
 
@@ -111,6 +117,7 @@ namespace R2API {
             var equipments = EquipmentDefinitions.Where(c => c.EquipmentDef.canDrop).Select(x => x.EquipmentDef.equipmentIndex).ToArray();
 
             ItemDropAPI.AddToDefaultEquipment(equipments);
+            MonsterItemsAPI.AddToDefaultEquipment(equipments);
 
             _equipmentCatalogInitialized = true;
         }

--- a/R2API/ItemDropAPI/Catalogue.cs
+++ b/R2API/ItemDropAPI/Catalogue.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using RoR2;
+using UnityEngine;
+using R2API;
+
+namespace R2API {
+    namespace ItemDropAPITools {
+        public class Catalogue : MonoBehaviour {
+            static public bool loaded = false;
+            static public Dictionary<ItemTier, ItemIndex> scrapItems = new Dictionary<ItemTier, ItemIndex>();
+            static public List<EquipmentIndex> eliteEquipment = new List<EquipmentIndex>();
+            
+            static public List<ItemIndex> pearls = new List<ItemIndex>() {
+                ItemIndex.Pearl,
+                ItemIndex.ShinyPearl,
+            };
+
+            static public void PopulateItemCatalogues() {                
+                if (!loaded) {
+                    foreach (ItemIndex itemIndex in RoR2.ItemCatalog.allItems) {
+                        if (itemIndex.ToString().ToLower().Contains("scrap")) {
+                            scrapItems.Add(RoR2.ItemCatalog.GetItemDef(itemIndex).tier, itemIndex);
+                        }
+                    }
+                    foreach (EquipmentIndex equipmentIndex in RoR2.EquipmentCatalog.allEquipment) {
+                        if (!RoR2.EquipmentCatalog.equipmentList.Contains(equipmentIndex)) {
+                            eliteEquipment.Add(equipmentIndex);
+                        }
+                    }
+                    loaded = true;
+                }
+            }
+
+            static public ItemIndex GetScrapIndex(ItemTier itemTier) {
+                if (scrapItems.ContainsKey(itemTier)) {
+                    return scrapItems[itemTier];
+                }
+                return ItemIndex.None;
+            }
+        }
+    }
+}

--- a/R2API/ItemDropAPI/DropList.cs
+++ b/R2API/ItemDropAPI/DropList.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using RoR2;
+
+namespace R2API {
+    namespace ItemDropAPITools {
+        public class DropList : MonoBehaviour {
+            static public bool originalListsSaved = false;
+            static public List<PickupIndex> tier1DropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> tier2DropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> tier3DropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> bossDropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> lunarDropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> equipmentDropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> normalEquipmentDropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> lunarEquipmentDropListOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> specialItemsOriginal = new List<PickupIndex>();
+            static public List<PickupIndex> eliteEquipmentOriginal = new List<PickupIndex>();
+
+
+            static private List<PickupIndex> tier1DropListBackup = new List<PickupIndex>();
+            static private List<PickupIndex> tier2DropListBackup = new List<PickupIndex>();
+            static private List<PickupIndex> tier3DropListBackup = new List<PickupIndex>();
+            static private List<PickupIndex> equipmentDropListBackup = new List<PickupIndex>();
+
+            public List<PickupIndex> availableTier1DropList = new List<PickupIndex>();
+            public List<PickupIndex> availableTier2DropList = new List<PickupIndex>();
+            public List<PickupIndex> availableTier3DropList = new List<PickupIndex>();
+            public List<PickupIndex> availableBossDropList = new List<PickupIndex>();
+            public List<PickupIndex> availableLunarDropList = new List<PickupIndex>();
+            public List<PickupIndex> availableEquipmentDropList = new List<PickupIndex>();
+            public List<PickupIndex> availableNormalEquipmentDropList = new List<PickupIndex>();
+            public List<PickupIndex> availableLunarEquipmentDropList = new List<PickupIndex>();
+            public List<PickupIndex> availableSpecialItems = new List<PickupIndex>();
+            public List<PickupIndex> availableEliteEquipment = new List<PickupIndex>();
+
+            public List<PickupIndex> GetDropList( ItemTier itemTier) {
+                if (itemTier == ItemTier.Tier1) {
+                    return availableTier1DropList;
+                } else if (itemTier == ItemTier.Tier2) {
+                    return availableTier2DropList;
+                } else if(itemTier == ItemTier.Tier3) {
+                    return availableTier3DropList;
+                } else if (itemTier == ItemTier.Boss) {
+                    return availableBossDropList;
+                } else if (itemTier == ItemTier.Lunar) {
+                    return availableLunarDropList;
+                } else {
+                    return availableNormalEquipmentDropList;
+                }
+            }
+
+            static public void DuplicateDropList(List<PickupIndex> original, List<PickupIndex> backup) {
+                backup.Clear();
+                foreach (PickupIndex pickupIndex in original) {
+                    backup.Add(pickupIndex);
+                }
+            }
+
+            static public void SetDropLists(List<PickupIndex> givenTier1, List<PickupIndex> givenTier2, List<PickupIndex> givenTier3, List<PickupIndex> givenEquipment) {
+                List<PickupIndex> none = new List<PickupIndex>() { PickupIndex.none };
+                List<List<PickupIndex>> availableItems = new List<List<PickupIndex>>() { new List<PickupIndex>(), new List<PickupIndex>(), new List<PickupIndex>(), new List<PickupIndex>() };
+                DuplicateDropList(givenTier1, availableItems[0]);
+                DuplicateDropList(givenTier2, availableItems[1]);
+                DuplicateDropList(givenTier3, availableItems[2]);
+                DuplicateDropList(givenEquipment, availableItems[3]);
+                for (int availableIndex = 0; availableIndex < 4; availableIndex++) {
+                    if (availableItems[availableIndex].Count == 0) {
+                        availableItems[availableIndex] = none;
+                    }
+                }
+
+                DuplicateDropList(Run.instance.availableTier1DropList, tier1DropListBackup);
+                DuplicateDropList(Run.instance.availableTier2DropList, tier2DropListBackup);
+                DuplicateDropList(Run.instance.availableTier3DropList, tier3DropListBackup);
+                DuplicateDropList(Run.instance.availableEquipmentDropList, equipmentDropListBackup);
+                System.Type type = typeof(RoR2.Run);
+                System.Reflection.FieldInfo tier1 = type.GetField("availableTier1DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo tier2 = type.GetField("availableTier2DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo tier3 = type.GetField("availableTier3DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo equipment = type.GetField("availableEquipmentDropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                tier1.SetValue(RoR2.Run.instance, availableItems[0]);
+                tier2.SetValue(RoR2.Run.instance, availableItems[1]);
+                tier3.SetValue(RoR2.Run.instance, availableItems[2]);
+                equipment.SetValue(RoR2.Run.instance, availableItems[3]);
+            }
+
+            static public void RevertDropLists() {
+                System.Type type = typeof(RoR2.Run);
+                System.Reflection.FieldInfo tier1 = type.GetField("availableTier1DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo tier2 = type.GetField("availableTier2DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo tier3 = type.GetField("availableTier3DropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo equipment = type.GetField("availableEquipmentDropList", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+
+                List<List<PickupIndex>> oldItems = new List<List<PickupIndex>>() { new List<PickupIndex>(), new List<PickupIndex>(), new List<PickupIndex>(), new List<PickupIndex>() };
+                DuplicateDropList(tier1DropListBackup, oldItems[0]);
+                DuplicateDropList(tier2DropListBackup, oldItems[1]);
+                DuplicateDropList(tier3DropListBackup, oldItems[2]);
+                DuplicateDropList(equipmentDropListBackup, oldItems[3]);
+
+                tier1.SetValue(RoR2.Run.instance, oldItems[0]);
+                tier2.SetValue(RoR2.Run.instance, oldItems[1]);
+                tier3.SetValue(RoR2.Run.instance, oldItems[2]);
+                equipment.SetValue(RoR2.Run.instance, oldItems[3]);
+            }
+
+            public  void ClearAllLists(RoR2.Run run) {
+                run.availableItems.Clear();
+                run.availableEquipment.Clear();
+                run.availableTier1DropList.Clear();
+                run.availableTier2DropList.Clear();
+                run.availableTier3DropList.Clear();
+                run.availableBossDropList.Clear();
+                run.availableLunarDropList.Clear();
+                run.availableEquipmentDropList.Clear();
+                run.availableNormalEquipmentDropList.Clear();
+                run.availableLunarEquipmentDropList.Clear();
+            }
+
+            public void DuplicateDropLists(Run run) {
+                if (!originalListsSaved) {
+                    DuplicateDropList(run.availableTier1DropList, tier1DropListOriginal);
+                    DuplicateDropList(run.availableTier2DropList, tier2DropListOriginal);
+                    DuplicateDropList(run.availableTier3DropList, tier3DropListOriginal);
+                    DuplicateDropList(run.availableBossDropList, bossDropListOriginal);
+                    DuplicateDropList(run.availableLunarDropList, lunarDropListOriginal);
+                    DuplicateDropList(run.availableEquipmentDropList, equipmentDropListOriginal);
+                    DuplicateDropList(run.availableNormalEquipmentDropList, normalEquipmentDropListOriginal);
+                    DuplicateDropList(run.availableLunarEquipmentDropList, lunarEquipmentDropListOriginal);
+                    specialItemsOriginal.Clear();
+                    foreach (ItemIndex itemIndex in Catalogue.scrapItems.Values) {
+                        Sprite sprite = ItemCatalog.GetItemDef(itemIndex).pickupIconSprite;
+                        if (sprite != null && !sprite.name.Contains("texNullIcon")) {
+                            specialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                        }
+                    }
+                    eliteEquipmentOriginal.Clear();
+                    foreach (EquipmentIndex equipmentIndex in Catalogue.eliteEquipment) {
+                        Sprite sprite = EquipmentCatalog.GetEquipmentDef(equipmentIndex).pickupIconSprite;
+                        if (sprite != null && !sprite.name.Contains("texNullIcon")) {
+                            eliteEquipmentOriginal.Add(PickupCatalog.FindPickupIndex(equipmentIndex));
+                        }
+                    }
+                    originalListsSaved = true;
+                }
+            }
+
+            public void GenerateItems(
+                Dictionary<ItemTier, HashSet<ItemIndex>> additionalTierItems,
+                HashSet<EquipmentIndex> additionalEquipment,
+                Dictionary<ItemTier, List<PickupIndex>> addItems,
+                Dictionary<ItemTier, List<PickupIndex>> removeItems,
+                Dictionary<ItemTier, List<PickupIndex>> addEquipment,
+                Dictionary<ItemTier, List<PickupIndex>> removeEquipment) {
+
+                availableTier1DropList.Clear();
+                availableTier2DropList.Clear();
+                availableTier3DropList.Clear();
+                availableBossDropList.Clear();
+                availableLunarDropList.Clear();
+                availableLunarEquipmentDropList.Clear();
+                availableEquipmentDropList.Clear();
+                availableNormalEquipmentDropList.Clear();
+
+                AdjustList(availableTier1DropList, additionalTierItems[ItemTier.Tier1], tier1DropListOriginal, addItems[ItemTier.Tier1], removeItems[ItemTier.Tier1]);
+                AdjustList(availableTier2DropList, additionalTierItems[ItemTier.Tier2], tier2DropListOriginal, addItems[ItemTier.Tier2], removeItems[ItemTier.Tier2]);
+                AdjustList(availableTier3DropList, additionalTierItems[ItemTier.Tier3], tier3DropListOriginal, addItems[ItemTier.Tier3], removeItems[ItemTier.Tier3]);
+                AdjustList(availableBossDropList, additionalTierItems[ItemTier.Boss], bossDropListOriginal, addItems[ItemTier.Boss], removeItems[ItemTier.Boss]);
+                AdjustList(availableLunarDropList, additionalTierItems[ItemTier.Lunar], lunarDropListOriginal, addItems[ItemTier.Lunar], removeItems[ItemTier.Lunar]);
+                AdjustList(availableSpecialItems, new HashSet<ItemIndex>(), specialItemsOriginal, addItems[ItemTier.NoTier], removeItems[ItemTier.NoTier]);
+
+                AdjustList(availableNormalEquipmentDropList, additionalEquipment, normalEquipmentDropListOriginal, addEquipment[ItemTier.Tier1], removeEquipment[ItemTier.Tier1], ItemTier.Tier1);
+                AdjustList(availableLunarEquipmentDropList, additionalEquipment, lunarEquipmentDropListOriginal, addEquipment[ItemTier.Lunar], removeEquipment[ItemTier.Lunar], ItemTier.Lunar);
+                AdjustList(availableEliteEquipment, additionalEquipment, eliteEquipmentOriginal, addEquipment[ItemTier.NoTier], removeEquipment[ItemTier.NoTier], ItemTier.NoTier);
+            }
+
+            public void AdjustList(
+                List<PickupIndex> dropList,
+                HashSet<ItemIndex> moddedOriginalList,
+                List<PickupIndex> original,
+                List<PickupIndex> addItems,
+                List<PickupIndex> removeItems) {
+
+                List<PickupIndex> convertedList = new List<PickupIndex>();
+                foreach (ItemIndex itemIndex in moddedOriginalList) {
+                    PickupIndex pickupIndex = PickupCatalog.FindPickupIndex(itemIndex);
+                    if (!convertedList.Contains(pickupIndex)) {
+                        convertedList.Add(pickupIndex);
+                    }
+                }
+                AdjustList(dropList, convertedList, original, addItems, removeItems);
+            }
+
+            public void AdjustList(
+                List<PickupIndex> dropList,
+                HashSet<EquipmentIndex> moddedOriginalList,
+                List<PickupIndex> original,
+                List<PickupIndex> addItems,
+                List<PickupIndex> removeItems,
+                ItemTier itemTier) {
+
+                List<PickupIndex> convertedList = new List<PickupIndex>();
+                foreach (EquipmentIndex equipmentIndex in moddedOriginalList) {
+                    PickupIndex pickupIndex = PickupCatalog.FindPickupIndex(equipmentIndex);
+                    if (!convertedList.Contains(pickupIndex)) {
+                        EquipmentDef equipmentDef = EquipmentCatalog.GetEquipmentDef(equipmentIndex);
+                        if ((itemTier == ItemTier.Lunar && equipmentDef.isLunar) || (itemTier == ItemTier.Tier1 && !equipmentDef.isLunar && !Catalogue.eliteEquipment.Contains(equipmentIndex)) || (itemTier == ItemTier.NoTier && !equipmentDef.isLunar && Catalogue.eliteEquipment.Contains(equipmentIndex))) {
+                            convertedList.Add(pickupIndex);
+                        }
+                    }
+                }
+                AdjustList(dropList, convertedList, original, addItems, removeItems);
+            }
+
+            public void AdjustList(
+                List<PickupIndex> dropList,
+                List<PickupIndex> moddedOriginalList,
+                List<PickupIndex> original,
+                List<PickupIndex> addItems,
+                List<PickupIndex> removeItems) {
+
+                foreach (PickupIndex pickupIndex in original) {
+                    if (!dropList.Contains(pickupIndex)) {
+                        dropList.Add(pickupIndex);
+                    }
+                }
+                foreach (PickupIndex pickupIndex in addItems) {
+                    if (!dropList.Contains(pickupIndex)) {
+                        dropList.Add(pickupIndex);
+                    }
+                }
+                foreach (PickupIndex pickupIndex in removeItems) {
+                    if (dropList.Contains(pickupIndex)) {
+                        dropList.Remove(pickupIndex);
+                    }
+                }
+            }
+
+            public void SetItems(Run run) {
+                foreach (PickupIndex pickupIndex in availableTier1DropList) {
+                    run.availableTier1DropList.Add(pickupIndex);
+                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableTier2DropList) {
+                    run.availableTier2DropList.Add(pickupIndex);
+                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableTier3DropList) {
+                    run.availableTier3DropList.Add(pickupIndex);
+                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableBossDropList) {
+                    run.availableBossDropList.Add(pickupIndex);
+                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableLunarDropList) {
+                    run.availableLunarDropList.Add(pickupIndex);
+                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableEquipmentDropList) {
+                    run.availableEquipmentDropList.Add(pickupIndex);
+                    run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableNormalEquipmentDropList) {
+                    run.availableNormalEquipmentDropList.Add(pickupIndex);
+                    run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                }
+                foreach (PickupIndex pickupIndex in availableLunarEquipmentDropList) {
+                    run.availableLunarEquipmentDropList.Add(pickupIndex);
+                    run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                }
+
+                DefaultItemDrops.AddDefaults();
+            }
+        }
+    }
+}

--- a/R2API/ItemDropAPI/DropOdds.cs
+++ b/R2API/ItemDropAPI/DropOdds.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using RoR2;
+
+namespace R2API {
+    namespace ItemDropAPITools {
+        public class DropOdds : MonoBehaviour {
+            static private List<string> chestInteractables = new List<string>() {
+                "Chest1",
+                "Chest2",
+                "CategoryChestDamage",
+                "CategoryChestHealing",
+                "CategoryChestUtility",
+                "Chest1Stealthed",
+                "Lockbox",
+                "ScavBackpack",
+            };
+
+            static private Dictionary<string, List<float>> chestTierOdds = new Dictionary<string, List<float>>();
+
+            static public void UpdateChestTierOdds(SpawnCard spawnCard, string interactableName) {
+                if (chestInteractables.Contains(interactableName)) {
+                    ChestBehavior chestBehavior = spawnCard.prefab.GetComponent<ChestBehavior>();
+                    if (!chestTierOdds.ContainsKey(interactableName)) {
+                        chestTierOdds.Add(interactableName, new List<float>());
+                        chestTierOdds[interactableName].Add(chestBehavior.tier1Chance);
+                        chestTierOdds[interactableName].Add(chestBehavior.tier2Chance);
+                        chestTierOdds[interactableName].Add(chestBehavior.tier3Chance);
+                    }
+
+                    if (chestTierOdds.ContainsKey(interactableName)) {
+                        chestBehavior.tier1Chance = chestTierOdds[interactableName][0];
+                        chestBehavior.tier2Chance = chestTierOdds[interactableName][1];
+                        chestBehavior.tier3Chance = chestTierOdds[interactableName][2];
+                    }
+                    if (ItemDropAPI.playerInteractables.subsetTiersPresent.ContainsKey(interactableName)) {
+                        if (!ItemDropAPI.playerInteractables.subsetTiersPresent[interactableName]["tier1"]) {
+                            chestBehavior.tier1Chance = 0;
+                        }
+                        if (!ItemDropAPI.playerInteractables.subsetTiersPresent[interactableName]["tier2"]) {
+                            chestBehavior.tier2Chance = 0;
+                        }
+                        if (!ItemDropAPI.playerInteractables.subsetTiersPresent[interactableName]["tier3"]) {
+                            chestBehavior.tier3Chance = 0;
+                        }
+                    } else {
+                        if (!ItemDropAPI.playerInteractables.tiersPresent["tier1"]) {
+                            chestBehavior.tier1Chance = 0;
+                        }
+                        if (!ItemDropAPI.playerInteractables.tiersPresent["tier2"]) {
+                            chestBehavior.tier2Chance = 0;
+                        }
+                        if (!ItemDropAPI.playerInteractables.tiersPresent["tier3"]) {
+                            chestBehavior.tier3Chance = 0;
+                        }
+                    }
+                }
+            }
+
+            static private List<string> shrineInteractables = new List<string>() {
+                "ShrineChance",
+            };
+
+            static private Dictionary<string, List<float>> shrineTierOdds = new Dictionary<string, List<float>>();
+
+            static public void UpdateShrineTierOdds(DirectorCard directorCard, string interactableName) {
+                if (shrineInteractables.Contains(interactableName)) {
+                    ShrineChanceBehavior shrineBehavior = directorCard.spawnCard.prefab.GetComponent<ShrineChanceBehavior>();
+                    if (!shrineTierOdds.ContainsKey(interactableName)) {
+                        shrineTierOdds.Add(interactableName, new List<float>());
+                        shrineTierOdds[interactableName].Add(shrineBehavior.tier1Weight);
+                        shrineTierOdds[interactableName].Add(shrineBehavior.tier2Weight);
+                        shrineTierOdds[interactableName].Add(shrineBehavior.tier3Weight);
+                        shrineTierOdds[interactableName].Add(shrineBehavior.equipmentWeight);
+                    }
+
+                    if (shrineTierOdds.ContainsKey(interactableName)) {
+                        shrineBehavior.tier1Weight = shrineTierOdds[interactableName][0];
+                        shrineBehavior.tier2Weight = shrineTierOdds[interactableName][1];
+                        shrineBehavior.tier3Weight = shrineTierOdds[interactableName][2];
+                        shrineBehavior.equipmentWeight = shrineTierOdds[interactableName][3];
+                    }
+
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier1"]) {
+                        shrineBehavior.tier1Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier2"]) {
+                        shrineBehavior.tier2Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier3"]) {
+                        shrineBehavior.tier3Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["equipment"]) {
+                        shrineBehavior.equipmentWeight = 0;
+                    }
+                }
+            }
+
+            static private List<string> dropTableInteractables = new List<string>() {
+                "CasinoChest",
+            };
+
+            static private Dictionary<string, List<float>> dropTableTierOdds = new Dictionary<string, List<float>>();
+
+            static public void UpdateDropTableTierOdds(SpawnCard spawnCard, string interactableName) {
+                if (dropTableInteractables.Contains(interactableName)) {
+                    BasicPickupDropTable dropTable = spawnCard.prefab.GetComponent<RouletteChestController>().dropTable as BasicPickupDropTable;
+                    if (!dropTableTierOdds.ContainsKey(interactableName)) {
+                        dropTableTierOdds.Add(interactableName, new List<float>());
+                        dropTableTierOdds[interactableName].Add(dropTable.tier1Weight);
+                        dropTableTierOdds[interactableName].Add(dropTable.tier2Weight);
+                        dropTableTierOdds[interactableName].Add(dropTable.tier3Weight);
+                        dropTableTierOdds[interactableName].Add(dropTable.equipmentWeight);
+                    }
+                    if (dropTableTierOdds.ContainsKey(interactableName)) {
+                        dropTable.tier1Weight = dropTableTierOdds[interactableName][0];
+                        dropTable.tier2Weight = dropTableTierOdds[interactableName][1];
+                        dropTable.tier3Weight = dropTableTierOdds[interactableName][2];
+                        dropTable.equipmentWeight = dropTableTierOdds[interactableName][3];
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier1"]) {
+                        dropTable.tier1Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier2"]) {
+                        dropTable.tier2Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["tier3"]) {
+                        dropTable.tier3Weight = 0;
+                    }
+                    if (!ItemDropAPI.playerInteractables.tiersPresent["equipment"]) {
+                        dropTable.equipmentWeight = 0;
+                    }
+                    System.Type type = typeof(RoR2.BasicPickupDropTable);
+                    System.Reflection.MethodInfo method = type.GetMethod("GenerateWeightedSelection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method.Invoke(dropTable, new object[] { Run.instance });
+                }
+            }
+
+            static private List<string> dropTableItemInteractables = new List<string>() {
+                "ShrineCleanse",
+            };
+
+            static private Dictionary<string, List<float>> dropTableItemOdds = new Dictionary<string, List<float>>();
+
+            static public void UpdateDropTableItemOdds(DropList dropList, ExplicitPickupDropTable dropTable, string interactableName) {
+                if (dropTableItemInteractables.Contains(interactableName)) {
+                    if (!dropTableItemOdds.ContainsKey(interactableName)) {
+                        dropTableItemOdds.Add(interactableName, new List<float>());
+                        foreach (ExplicitPickupDropTable.Entry entry in dropTable.entries) {
+                            dropTableItemOdds[interactableName].Add(entry.pickupWeight);
+                        }
+                    }
+
+                    if (dropTableItemOdds.ContainsKey(interactableName)) {
+                        for (int entryIndex = 0; entryIndex < dropTable.entries.Length; entryIndex++) {
+
+                            dropTable.entries[entryIndex].pickupWeight = dropTableItemOdds[interactableName][entryIndex];
+                        }
+                    }
+                    for (int entryIndex = 0; entryIndex < dropTable.entries.Length; entryIndex++) {
+                        if (!dropList.availableBossDropList.Contains(PickupCatalog.FindPickupIndex(dropTable.entries[entryIndex].pickupName))) {
+                            dropTable.entries[entryIndex].pickupWeight = 0;
+                        }
+                    }
+                    System.Type type = typeof(RoR2.ExplicitPickupDropTable);
+                    System.Reflection.MethodInfo method = type.GetMethod("GenerateWeightedSelection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method.Invoke(dropTable, new object[0]);
+                }
+            }
+        }
+	}
+}

--- a/R2API/ItemDropAPI/InteractableCalculator.cs
+++ b/R2API/ItemDropAPI/InteractableCalculator.cs
@@ -1,0 +1,280 @@
+﻿using UnityEngine;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using RoR2;
+
+namespace R2API {
+    namespace ItemDropAPITools {
+        public class InteractableCalculator : MonoBehaviour {
+            static public int prefixLength = 3;
+
+            public List<string> interactablesInvalid = new List<string>();
+
+            static public List<string> allTiersMustBePresent = new List<string>() {
+                "ShrineCleanse",
+            };
+            static public Dictionary<string, ItemTier> tierConversion = new Dictionary<string, ItemTier>() {
+                { "tier1", ItemTier.Tier1 },
+                { "tier2", ItemTier.Tier2 },
+                { "tier3", ItemTier.Tier3 },
+                { "boss", ItemTier.Boss },
+            };
+            private List<string> subsetChests = new List<string>() {
+                "CategoryChestDamage",
+                "CategoryChestHealing",
+                "CategoryChestUtility",
+            };
+            public Dictionary<string, Dictionary<string, bool>> subsetTiersPresent = new Dictionary<string, Dictionary<string, bool>>() {
+
+            };
+            public Dictionary<string, bool> tiersPresent = new Dictionary<string, bool>() {
+                { "tier1", false },
+                { "tier2", false },
+                { "tier3", false },
+                { "boss", false },
+                { "lunar", false },
+                { "equipment", false },
+                { "lunarEquipment", false },
+                { "damage", false },
+                { "healing", false },
+                { "utility", false },
+                { "pearl", false },
+                { "drone", false },
+            };
+            public Dictionary<string, Dictionary<string, bool>> interactablesTiers = new Dictionary<string, Dictionary<string, bool>>() {
+                { "Chest1", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    //{ "tier2", false },
+                    //{ "tier3", false },
+                }},
+                { "Chest2", new Dictionary<string, bool>() {
+                    { "tier2", false },
+                    //{ "tier3", false },
+                }},
+                { "EquipmentBarrel", new Dictionary<string, bool>() {
+                    { "equipment", false },
+                }},
+                { "TripleShop", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                }},
+                { "LunarChest", new Dictionary<string, bool>() {
+                    { "lunar", false },
+                }},
+                { "TripleShopLarge", new Dictionary<string, bool>() {
+                    { "tier2", false },
+                }},
+                { "CategoryChestDamage", new Dictionary<string, bool>() {
+                    { "damage", false },
+                }},
+                { "CategoryChestHealing", new Dictionary<string, bool>() {
+                    { "healing", false },
+                }},
+                { "CategoryChestUtility", new Dictionary<string, bool>() {
+                    { "utility", false },
+                }},
+                { "ShrineChance", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                    { "equipment", false},
+                }},
+                { "ShrineCleanse", new Dictionary<string, bool>() {
+                    { "lunar", false },
+                    { "pearl", false}
+                }},
+                { "ShrineRestack", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                    { "boss", false },
+                    { "lunar", false },
+                }},
+                { "TripleShopEquipment", new Dictionary<string, bool>() {
+                    { "equipment", false },
+                }},
+                { "BrokenEquipmentDrone", new Dictionary<string, bool>() {
+                    { "equipment", false },
+                }},
+                { "Chest1Stealthed", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                }},
+                { "GoldChest", new Dictionary<string, bool>() {
+                    { "tier3", false },
+                }},
+                { "Scrapper", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                    { "boss", false },
+                }},
+                { "Duplicator", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                }},
+                { "DuplicatorLarge", new Dictionary<string, bool>() {
+                    { "tier2", false },
+                }},
+                { "DuplicatorMilitary", new Dictionary<string, bool>() {
+                    { "tier3", false },
+                }},
+                { "DuplicatorWild", new Dictionary<string, bool>() {
+                    { "boss", false },
+                }},
+                { "ScavBackpack", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                }},
+                { "CasinoChest", new Dictionary<string, bool>() {
+                    { "tier1", false },
+                    { "tier2", false },
+                    { "tier3", false },
+                    { "equipment", false },
+                }},
+            };
+
+            static public string GetSpawnCardName(RoR2.SpawnCard givenSpawncard) {
+                return givenSpawncard.name.Substring(prefixLength, givenSpawncard.name.Length - prefixLength);
+            }
+
+            static public void AddItemsToList(List<PickupIndex> listA, List<PickupIndex> listB) {
+                foreach (PickupIndex pickupIndex in listB) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None) {
+                        if (!listA.Contains(pickupIndex)) {
+                            listA.Add(pickupIndex);
+                        }
+                    }
+                }
+            }
+
+            public void CalculateInvalidInteractables(DropList dropList) {
+                List<string> tiersPresentKeys = tiersPresent.Keys.ToList();
+                foreach (string tier in tiersPresentKeys) {
+                    tiersPresent[tier] = false;
+                }
+                subsetTiersPresent.Clear();
+                foreach (string subsetChest in subsetChests) {
+                    subsetTiersPresent.Add(subsetChest, new Dictionary<string, bool>());
+                    foreach (string tier in tiersPresentKeys) {
+                        subsetTiersPresent[subsetChest].Add(tier, false);
+                    }
+                }
+                foreach (PickupIndex pickupIndex in dropList.availableTier1DropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["tier1"] = true;
+                        break;
+                    }
+                }
+                foreach (PickupIndex pickupIndex in dropList.availableTier2DropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["tier2"] = true;
+                        break;
+                    }
+                }
+                foreach (PickupIndex pickupIndex in dropList.availableTier3DropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["tier3"] = true;
+                        break;
+                    }
+                }
+                foreach (PickupIndex pickupIndex in dropList.availableBossDropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex) && Catalogue.pearls.Contains(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["pearl"] = true;
+                        break;
+                    }
+                }
+                foreach (PickupIndex pickupIndex in dropList.availableBossDropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex) && !Catalogue.pearls.Contains(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["boss"] = true;
+                        break;
+                    }
+                }
+
+                foreach (PickupIndex pickupIndex in dropList.availableLunarDropList) {
+                    if (PickupCatalog.GetPickupDef(pickupIndex).itemIndex != ItemIndex.None && !Catalogue.scrapItems.ContainsValue(PickupCatalog.GetPickupDef(pickupIndex).itemIndex) && Catalogue.pearls.Contains(PickupCatalog.GetPickupDef(pickupIndex).itemIndex)) {
+                        tiersPresent["lunar"] = true;
+                        break;
+                    }
+                }
+                List<PickupIndex> everyItem = new List<PickupIndex>();
+                AddItemsToList(everyItem, dropList.availableTier1DropList);
+                AddItemsToList(everyItem, dropList.availableTier2DropList);
+                AddItemsToList(everyItem, dropList.availableTier3DropList);
+                foreach (PickupIndex pickupIndex in everyItem) {
+                    PickupDef pickupDef = PickupCatalog.GetPickupDef(pickupIndex);
+                    RoR2.ItemDef itemDef = RoR2.ItemCatalog.GetItemDef(pickupDef.itemIndex);
+                    foreach (RoR2.ItemTag itemTag in itemDef.tags) {
+                        string interactableName = "";
+                        if (itemTag == RoR2.ItemTag.Damage) {
+                            tiersPresent["damage"] = true;
+                            interactableName = "CategoryChestDamage";
+                        } else if (itemTag == RoR2.ItemTag.Healing) {
+                            tiersPresent["healing"] = true;
+                            interactableName = "CategoryChestHealing";
+                        } else if (itemTag == RoR2.ItemTag.Utility) {
+                            tiersPresent["utility"] = true;
+                            interactableName = "CategoryChestUtility";
+                        }
+                        if (subsetChests.Contains(interactableName)) {
+                            if (RoR2.ItemCatalog.tier1ItemList.Contains(pickupDef.itemIndex)) {
+                                subsetTiersPresent[interactableName]["tier1"] = true;
+                            } else if (RoR2.ItemCatalog.tier2ItemList.Contains(pickupDef.itemIndex)) {
+                                subsetTiersPresent[interactableName]["tier2"] = true;
+                            } else if (RoR2.ItemCatalog.tier3ItemList.Contains(pickupDef.itemIndex)) {
+                                subsetTiersPresent[interactableName]["tier3"] = true;
+                            }
+                        }
+                    }
+                }
+                if (dropList.availableNormalEquipmentDropList.Count > 0) {
+                    tiersPresent["equipment"] = true;
+                }
+                if (dropList.availableLunarEquipmentDropList.Count > 0) {
+                    tiersPresent["lunar"] = true;
+                }
+                List<string> interactableTypeKeys = interactablesTiers.Keys.ToList();
+                foreach (string interactableType in interactableTypeKeys) {
+                    List<string> interactableTypeTierKeys = interactablesTiers[interactableType].Keys.ToList();
+                    foreach (string tier in interactableTypeTierKeys) {
+                        interactablesTiers[interactableType][tier] = false;
+                    }
+                }
+                foreach (string tier in tiersPresent.Keys) {
+                    if (tiersPresent[tier]) {
+                        foreach (string interactableType in interactableTypeKeys) {
+                            if (interactablesTiers[interactableType].ContainsKey(tier)) {
+                                interactablesTiers[interactableType][tier] = true;
+                            }
+                        }
+                    }
+                }
+                List<string> scrapTierKeys = interactablesTiers["Scrapper"].Keys.ToList();
+                foreach (string tier in scrapTierKeys) {
+                    if (interactablesTiers["Scrapper"][tier]) {
+                        if (!dropList.availableSpecialItems.Contains(PickupCatalog.FindPickupIndex(Catalogue.scrapItems[tierConversion[tier]]))) {
+                            interactablesTiers["Scrapper"][tier] = false;
+                        }
+                    }
+                }
+
+                interactablesInvalid.Clear();
+                foreach (string interactableType in interactablesTiers.Keys) {
+                    bool interactableValid = false;
+                    bool allTrue = true;
+                    foreach (string tier in interactablesTiers[interactableType].Keys) {
+                        if (interactablesTiers[interactableType][tier]) {
+                            interactableValid = true;
+                        } else {
+                            allTrue = false;
+                        }
+                    }
+                    if (!interactableValid || (allTiersMustBePresent.Contains(interactableType) && !allTrue)) {
+                        interactablesInvalid.Add(interactableType);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/R2API/MonsterItemsAPI.cs
+++ b/R2API/MonsterItemsAPI.cs
@@ -1,0 +1,416 @@
+﻿using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using RoR2;
+using R2API;
+using R2API.Utils;
+using R2API.ItemDropAPITools;
+using MonoMod.Cil;
+using UnityEngine.Events;
+
+namespace R2API {
+    [R2APISubmodule]
+    public class MonsterItemsAPI {
+        public static bool Loaded {
+            get => _loaded;
+            internal set => _loaded = value;
+        }
+        private static bool _loaded;
+
+        private static readonly Dictionary<ItemTier, HashSet<ItemIndex>> AdditionalTierItems = new Dictionary<ItemTier, HashSet<ItemIndex>> {
+            { ItemTier.Tier1, new HashSet<ItemIndex>() },
+            { ItemTier.Tier2, new HashSet<ItemIndex>() },
+            { ItemTier.Tier3, new HashSet<ItemIndex>() },
+            { ItemTier.Boss, new HashSet<ItemIndex>() },
+            { ItemTier.Lunar, new HashSet<ItemIndex>() }
+        };
+
+        private static readonly HashSet<EquipmentIndex> AdditionalEquipment = new HashSet<EquipmentIndex>();
+
+        private static Dictionary<ItemTier, List<PickupIndex>> _itemsToAdd = new Dictionary<ItemTier, List<PickupIndex>>() {
+            { ItemTier.Tier1, new List<PickupIndex>() },
+            { ItemTier.Tier2, new List<PickupIndex>() },
+            { ItemTier.Tier3, new List<PickupIndex>() },
+            { ItemTier.Boss, new List<PickupIndex>() },
+            { ItemTier.Lunar, new List<PickupIndex>() },
+            { ItemTier.NoTier, new List<PickupIndex>() },
+        };
+
+        private static Dictionary<ItemTier, List<PickupIndex>> _itemsToRemove = new Dictionary<ItemTier, List<PickupIndex>>() {
+            { ItemTier.Tier1, new List<PickupIndex>() },
+            { ItemTier.Tier2, new List<PickupIndex>() },
+            { ItemTier.Tier3, new List<PickupIndex>() },
+            { ItemTier.Boss, new List<PickupIndex>() },
+            { ItemTier.Lunar, new List<PickupIndex>() },
+            { ItemTier.NoTier, new List<PickupIndex>() },
+        };
+
+        private static Dictionary<ItemTier, List<PickupIndex>> _equipmentToAdd = new Dictionary<ItemTier, List<PickupIndex>>() {
+            { ItemTier.Tier1, new List<PickupIndex>() },
+            { ItemTier.Lunar, new List<PickupIndex>() },
+            { ItemTier.NoTier, new List<PickupIndex>() },
+        };
+
+        private static Dictionary<ItemTier, List<PickupIndex>> _equipmentToRemove = new Dictionary<ItemTier, List<PickupIndex>>() {
+            { ItemTier.Tier1, new List<PickupIndex>() },
+            { ItemTier.Lunar, new List<PickupIndex>() },
+            { ItemTier.NoTier, new List<PickupIndex>() },
+        };
+
+        static public Dictionary<ItemTier, List<PickupIndex>> itemsToAdd {
+            get { return _itemsToAdd; }
+            private set { _itemsToAdd = value; }
+        }
+
+        static public Dictionary<ItemTier, List<PickupIndex>> itemsToRemove {
+            get { return _itemsToRemove; }
+            private set { _itemsToRemove = value; }
+        }
+
+        static public Dictionary<ItemTier, List<PickupIndex>> equipmentToAdd {
+            get { return _equipmentToAdd; }
+            private set { _equipmentToAdd = value; }
+        }
+
+        static public Dictionary<ItemTier, List<PickupIndex>> equipmentToRemove {
+            get { return _equipmentToRemove; }
+            private set { _equipmentToRemove = value; }
+        }
+
+        static private Dictionary<ItemTier, bool> tierValidMonsterTeam = new Dictionary<ItemTier, bool>();
+        static private Dictionary<ItemTier, bool> tierValidScav = new Dictionary<ItemTier, bool>();
+        static private ItemTier[] patternAdjusted = new ItemTier[0];
+        static public DropList monsterDropList = new DropList();
+
+        [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
+        internal static void SetHooks() {
+            On.RoR2.Run.BuildDropTable += RunOnBuildDropTable;
+            On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.GenerateAvailableItemsSet += GenerateAvailableItemsSet;
+            On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.EnsureMonsterTeamItemCount += EnsureMonsterTeamItemCount;
+            IL.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.GrantMonsterTeamItem += GrantMonsterTeamItem;
+            On.EntityStates.ScavMonster.FindItem.OnEnter += OnEnter;
+            On.RoR2.ScavengerItemGranter.Start += ScavengerItemGranterStart;
+            On.RoR2.Inventory.GiveRandomEquipment += GiveRandomEquipment;
+        }
+
+        [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
+        internal static void UnsetHooks() {
+            On.RoR2.Run.BuildDropTable -= RunOnBuildDropTable;
+            On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.GenerateAvailableItemsSet -= GenerateAvailableItemsSet;
+            On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.EnsureMonsterTeamItemCount -= EnsureMonsterTeamItemCount;
+            IL.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.GrantMonsterTeamItem -= GrantMonsterTeamItem;
+            On.EntityStates.ScavMonster.FindItem.OnEnter -= OnEnter;
+            On.RoR2.ScavengerItemGranter.Start -= ScavengerItemGranterStart;
+            On.RoR2.Inventory.GiveRandomEquipment -= GiveRandomEquipment;
+        }
+
+        private static void RunOnBuildDropTable(On.RoR2.Run.orig_BuildDropTable orig, Run run) {
+            Catalogue.PopulateItemCatalogues();
+            orig(run);
+            monsterDropList.DuplicateDropLists(run);
+            monsterDropList.GenerateItems(AdditionalTierItems, AdditionalEquipment, itemsToAdd, itemsToRemove, equipmentToAdd, equipmentToRemove);
+        }
+
+        static private void GenerateAvailableItemsSet(On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.orig_GenerateAvailableItemsSet orig) {
+            List<ItemTag> forbiddenTags = new List<ItemTag>();
+            System.Type type = typeof(RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager);
+            System.Reflection.FieldInfo info = type.GetField("forbiddenTags", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            ICollection collection = info.GetValue(null) as ICollection;
+            foreach (object itemTag in collection) {
+                forbiddenTags.Add((ItemTag)itemTag);
+            }
+
+            tierValidScav.Clear();
+            tierValidMonsterTeam.Clear();
+            List<PickupIndex> tier1Adjusted = monsterDropList.availableTier1DropList;
+            tierValidMonsterTeam.Add(ItemTier.Tier1, ListContainsValidItems(forbiddenTags, tier1Adjusted));
+            tierValidScav.Add(ItemTier.Tier1, ListContainsValidItems(new List<ItemTag>() { ItemTag.AIBlacklist }, tier1Adjusted));
+            if (!tierValidMonsterTeam[ItemTier.Tier1]) {
+                tier1Adjusted = DropList.tier1DropListOriginal;
+            }
+            List<PickupIndex> tier2Adjusted = monsterDropList.availableTier2DropList;
+            tierValidMonsterTeam.Add(ItemTier.Tier2, ListContainsValidItems(forbiddenTags, tier2Adjusted));
+            tierValidScav.Add(ItemTier.Tier2, ListContainsValidItems(new List<ItemTag>() { ItemTag.AIBlacklist }, tier2Adjusted));
+            if (!tierValidMonsterTeam[ItemTier.Tier2]) {
+                tier2Adjusted = DropList.tier2DropListOriginal;
+            }
+            List<PickupIndex> tier3Adjusted = monsterDropList.availableTier3DropList;
+            tierValidMonsterTeam.Add(ItemTier.Tier3, ListContainsValidItems(forbiddenTags, tier3Adjusted));
+            tierValidScav.Add(ItemTier.Tier3, ListContainsValidItems(new List<ItemTag>() { ItemTag.AIBlacklist }, tier3Adjusted));
+            if (!tierValidMonsterTeam[ItemTier.Tier3]) {
+                tier3Adjusted = DropList.tier3DropListOriginal;
+            }
+
+            DropList.SetDropLists(tier1Adjusted, tier2Adjusted, tier3Adjusted, DropList.equipmentDropListOriginal);
+            orig();
+            DropList.RevertDropLists();
+
+
+            info = type.GetField("pattern", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            collection = info.GetValue(null) as ICollection;
+            List<ItemTier> patternAdjustedList = new List<ItemTier>();
+            int patternIndex = 0;
+            foreach (object itemTier in collection) {
+                patternAdjustedList.Add((ItemTier)itemTier);
+                patternIndex += 1;
+            }
+            if (!tierValidMonsterTeam[ItemTier.Tier1]) {
+                while (patternAdjustedList.Contains(ItemTier.Tier1)) {
+                    patternAdjustedList.Remove(ItemTier.Tier1);
+                }
+            }
+            if (!tierValidMonsterTeam[ItemTier.Tier2]) {
+                while (patternAdjustedList.Contains(ItemTier.Tier2)) {
+                    patternAdjustedList.Remove(ItemTier.Tier2);
+                }
+            }
+            if (!tierValidMonsterTeam[ItemTier.Tier3]) {
+                while (patternAdjustedList.Contains(ItemTier.Tier3)) {
+                    patternAdjustedList.Remove(ItemTier.Tier3);
+                }
+            }
+            patternAdjusted = new ItemTier[patternAdjustedList.Count];
+            patternIndex = 0;
+            foreach (ItemTier itemTier in patternAdjustedList) {
+                patternAdjusted[patternIndex] = itemTier;
+                patternIndex += 1;
+            }
+        }
+
+        static private void EnsureMonsterTeamItemCount(On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.orig_EnsureMonsterTeamItemCount orig, int integer) {
+            if (patternAdjusted.Length > 0) {
+                orig(integer);
+            }
+        }
+
+        static private void GrantMonsterTeamItem(ILContext ilContext) {
+            //https://github.com/risk-of-thunder/R2Wiki/wiki/Working-with-IL
+            System.Type type = typeof(RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager);
+            System.Reflection.FieldInfo pattern = type.GetField("pattern", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            System.Reflection.FieldInfo currentItemIterator = type.GetField("currentItemIterator", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+
+            ILCursor cursor = new ILCursor(ilContext);
+            cursor.GotoNext(
+                x => x.MatchLdsfld(pattern),
+                x => x.MatchLdsfld(currentItemIterator),
+                x => x.MatchDup(),
+                x => x.MatchLdcI4(1),
+                x => x.MatchAdd(),
+                x => x.MatchStsfld(currentItemIterator),
+                x => x.MatchLdsfld(pattern),
+                x => x.MatchLdlen(),
+                x => x.MatchConvI4(),
+                x => x.MatchRem(),
+                x => x.MatchLdelemI4(),
+                x => x.MatchStloc(0)
+            );
+            cursor.RemoveRange(11);
+
+            cursor.EmitDelegate<System.Func<ItemTier>>(() => {
+                int currentItemIteratorValue = int.Parse(currentItemIterator.GetValue(null).ToString());
+                ItemTier itemTier = patternAdjusted[currentItemIteratorValue % patternAdjusted.Length];
+                currentItemIterator.SetValue(null, currentItemIteratorValue + 1);
+                return itemTier;
+            });
+        }
+
+        static private void OnEnter(On.EntityStates.ScavMonster.FindItem.orig_OnEnter orig, EntityStates.ScavMonster.FindItem findItem) {
+            bool valid = false;
+            foreach (bool tierValid in tierValidScav.Values) {
+                if (tierValid) {
+                    valid = true;
+                    break;
+                }
+            }
+            if (valid) {
+                List<PickupIndex> tier1Adjusted = monsterDropList.availableTier1DropList;
+                if (!tierValidMonsterTeam[ItemTier.Tier1]) {
+                    tier1Adjusted = DropList.tier1DropListOriginal;
+                }
+                List<PickupIndex> tier2Adjusted = monsterDropList.availableTier2DropList;
+                if (!tierValidMonsterTeam[ItemTier.Tier2]) {
+                    tier2Adjusted = DropList.tier2DropListOriginal;
+                }
+                List<PickupIndex> tier3Adjusted = monsterDropList.availableTier3DropList;
+                if (!tierValidScav[ItemTier.Tier3]) {
+                    tier3Adjusted = DropList.tier3DropListOriginal;
+                }
+                DropList.SetDropLists(tier1Adjusted, tier2Adjusted, tier3Adjusted, DropList.equipmentDropListOriginal);
+
+                List<float> scavTierChanceBackup = new List<float>();
+                scavTierChanceBackup.Add(EntityStates.ScavMonster.FindItem.tier1Chance);
+                scavTierChanceBackup.Add(EntityStates.ScavMonster.FindItem.tier2Chance);
+                scavTierChanceBackup.Add(EntityStates.ScavMonster.FindItem.tier3Chance);
+
+                if (!tierValidScav[ItemTier.Tier1]) {
+                    EntityStates.ScavMonster.FindItem.tier1Chance = 0;
+                }
+                if (!tierValidScav[ItemTier.Tier2]) {
+                    EntityStates.ScavMonster.FindItem.tier2Chance = 0;
+                }
+                if (!tierValidScav[ItemTier.Tier3]) {
+                    EntityStates.ScavMonster.FindItem.tier3Chance = 0;
+                }
+
+                orig(findItem);
+
+                DropList.RevertDropLists();
+                EntityStates.ScavMonster.FindItem.tier1Chance = scavTierChanceBackup[0];
+                EntityStates.ScavMonster.FindItem.tier2Chance = scavTierChanceBackup[1];
+                EntityStates.ScavMonster.FindItem.tier3Chance = scavTierChanceBackup[2];
+            }
+        }
+
+        static private void ScavengerItemGranterStart(On.RoR2.ScavengerItemGranter.orig_Start orig, ScavengerItemGranter scavengerItemGranter) {
+            List<int> scavTierTypesBackup = new List<int>();
+            scavTierTypesBackup.Add(scavengerItemGranter.tier1Types);
+            scavTierTypesBackup.Add(scavengerItemGranter.tier2Types);
+            scavTierTypesBackup.Add(scavengerItemGranter.tier3Types);
+
+            if (!tierValidScav[ItemTier.Tier1]) {
+                scavengerItemGranter.tier1Types = 0;
+            }
+            if (!tierValidScav[ItemTier.Tier2]) {
+                scavengerItemGranter.tier2Types = 0;
+            }
+            if (!tierValidScav[ItemTier.Tier3]) {
+                scavengerItemGranter.tier3Types = 0;
+            }
+
+            orig(scavengerItemGranter);
+
+            scavengerItemGranter.tier1Types = scavTierTypesBackup[0];
+            scavengerItemGranter.tier2Types = scavTierTypesBackup[1];
+            scavengerItemGranter.tier3Types = scavTierTypesBackup[2];
+        }
+
+        static private void GiveRandomEquipment(On.RoR2.Inventory.orig_GiveRandomEquipment orig, Inventory inventory) {
+            if (monsterDropList.availableEquipmentDropList.Count > 0) {
+                orig(inventory);
+            }
+        }
+
+        static public bool ListContainsValidItems(List<ItemTag> forbiddenTags, List<PickupIndex> givenList) {
+            foreach (PickupIndex pickupIndex in givenList) {
+                bool validItem = true;
+                ItemDef itemDef = ItemCatalog.GetItemDef(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                foreach (ItemTag itemTag in forbiddenTags) {
+                    if (itemDef.ContainsTag(itemTag)) {
+                        validItem = false;
+                        break;
+                    }
+                }
+                if (validItem) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static void AddItemByTier(ItemTier itemTier, ItemIndex itemIndex) {
+            if (itemsToAdd.ContainsKey(itemTier)) {
+                if (!itemsToAdd[itemTier].Contains(PickupCatalog.FindPickupIndex(itemIndex))) {
+                    itemsToAdd[itemTier].Add(PickupCatalog.FindPickupIndex(itemIndex));
+                }
+            }
+        }
+
+        public static void UnaddItemByTier(ItemTier itemTier, ItemIndex itemIndex) {
+            if (itemsToAdd.ContainsKey(itemTier)) {
+                if (itemsToAdd[itemTier].Contains(PickupCatalog.FindPickupIndex(itemIndex))) {
+                    itemsToAdd[itemTier].Remove(PickupCatalog.FindPickupIndex(itemIndex));
+                }
+            }
+        }
+
+        public static void RemoveItemByTier(ItemTier itemTier, ItemIndex itemIndex) {
+            if (itemsToRemove.ContainsKey(itemTier)) {
+                if (!itemsToRemove[itemTier].Contains(PickupCatalog.FindPickupIndex(itemIndex))) {
+                    itemsToRemove[itemTier].Add(PickupCatalog.FindPickupIndex(itemIndex));
+                }
+            }
+        }
+
+        public static void UnremoveItemByTier(ItemTier itemTier, ItemIndex itemIndex) {
+            if (itemsToRemove.ContainsKey(itemTier)) {
+                if (itemsToRemove[itemTier].Contains(PickupCatalog.FindPickupIndex(itemIndex))) {
+                    itemsToRemove[itemTier].Remove(PickupCatalog.FindPickupIndex(itemIndex));
+                }
+            }
+        }
+
+        public static void AddEquipmentByTier(ItemTier itemTier, EquipmentIndex equipmentIndex) {
+            if (equipmentToAdd.ContainsKey(itemTier)) {
+                if (!equipmentToAdd[itemTier].Contains(PickupCatalog.FindPickupIndex(equipmentIndex))) {
+                    equipmentToAdd[itemTier].Add(PickupCatalog.FindPickupIndex(equipmentIndex));
+                }
+            }
+        }
+
+
+        public static void UnaddEquipmentByTier(ItemTier itemTier, EquipmentIndex equipmentIndex) {
+            if (equipmentToAdd.ContainsKey(itemTier)) {
+                if (equipmentToAdd[itemTier].Contains(PickupCatalog.FindPickupIndex(equipmentIndex))) {
+                    equipmentToAdd[itemTier].Remove(PickupCatalog.FindPickupIndex(equipmentIndex));
+                }
+            }
+        }
+
+        public static void RemoveEquipmentByTier(ItemTier itemTier, EquipmentIndex equipmentIndex) {
+            if (equipmentToAdd.ContainsKey(itemTier)) {
+                if (!equipmentToRemove[itemTier].Contains(PickupCatalog.FindPickupIndex(equipmentIndex))) {
+                    equipmentToRemove[itemTier].Add(PickupCatalog.FindPickupIndex(equipmentIndex));
+                }
+            }
+        }
+
+        public static void UnremoveEquipmentByTier(ItemTier itemTier, EquipmentIndex equipmentIndex) {
+            if (equipmentToAdd.ContainsKey(itemTier)) {
+                if (equipmentToRemove[itemTier].Contains(PickupCatalog.FindPickupIndex(equipmentIndex))) {
+                    equipmentToRemove[itemTier].Remove(PickupCatalog.FindPickupIndex(equipmentIndex));
+                }
+            }
+        }
+
+        public static void AddToDefaultByTier(ItemTier itemTier, params ItemIndex[] items) {
+            if (itemTier == ItemTier.NoTier) {
+                return;
+            }
+
+            AdditionalTierItems[itemTier].UnionWith(items);
+        }
+
+        public static void RemoveFromDefaultByTier(ItemTier itemTier, params ItemIndex[] items) {
+            if (itemTier == ItemTier.NoTier) {
+                return;
+            }
+
+            AdditionalTierItems[itemTier].ExceptWith(items);
+        }
+
+        public static void AddToDefaultByTier(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+            foreach (var list in AdditionalTierItems)
+                AddToDefaultByTier(list.Key,
+                    items.Where(item => list.Key == item.Value)
+                    .Select(item => item.Key)
+                    .ToArray());
+        }
+
+        public static void RemoveFromDefaultByTier(params KeyValuePair<ItemIndex, ItemTier>[] items) {
+            foreach (var list in AdditionalTierItems)
+                RemoveFromDefaultByTier(list.Key,
+                    items.Where(item => list.Key == item.Value)
+                    .Select(item => item.Key)
+                    .ToArray());
+        }
+
+        public static void AddToDefaultEquipment(params EquipmentIndex[] equipment) {
+            AdditionalEquipment.UnionWith(equipment);
+        }
+
+        public static void RemoveFromDefaultEquipment(params EquipmentIndex[] equipments) {
+            AdditionalEquipment.ExceptWith(equipments);
+        }
+    }
+}


### PR DESCRIPTION
For players, if an interactable cannot yield any items it will be prevented from spawning.
If an interactable cannot yield any items of a particular tier the selection weight for that tier will be 0.
For monsters if a particular tier cannot yield any valid items the selection weight for that tier will be 0.

Created functions for both ItemDropAPI and MonsterItemsAPI to handle adding and removing items from the drop list.
AddItemByTier and UnaddItemByTier to add items to tier lists.
RemoveItemByTier and UnremoveItemByTier to remove items from tier lists.
AddEquipmentByTier and UnaddEquipmentByTier to add equipment to tier lists.
RemoveEquipmentByTier and UnremoveEquipmentByTier to remove equipment from tier lists.

Refactored hooks for player items from ItemDropAPIFixes into ItemDropAPI.
Created new module named MonsterItemsAPI.
Refactored hooks related to monster items into this module.
Updated funcationality so either module can function regardless of whether the other is loaded.

The following scripts were added in the R2API/ItemDropAPI folder in the ItemDropAPITools namespace.
Catalogue generates lists to identify special pickups, such as scrap and the aspects.
DropList manages the drop lists; clearing them, generating them, updating them through reflection.
DropOdds will update tier selection weight whenever items are spawned.
InteractableCalculator determines whether each type of interactable can yield any items.