### PR TITLE
NetworkCompatibility ingore mods with SoftDependency

### DIFF
--- a/R2API/Utils/NetworkCompatibility.cs
+++ b/R2API/Utils/NetworkCompatibility.cs
@@ -75,7 +75,7 @@ namespace R2API.Utils {
                         continue;
                     }
 
-                    if (pluginInfo.Dependencies.All(dependency => dependency.DependencyGUID != R2API.PluginGUID)) {
+                    if (pluginInfo.Dependencies.All(dependency => dependency.DependencyGUID != R2API.PluginGUID || dependency.Flags == BepInEx.BepInDependency.DependencyFlags.SoftDependency)) {
                         continue;
                     }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 
 **Current**
 
+* **IMPORTANT FOR MOD DEVS:** [R2API will no longer register mods to network if they don't depend on it with HardDependecy](https://github.com/risk-of-thunder/R2API/pull/286)
 * [Added DeployableAPI](https://github.com/risk-of-thunder/R2API/pull/279)
 * [Added DamageAPI](https://github.com/risk-of-thunder/R2API/pull/284)
 


### PR DESCRIPTION
Related conversation: https://discordapp.com/channels/562704639141740588/567836513078083584/841529389207650315
TL; DR;
Mods that used SoftDependency to R2API were in the middle ground where they are registered to the network and can't do anything about it.
This change excludes mods with SoftDependency from the network registration.