### PR TITLE
Move possible nullref from warnings to suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,9 @@ dotnet_diagnostic.CS1591.severity = suggestion
 
 # IDE0032: Use auto property
 dotnet_style_prefer_auto_properties = true:silent
+
+# CS8604: Possible null reference argument.
+dotnet_diagnostic.CS8604.severity = suggestion
+
+# CS8602: Dereference of a possibly null reference.
+dotnet_diagnostic.CS8602.severity = suggestion


### PR DESCRIPTION
While we should take care in this, having 400+ warnings about it is not helpful in seeing issues in new code. Once we start removing these, it can be graded back up to warning.