### PR TITLE
Printing BepInEx folder if it's not under Risk of Rain 2 folder

### DIFF
--- a/R2API/Utils/DirectoryUtilities.cs
+++ b/R2API/Utils/DirectoryUtilities.cs
@@ -4,6 +4,7 @@ using System.IO;
 namespace R2API.Utils {
     internal static class DirectoryUtilities {
         private static bool _alreadyPrintedFolderStructure;
+        private static bool _bepinexFolderPrinted;
 
         private static readonly HashSet<string> BannedFolders = new HashSet<string> {
             "MonoBleedingEdge",
@@ -14,6 +15,9 @@ namespace R2API.Utils {
             if (_alreadyPrintedFolderStructure)
                 return;
             WriteFolderStructure(directory);
+            if (!_bepinexFolderPrinted) {
+                WriteFolderStructure(BepInEx.Paths.BepInExRootPath);
+            }
             _alreadyPrintedFolderStructure = true;
         }
 
@@ -38,6 +42,10 @@ namespace R2API.Utils {
         private static void WriteFolderStructureRecursively(string directory, int spaces = 0) {
             var dirInfo = new DirectoryInfo(directory);
             R2API.Logger.LogDebug($"{GenerateSpaces(spaces)}|---+ {dirInfo.Name}");
+
+            if (!_bepinexFolderPrinted && BepInEx.Paths.BepInExRootPath == directory) {
+                _bepinexFolderPrinted = true;
+            }
 
             if (dirInfo.Parent != null && (BannedFolders.Contains(dirInfo.Name) ||
                                            BannedFolders.Contains($"{dirInfo.Parent.Name}/{dirInfo.Name}")))


### PR DESCRIPTION
I'm currently working with ThunderKit and having some issues, which lead to printing folder structure to in log. And, since ThunderKit stores BepInEx not under a game folder (which is a totally valid way to do it), an important part of the folder structure was not printed.
This change ensures that BepInEx folder content is printed.
Now that I think about it, why print a game folder structure and not BepInEx in the first place, since there's nothing useful outside of the BepInEx folder.