### PR TITLE
Change `R2API` constructor to Awake

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -32,7 +32,7 @@ namespace R2API {
 
         internal static HashSet<string> LoadedSubmodules;
 
-        public R2API() {
+        public void Awake() {
             Logger = base.Logger;
             ModManager = new DetourModManager();
             AddHookLogging();


### PR DESCRIPTION
Some time ago I've reported a minor error in r2api channel in Discord. 
TL;DR;
When launching RoR with Unity debug build it throws an error in SoundAPI because Unity doesn't allow to call its API from MonoBehaviour's constructor (in this case it's `Application.isBatchMode`). 
Changing from constructor to Awake fixes the problem and doesn't make any difference for r2api loading logic.

Here's the link to a discussion about this error: https://discord.com/channels/562704639141740588/567836513078083584/800293856629358603