### PR TITLE
Bug fixes for ItemDropAPI and MonsterItemsAPI

### DIFF
--- a/R2API/ItemDrop/Catalog.cs
+++ b/R2API/ItemDrop/Catalog.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using RoR2;
+using UnityEngine;
 
 namespace R2API {
     namespace ItemDropAPITools {
         public static class Catalog {
             public static bool Loaded;
-            public static readonly List<ItemIndex> SpecialBossItems = new List<ItemIndex>();
+            public static readonly List<ItemIndex> SpecialItems = new List<ItemIndex>();
             public static readonly Dictionary<ItemTier, ItemIndex> ScrapItems = new Dictionary<ItemTier, ItemIndex>();
             public static readonly List<EquipmentIndex> EliteEquipment = new List<EquipmentIndex>();
             
@@ -18,24 +19,13 @@ namespace R2API {
                 if (!Loaded) {
                     foreach (var itemIndex in ItemCatalog.allItems) {
                         var itemDef = ItemCatalog.GetItemDef(itemIndex);
-                        foreach (var itemTag in itemDef.tags) {
-                            if (itemTag == ItemTag.Scrap) {
+                        if (itemDef.tier != ItemTier.NoTier && itemDef.pickupIconSprite != null && itemDef.pickupIconSprite.name != DropList.NullIconTextureName) {
+                            if (itemDef.ContainsTag(ItemTag.Scrap)) {
                                 if (!ScrapItems.ContainsKey(itemDef.tier)) {
                                     ScrapItems.Add(itemDef.tier, itemIndex);
                                 }
-                            }
-                        }
-                        if (!ItemCatalog.tier1ItemList.Contains(itemIndex) &&
-                            !ItemCatalog.tier2ItemList.Contains(itemIndex) &&
-                            !ItemCatalog.tier3ItemList.Contains(itemIndex) &&
-                            !ItemCatalog.lunarItemList.Contains(itemIndex)) {
-                            if (!ScrapItems.ContainsValue(itemIndex) && itemDef.tier != ItemTier.NoTier &&
-                                itemDef.pickupIconSprite != null && itemDef.pickupIconSprite.name != DropList.NullIconTextureName) {
-                                foreach (var itemTag in itemDef.tags) {
-                                    if (itemTag == ItemTag.WorldUnique) {
-                                        SpecialBossItems.Add(itemIndex);
-                                    }
-                                }
+                            } else if (itemDef.ContainsTag(ItemTag.WorldUnique)) {
+                                SpecialItems.Add(itemIndex);
                             }
                         }
                     }

--- a/R2API/ItemDrop/DropList.cs
+++ b/R2API/ItemDrop/DropList.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using R2API.ItemDrop;
 using RoR2;
+using UnityEngine;
+
 
 namespace R2API {
     namespace ItemDropAPITools {
@@ -119,14 +121,19 @@ namespace R2API {
                     LunarEquipmentDropListOriginal = BackupDropList(run.availableLunarEquipmentDropList);
 
                     BossDropListOriginal = BackupDropList(run.availableBossDropList);
-                    foreach (var bossItem in Catalog.SpecialBossItems) {
+                    /*
+                    foreach (var bossItem in Catalog.SpecialItems) {
                         var pickupIndex = PickupCatalog.FindPickupIndex(bossItem);
                         if (!BossDropListOriginal.Contains(pickupIndex)) {
                             BossDropListOriginal.Add(pickupIndex);
                         }
                     }
+                    */
 
                     SpecialItemsOriginal.Clear();
+                    foreach (var itemIndex in Catalog.SpecialItems) {
+                        SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                    }
                     foreach (var itemIndex in Catalog.ScrapItems.Values) {
                         SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
                     }
@@ -149,25 +156,26 @@ namespace R2API {
                 Dictionary<EquipmentDropType, List<EquipmentIndex>> equipmentsToAdd,
                 Dictionary<EquipmentDropType, List<EquipmentIndex>> equipmentsToRemove) {
 
-                AvailableTier1DropList = CreateDropList(Tier1DropListOriginal, itemsToAdd[ItemTier.Tier1], itemsToRemove[ItemTier.Tier1]);
-                AvailableTier2DropList = CreateDropList(Tier2DropListOriginal, itemsToAdd[ItemTier.Tier2], itemsToRemove[ItemTier.Tier2]);
-                AvailableTier3DropList = CreateDropList(Tier3DropListOriginal, itemsToAdd[ItemTier.Tier3], itemsToRemove[ItemTier.Tier3]);
-                AvailableLunarDropList = CreateDropList(LunarDropListOriginal, itemsToAdd[ItemTier.Lunar], itemsToRemove[ItemTier.Lunar]);
-                AvailableSpecialItems = CreateDropList(SpecialItemsOriginal, itemsToAdd[ItemTier.NoTier], itemsToRemove[ItemTier.NoTier]);
+                AvailableTier1DropList = BackupDropList(CreateDropList(Tier1DropListOriginal, itemsToAdd[ItemTier.Tier1], itemsToRemove[ItemTier.Tier1]));
+                AvailableTier2DropList = BackupDropList(CreateDropList(Tier2DropListOriginal, itemsToAdd[ItemTier.Tier2], itemsToRemove[ItemTier.Tier2]));
+                AvailableTier3DropList = BackupDropList(CreateDropList(Tier3DropListOriginal, itemsToAdd[ItemTier.Tier3], itemsToRemove[ItemTier.Tier3]));
+                AvailableLunarDropList = BackupDropList(CreateDropList(LunarDropListOriginal, itemsToAdd[ItemTier.Lunar], itemsToRemove[ItemTier.Lunar]));
+                AvailableSpecialItems = BackupDropList(CreateDropList(SpecialItemsOriginal, itemsToAdd[ItemTier.NoTier], itemsToRemove[ItemTier.NoTier]));
 
-                AvailableEquipmentDropList = CreateDropList(NormalEquipmentDropListOriginal,
-                    equipmentsToAdd[EquipmentDropType.Normal], equipmentsToRemove[EquipmentDropType.Normal]);
+                AvailableEquipmentDropList = BackupDropList(CreateDropList(NormalEquipmentDropListOriginal,
+                    equipmentsToAdd[EquipmentDropType.Normal], equipmentsToRemove[EquipmentDropType.Normal]));
                 AvailableNormalEquipmentDropList = AvailableEquipmentDropList;
 
-                AvailableLunarEquipmentDropList = CreateDropList(LunarEquipmentDropListOriginal,
-                    equipmentsToAdd[EquipmentDropType.Lunar], equipmentsToRemove[EquipmentDropType.Lunar]);
+                AvailableLunarEquipmentDropList = BackupDropList(CreateDropList(LunarEquipmentDropListOriginal,
+                    equipmentsToAdd[EquipmentDropType.Lunar], equipmentsToRemove[EquipmentDropType.Lunar]));
 
-                AvailableSpecialEquipment = CreateDropList(SpecialEquipmentOriginal,
-                    equipmentsToAdd[EquipmentDropType.Elite], equipmentsToRemove[EquipmentDropType.Elite]);
+                AvailableSpecialEquipment = BackupDropList(CreateDropList(SpecialEquipmentOriginal,
+                    equipmentsToAdd[EquipmentDropType.Elite], equipmentsToRemove[EquipmentDropType.Elite]));
 
-                AvailableBossDropList = CreateDropList(BossDropListOriginal,
+                AvailableBossDropList = BackupDropList(CreateDropList(BossDropListOriginal,
                     itemsToAdd[ItemTier.Boss], equipmentsToAdd[EquipmentDropType.Boss],
-                    itemsToRemove[ItemTier.Boss], equipmentsToRemove[EquipmentDropType.Boss]);
+                    itemsToRemove[ItemTier.Boss], equipmentsToRemove[EquipmentDropType.Boss]));
+
             }
 
             private static List<PickupIndex> CreateDropList(IEnumerable<PickupIndex> vanillaDropList,
@@ -273,41 +281,67 @@ namespace R2API {
             }
 
             public void SetItems(Run run) {
-                foreach (var pickupIndex in AvailableTier1DropList) {
-                    run.availableTier1DropList.Add(pickupIndex);
-                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                if (IsValidList(AvailableTier1DropList)) {
+                    foreach (var pickupIndex in AvailableTier1DropList) {
+                        run.availableTier1DropList.Add(pickupIndex);
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
                 }
 
-                foreach (var pickupIndex in AvailableTier2DropList) {
-                    run.availableTier2DropList.Add(pickupIndex);
-                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                if (IsValidList(AvailableTier2DropList)) {
+                    foreach (var pickupIndex in AvailableTier2DropList) {
+                        run.availableTier2DropList.Add(pickupIndex);
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
                 }
 
-                foreach (var pickupIndex in AvailableTier3DropList) {
-                    run.availableTier3DropList.Add(pickupIndex);
-                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                if (IsValidList(AvailableTier3DropList)) {
+                    foreach (var pickupIndex in AvailableTier3DropList) {
+                        run.availableTier3DropList.Add(pickupIndex);
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
                 }
 
-                foreach (var pickupIndex in AvailableBossDropList) {
-                    run.availableBossDropList.Add(pickupIndex);
-                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                if (IsValidList(AvailableBossDropList)) {
+                    foreach (var pickupIndex in AvailableBossDropList) {
+                        run.availableBossDropList.Add(pickupIndex);
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
                 }
 
-                foreach (var pickupIndex in AvailableLunarDropList) {
-                    run.availableLunarDropList.Add(pickupIndex);
-                    run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                if (IsValidList(AvailableLunarDropList)) {
+                    foreach (var pickupIndex in AvailableLunarDropList) {
+                        run.availableLunarDropList.Add(pickupIndex);
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
                 }
 
-                foreach (var pickupIndex in AvailableEquipmentDropList) {
-                    run.availableEquipmentDropList.Add(pickupIndex);
-                    run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                if (IsValidList(AvailableSpecialItems)) {
+                    foreach (var pickupIndex in AvailableSpecialItems) {
+                        run.availableItems.Add(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    }
+                }
+
+                if (IsValidList(AvailableEquipmentDropList)) {
+                    foreach (var pickupIndex in AvailableEquipmentDropList) {
+                        run.availableEquipmentDropList.Add(pickupIndex);
+                        run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                    }
                 }
                 // high probability of code smell from ror2 code
                 run.availableNormalEquipmentDropList = run.availableEquipmentDropList;
 
-                foreach (var pickupIndex in AvailableLunarEquipmentDropList) {
-                    run.availableLunarEquipmentDropList.Add(pickupIndex);
-                    run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                if (IsValidList(AvailableLunarEquipmentDropList)) {
+                    foreach (var pickupIndex in AvailableLunarEquipmentDropList) {
+                        run.availableLunarEquipmentDropList.Add(pickupIndex);
+                        run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                    }
+                }
+
+                if (IsValidList(AvailableSpecialEquipment)) {
+                    foreach (var pickupIndex in AvailableSpecialEquipment) {
+                        run.availableEquipment.Add(PickupCatalog.GetPickupDef(pickupIndex).equipmentIndex);
+                    }
                 }
             }
 
@@ -317,6 +351,13 @@ namespace R2API {
 
             public static List<PickupIndex> ToPickupIndices(IEnumerable<EquipmentIndex> indices) {
                 return indices.Select(PickupCatalog.FindPickupIndex).ToList();
+            }
+
+            public static bool IsValidList(IEnumerable<PickupIndex> dropList) {
+                if (dropList.Count() == 1 && dropList.Contains(PickupIndex.none)) {
+                    return false;
+                }
+                return true;
             }
         }
     }

--- a/R2API/ItemDrop/DropList.cs
+++ b/R2API/ItemDrop/DropList.cs
@@ -121,6 +121,7 @@ namespace R2API {
                     LunarEquipmentDropListOriginal = BackupDropList(run.availableLunarEquipmentDropList);
 
                     BossDropListOriginal = BackupDropList(run.availableBossDropList);
+
                     /*
                     foreach (var bossItem in Catalog.SpecialItems) {
                         var pickupIndex = PickupCatalog.FindPickupIndex(bossItem);

--- a/R2API/ItemDrop/InteractableCalculator.cs
+++ b/R2API/ItemDrop/InteractableCalculator.cs
@@ -193,11 +193,10 @@ namespace R2API.ItemDrop {
                 }
             }
 
-            foreach (var pickupIndex in dropList.AvailableBossDropList) {
+            foreach (var pickupIndex in dropList.AvailableSpecialItems) {
                 var pickupDef = PickupCatalog.GetPickupDef(pickupIndex);
                 if (pickupDef != null) {
                     if (pickupDef.itemIndex != ItemIndex.None &&
-                        !Catalog.ScrapItems.ContainsValue(pickupDef.itemIndex) &&
                         Catalog.Pearls.Contains(pickupDef.itemIndex)) {
                         TiersPresent["pearl"] = true;
                         break;
@@ -209,8 +208,7 @@ namespace R2API.ItemDrop {
                 var pickupDef = PickupCatalog.GetPickupDef(pickupIndex);
                 if (pickupDef != null) {
                     if (pickupDef.itemIndex != ItemIndex.None &&
-                        !Catalog.ScrapItems.ContainsValue(pickupDef.itemIndex) &&
-                        !Catalog.Pearls.Contains(pickupDef.itemIndex)) {
+                        !Catalog.ScrapItems.ContainsValue(pickupDef.itemIndex)) {
                         TiersPresent["boss"] = true;
                         break;
                     }
@@ -262,10 +260,10 @@ namespace R2API.ItemDrop {
                     }
                 }
             }
-            if (dropList.AvailableNormalEquipmentDropList.Count > 0) {
+            if (DropList.IsValidList(dropList.AvailableNormalEquipmentDropList)) {
                 TiersPresent["equipment"] = true;
             }
-            if (dropList.AvailableLunarEquipmentDropList.Count > 0) {
+            if (DropList.IsValidList(dropList.AvailableLunarEquipmentDropList)) {
                 TiersPresent["lunar"] = true;
             }
             var interactableTypeKeys = InteractablesTiers.Keys.ToList();

--- a/R2API/MonsterItemsAPI.cs
+++ b/R2API/MonsterItemsAPI.cs
@@ -85,6 +85,10 @@ namespace R2API {
             orig(run);
             MonsterDropList.DuplicateDropLists(run);
             MonsterDropList.GenerateDropLists(ItemsToAdd, ItemsToRemove, EquipmentsToAdd, EquipmentsToRemove);
+            ItemDropAPI.ClearItemOperations(ItemsToAdd);
+            ItemDropAPI.ClearItemOperations(ItemsToRemove);
+            ItemDropAPI.ClearEquipmentOperations(EquipmentsToAdd);
+            ItemDropAPI.ClearEquipmentOperations(EquipmentsToRemove);
         }
 
         private static void GenerateAvailableItemsSet(On.RoR2.Artifacts.MonsterTeamGainsItemsArtifactManager.orig_GenerateAvailableItemsSet orig) {
@@ -269,17 +273,19 @@ namespace R2API {
         }
 
         public static bool ListContainsValidItems(List<ItemTag> forbiddenTags, List<PickupIndex> givenList) {
-            foreach (var pickupIndex in givenList) {
-                var validItem = true;
-                var itemDef = ItemCatalog.GetItemDef(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
-                foreach (var itemTag in forbiddenTags) {
-                    if (itemDef.ContainsTag(itemTag)) {
-                        validItem = false;
-                        break;
+            if (DropList.IsValidList(givenList)) {
+                foreach (var pickupIndex in givenList) {
+                    var validItem = true;
+                    var itemDef = ItemCatalog.GetItemDef(PickupCatalog.GetPickupDef(pickupIndex).itemIndex);
+                    foreach (var itemTag in forbiddenTags) {
+                        if (itemDef.ContainsTag(itemTag)) {
+                            validItem = false;
+                            break;
+                        }
                     }
-                }
-                if (validItem) {
-                    return true;
+                    if (validItem) {
+                        return true;
+                    }
                 }
             }
             return false;


### PR DESCRIPTION
This should address the majority of the bugs that were passed on to me.

- Changed drop list operation lists so they are cleared each time they are used, as a stop gap measure so my other mods would be able to continue functioning normally. I know Rein's methods will make this redundant shortly.
- Drop lists should never be empty now and will always contain PickupIndex.none instead. This was for increased consistency, as previously these lists could sometimes contain PickupIndex.none and sometimes be empty, causing bugs.
- Added function to determine if a drop list only contained PickupIndex.none, this has been substituted in wherever a check was done previously to see if a drop list was empty.
- All world unique items are now stored in a list in Catalog and are no longer added to the subset drop lists in DropList by default.
- When using the command artifact, world unique items will now be listed by themselves unless they are added to the subset drop list of their tier.
- Boss drops now check their availability against the world unique drop list if their drop is a world unique item.