### PR TITLE
Drop list bug fixes

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -93,17 +93,6 @@ namespace R2API {
             var bossItems = ItemDefinitions.Where(x => x.ItemDef.tier == ItemTier.Boss).Select(x => x.ItemDef.itemIndex).ToArray();
 
             LoadRelatedAPIs();
-            ItemDropAPI.AddItemByTier(ItemTier.Tier1, t1Items);
-            ItemDropAPI.AddItemByTier(ItemTier.Tier2, t2Items);
-            ItemDropAPI.AddItemByTier(ItemTier.Tier3, t3Items);
-            ItemDropAPI.AddItemByTier(ItemTier.Lunar, lunarItems);
-            ItemDropAPI.AddItemByTier(ItemTier.Boss, bossItems);
-
-            MonsterItemsAPI.AddItemByTier(ItemTier.Tier1, t1Items);
-            MonsterItemsAPI.AddItemByTier(ItemTier.Tier2, t2Items);
-            MonsterItemsAPI.AddItemByTier(ItemTier.Tier3, t3Items);
-            MonsterItemsAPI.AddItemByTier(ItemTier.Lunar, lunarItems);
-            MonsterItemsAPI.AddItemByTier(ItemTier.Boss, bossItems);
 
             _itemCatalogInitialized = true;
         }
@@ -122,8 +111,6 @@ namespace R2API {
                 .ToArray();
 
             LoadRelatedAPIs();
-            ItemDropAPI.AddEquipment(droppableEquipments);
-            MonsterItemsAPI.AddEquipment(droppableEquipments);
 
             _equipmentCatalogInitialized = true;
         }

--- a/R2API/ItemDrop/Catalog.cs
+++ b/R2API/ItemDrop/Catalog.cs
@@ -29,6 +29,7 @@ namespace R2API {
                             }
                         }
                     }
+                    
                     foreach (var equipmentIndex in EquipmentCatalog.allEquipment) {
                         var equipmentDef = EquipmentCatalog.GetEquipmentDef(equipmentIndex);
                         if (!EquipmentCatalog.equipmentList.Contains(equipmentIndex)) {
@@ -38,6 +39,7 @@ namespace R2API {
                             }
                         }
                     }
+
                     foreach (var itemIndex in ItemCatalog.lunarItemList) {
                         var itemDef = ItemCatalog.GetItemDef(itemIndex);
                         var cleansable = false;

--- a/R2API/ItemDrop/DropList.cs
+++ b/R2API/ItemDrop/DropList.cs
@@ -133,12 +133,16 @@ namespace R2API {
 
                     SpecialItemsOriginal.Clear();
                     foreach (var itemIndex in Catalog.SpecialItems) {
-                        SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                        if (run.availableItems.Contains(itemIndex)) {
+                            SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                        }
                     }
                     foreach (var itemIndex in Catalog.ScrapItems.Values) {
-                        SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                        if (run.availableItems.Contains(itemIndex)) {
+                            SpecialItemsOriginal.Add(PickupCatalog.FindPickupIndex(itemIndex));
+                        }
                     }
-
+                    
                     SpecialEquipmentOriginal.Clear();
                     foreach (var equipmentIndex in Catalog.EliteEquipment) {
                         var sprite = EquipmentCatalog.GetEquipmentDef(equipmentIndex).pickupIconSprite;
@@ -176,7 +180,6 @@ namespace R2API {
                 AvailableBossDropList = BackupDropList(CreateDropList(BossDropListOriginal,
                     itemsToAdd[ItemTier.Boss], equipmentsToAdd[EquipmentDropType.Boss],
                     itemsToRemove[ItemTier.Boss], equipmentsToRemove[EquipmentDropType.Boss]));
-
             }
 
             private static List<PickupIndex> CreateDropList(IEnumerable<PickupIndex> vanillaDropList,

--- a/R2API/ItemDrop/DropOdds.cs
+++ b/R2API/ItemDrop/DropOdds.cs
@@ -152,7 +152,6 @@ namespace R2API.ItemDrop {
 
                 if (DropTableItemOdds.ContainsKey(interactableName)) {
                     for (int entryIndex = 0; entryIndex < dropTable.entries.Length; entryIndex++) {
-
                         dropTable.entries[entryIndex].pickupWeight = DropTableItemOdds[interactableName][entryIndex];
                     }
                 }


### PR DESCRIPTION
Fixed a bug where all items and equipment are part of standard drop lists during the first run after the game is launched.
Fixed a bug where all custom special items are added to drop lists regardless of whether they are unlocked.
Discovered potential issue where custom special equipment will be added to drop lists regardless of whether it is unlocked but don't have a good solution.