### PR TITLE
Adds a way for submodules to be able to check if they should be loaded

### DIFF
--- a/R2API/FontAPI.cs
+++ b/R2API/FontAPI.cs
@@ -32,6 +32,11 @@ namespace R2API {
             On.RoR2.Language.SetCurrentLanguage += Language_SetCurrentLanguage;
         }
 
+        [R2APISubmoduleInit(Stage = InitStage.LoadCheck)]
+        private static void ShouldLoad(out bool shouldload) {
+            shouldload = Directory.GetFiles(Paths.PluginPath, "*.font", SearchOption.AllDirectories).Length > 0;
+        }
+
         private static void Language_SetCurrentLanguage(On.RoR2.Language.orig_SetCurrentLanguage orig, string language) {
             orig(language);
             if (Fonts._fontAssets.Count != 0) {

--- a/R2API/LanguageAPI.cs
+++ b/R2API/LanguageAPI.cs
@@ -36,6 +36,11 @@ namespace R2API {
             Language.onCurrentLanguageChanged += OnCurrentLanguageChanged;
         }
 
+        [R2APISubmoduleInit(Stage = InitStage.LoadCheck)]
+        private static void ShouldLoad(out bool shouldload) {
+            shouldload = Directory.GetFiles(Paths.PluginPath, "*.language", SearchOption.AllDirectories).Length > 0;
+        }
+
         private static void OnCurrentLanguageChanged() {
             var currentLanguage = Language.currentLanguage;
             if (currentLanguage is null)

--- a/R2API/SoundAPI.cs
+++ b/R2API/SoundAPI.cs
@@ -42,6 +42,11 @@ namespace R2API {
             On.RoR2.RoR2Application.OnLoad += RoR2Application_OnLoad;
         }
 
+        [R2APISubmoduleInit(Stage = InitStage.LoadCheck)]
+        private static void ShouldLoad(out bool shouldload) {
+            shouldload = Directory.GetFiles(Paths.PluginPath, "*.sound", SearchOption.AllDirectories).Length > 0;
+        }
+
         private static void RoR2Application_OnLoad(On.RoR2.RoR2Application.orig_OnLoad orig, RoR2Application self)
         {
             orig(self);


### PR DESCRIPTION
it is implemented using a new step in InitStage that gets called if the submodule is not previously defined as a R2APISubmoduleDependency and should have the signature void func(out/ref bool)