### PR TITLE
[Damage api] Custom damage types

### DIFF
--- a/R2API/DamageAPI.cs
+++ b/R2API/DamageAPI.cs
@@ -1,0 +1,299 @@
+﻿using R2API.Utils;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using UnityEngine.Networking;
+
+namespace R2API {
+    /// <summary>
+    /// API for handling deployables added by mods
+    /// </summary>
+    [R2APISubmodule]
+    public static class DamageAPI {
+        public enum ModdedDamageType { };
+
+        private const byte valuesPerBlock = 8;
+        private const byte blocksPerSection = 18;
+        private const byte valuesPerSection = valuesPerBlock * blocksPerSection;
+
+        private static readonly ConditionalWeakTable<DamageInfo, Section> sectionPerInstance = new();
+
+        /// <summary>
+        /// Return true if the submodule is loaded.
+        /// </summary>
+        public static bool Loaded {
+            get => _loaded;
+            internal set => _loaded = value;
+        }
+        private static bool _loaded;
+
+        /// <summary>
+        /// Reserved ModdedDamageTypes count
+        /// </summary>
+        public static int ModdedDamageTypeCount { get; private set; }
+
+
+        #region Hooks
+        [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
+        internal static void SetHooks() {
+            On.RoR2.NetworkExtensions.Write_NetworkWriter_DamageInfo += WriteDamageInfo;
+            On.RoR2.NetworkExtensions.ReadDamageInfo += ReadDamageInfo;
+        }
+
+        [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
+        internal static void UnsetHooks() {
+            On.RoR2.NetworkExtensions.Write_NetworkWriter_DamageInfo -= WriteDamageInfo;
+            On.RoR2.NetworkExtensions.ReadDamageInfo -= ReadDamageInfo;
+        }
+
+        private static RoR2.DamageInfo ReadDamageInfo(On.RoR2.NetworkExtensions.orig_ReadDamageInfo orig, UnityEngine.Networking.NetworkReader reader) {
+            var damageInfo = orig(reader);
+
+            if (ModdedDamageTypeCount == 0) {
+                return damageInfo;
+            }
+
+            var section = Section.FromNetworkReader(reader);
+            if (section != null) {
+                sectionPerInstance.Add(damageInfo, section);
+            }
+
+            return damageInfo;
+        }
+
+        private static void WriteDamageInfo(On.RoR2.NetworkExtensions.orig_Write_NetworkWriter_DamageInfo orig, UnityEngine.Networking.NetworkWriter writer, RoR2.DamageInfo damageInfo) {
+            orig(writer, damageInfo);
+
+            if (ModdedDamageTypeCount == 0) {
+                return;
+            }
+
+            if (!sectionPerInstance.TryGetValue(damageInfo, out var section)) {
+                writer.Write((byte)0);
+                return;
+            }
+
+            section.Write(writer);
+        }
+        #endregion
+
+        #region Public
+        /// <summary>
+        /// Reserve ModdedDamageType to use it with
+        /// <see cref="DamageAPI.AddModdedDamageType(DamageInfo, ModdedDamageType)"/> and
+        /// <see cref="DamageAPI.HasModdedDamageType(DamageInfo, ModdedDamageType)"/>
+        /// </summary>
+        /// <returns></returns>
+        public static ModdedDamageType ReserveDamageType() {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(DamageAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(DamageAPI)})]");
+            }
+            return (ModdedDamageType)ModdedDamageTypeCount++;
+        }
+
+        /// <summary>
+        /// Adding ModdedDamageType to DamageInfo. You can add more than one damage type to one DamageInfo
+        /// </summary>
+        /// <param name="damageInfo"></param>
+        /// <param name="moddedDamageType"></param>
+        public static void AddModdedDamageType(this DamageInfo damageInfo, ModdedDamageType moddedDamageType) {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(DamageAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(DamageAPI)})]");
+            }
+
+            if ((int)moddedDamageType >= ModdedDamageTypeCount) {
+                throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types ({ModdedDamageTypeCount})");
+            }
+
+            if (!sectionPerInstance.TryGetValue(damageInfo, out var section)) {
+                sectionPerInstance.Add(damageInfo, section = new Section());
+            }
+
+            section.Add(moddedDamageType);
+        }
+
+        /// <summary>
+        /// Check if DamageInfo has ModdedDamageType. One DamageInfo can have more than one damage type.
+        /// </summary>
+        /// <param name="damageInfo"></param>
+        /// <param name="moddedDamageType"></param>
+        /// <returns></returns>
+        public static bool HasModdedDamageType(this DamageInfo damageInfo, ModdedDamageType moddedDamageType) {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(DamageAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(DamageAPI)})]");
+            }
+
+            if ((int)moddedDamageType >= ModdedDamageTypeCount) {
+                throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types ({ModdedDamageTypeCount})");
+            }
+
+            if (!sectionPerInstance.TryGetValue(damageInfo, out var section)) {
+                return false;
+            }
+
+            return section.Has(moddedDamageType);
+        }
+        #endregion
+
+        private class Section {
+            public readonly Dictionary<byte, Block> blocks = new();
+
+            public static Section FromNetworkReader(NetworkReader reader) {
+                var sectionByte = reader.ReadByte();
+                if (sectionByte == 0) {
+                    return null;
+                }
+                var section = new Section();
+
+                for (var i = 7; i >= 0; i--) {
+                    if ((sectionByte & 1 << i) != 0) {
+                        section.blocks[(byte)(7 - i)] = Block.FromNetworkReader(reader); 
+                    } 
+                }
+
+                return section;
+            }
+
+            public void Write(NetworkWriter writer) {
+                int section = 0;
+                foreach (var row in blocks) {
+                    section |= 1 << row.Key;
+                }
+                writer.Write((byte)section);
+
+                foreach (var row in blocks) {
+                    row.Value.Write(writer);
+                }
+            }
+
+            public void Add(ModdedDamageType moddedDamageType) {
+                var blockIndex = (byte)((int)moddedDamageType / valuesPerSection);
+                if (!blocks.TryGetValue(blockIndex, out var block)) {
+                    blocks[blockIndex] = block = new Block();
+                }
+                block.Add((byte)((int)moddedDamageType % valuesPerSection));
+            }
+
+            public bool Has(ModdedDamageType moddedDamageType) {
+                var blockIndex = (int)moddedDamageType / valuesPerSection;
+                if (!blocks.TryGetValue((byte)blockIndex, out var block)) {
+                    return false;
+                }
+                return block.Has((byte)((int)moddedDamageType % valuesPerSection));
+            }
+        }
+
+        private class Block {
+            public readonly Dictionary<byte, byte> values = new();
+
+            private const uint blockValuesMask = 0b_00111111_00011111_00001111_00000111;
+            private const uint blockHeader = 0b_00000000_01000000_01100000_01110000;
+            private const uint highestBit = 0b_10000000_00000000_00000000_00000000;
+            private const int endBlockMask = 0b_10000000;
+
+            public static Block FromNetworkReader(NetworkReader reader) {
+                var block = new Block();
+                throw new NotImplementedException();
+            }
+
+            public void Write(NetworkWriter writer) {
+                var bitesSkipped = 0;
+                var fullBlockMask = new FullBlockMask();
+                var orderedValues = new List<byte>();
+                for (var i = 0; i < 32; i++) {
+                    if ((blockValuesMask & highestBit >> i) == 0) {
+                        bitesSkipped++;
+                        fullBlockMask.integer >>= 1;
+                        continue;
+                    }
+                    if (values.TryGetValue((byte)(bitesSkipped + i), out var value)) {
+                        fullBlockMask.integer |= highestBit;
+                        orderedValues.Add(value);
+                    }
+                }
+                fullBlockMask.integer |= blockHeader;
+                var lastIndex = 0;
+                for (var i = 3; i >= 0; i--) {
+                    if (fullBlockMask[i] != 0) {
+                        lastIndex = i;
+                        break;
+                    }
+                }
+                fullBlockMask[lastIndex] = (byte)(fullBlockMask[lastIndex] | endBlockMask);
+
+                for (var i = 0; i < 4; i++) {
+                    if (fullBlockMask[i] != 0) {
+                        writer.Write(fullBlockMask[i]);
+                    }
+                }
+                foreach (var value in orderedValues) {
+                    writer.Write(value);
+                }
+            }
+
+            public bool Has(byte insideBlockIndex) {
+                var valueIndex = (byte)(insideBlockIndex / valuesPerBlock);
+                if (!values.TryGetValue(valueIndex, out var value)) {
+                    return false;
+                }
+                return (value & (1 << insideBlockIndex % valuesPerBlock)) != 0;
+            }
+
+            public void Add(byte insideBlockIndex) {
+                var valueIndex = (byte)(insideBlockIndex / valuesPerBlock);
+                if (!values.TryGetValue(valueIndex, out var value)) {
+                    value = 0;
+                }
+                values[valueIndex] = (byte)(value | 1 << insideBlockIndex % valuesPerBlock);
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct FullBlockMask {
+            [FieldOffset(0)]
+            public byte byte0;
+            [FieldOffset(1)]
+            public byte byte1;
+            [FieldOffset(2)]
+            public byte byte2;
+            [FieldOffset(3)]
+            public byte byte3;
+
+            [FieldOffset(0)]
+            public uint integer;
+
+            public byte this[int i] {
+                get {
+                    return i switch {
+                        0 => byte0,
+                        1 => byte1,
+                        2 => byte2,
+                        3 => byte3,
+                        _ => throw new IndexOutOfRangeException(),
+                    };
+                }
+                set {
+                    switch (i) {
+                        case 0:
+                            byte0 = value;
+                            break;
+                        case 1:
+                            byte1 = value;
+                            break;
+                        case 2:
+                            byte2 = value;
+                            break;
+                        case 3:
+                            byte3 = value;
+                            break;
+                        default:
+                            throw new IndexOutOfRangeException();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
First draft of custom damage types.

## TL; DR;
Allows to use up to 1152 damage types for modding purposes while sending only 3 extra bytes in most cases.
Still need to add extensions for vanilla EntityStates that store DamageType to later use in DamageInfo.
There are 3 public methods:

- `ReserveDamageType` - returns `ModdedDamageType` enum value that mod can use to add/check with extension methods.
- `AddModdedDamageType` - adds reserved damage type to DamageInfo. Can add more than one ModdedDamageType to single DamageInfo. (need to do overloads for some vanilla EntityStates)
- `HasModdedDamageType` - checks reserved damage type on DamageInfo (need to do overloads for some vanilla EntityStates)

## Implementation details
### Vanilla DamageInfos
Obviously, vanilla attacks won't use this system and for them, only 1 extra byte will be sent over the network that will indicate that there are no modded damage types.

### Modded DamageInfos
The first thing necessary to understand is that while you can have a lot of unique damage types most of the time only 1-2 will be used per attack. This means you need to send 144 bytes with each attack (for 1152 unique flag values) even if it doesn't have any damage types enabled, or you can invent stupidly complicated compression that will allow you to send a lot less information in most cases, which I did.

There are 3 key pieces in this system:

- Section
- Block
- Value

#### Section
Section contains up to 8 blocks. When written to NetworkWriter it's converted to a byte with each bit indicating if a corresponding block has a value, that allows to not write blocks that don't have any value. Each block stores info about ModdedDamageTypes within range: from `block index * 144` to `(block index + 1) * 144 - 1`.

#### Block
Block contains up to 18 values. When written to NetworkWriter it's converted to 1-4 bytes depending on enabled values.
Block is the most complicated thing in this implementation, so it requires an image with a description:
![BlockBytes](https://user-images.githubusercontent.com/31794213/116788595-b7e5a000-aad4-11eb-83aa-eb2d1d729411.png)

#### Value
Byte value storing 8 flags that indicate that corresponding DamageTypes are enabled or not.

### What is sent over the network 
- 1 byte - section, indicating what blocks are enabled, if equal to 0 then there is no ModdedDamageTypes and no more info in NetworkReader.
- 1-4 bytes - block parts, indicating what values are enabled.
- 1-18 bytes - values, indicating what flags are enabled.
- Next block bytes if there are any.

### Examples
If I were to send DamageInfo with ModdedDamageType with index 12 enabled only 3 extra bytes would be used:
```cs
00000001 10010000 00001000
```
If I were to send 12, 13, and 14 I would still use only 3 bytes:
```cs
00000001 10010000 00001110
```
If I were to send 463, still only 3 bytes:
```cs
00001000 10000100 00000001
```
If I were to send 12 and 463, that would require 5 bytes:
```cs
00001001 10010000 00001000 10000100 00000001
```

It's pretty complicated, so, if you have any questions I will of course answer them.