### PR TITLE
Network registration fix

### DIFF
--- a/R2API/PrefabAPI.cs
+++ b/R2API/PrefabAPI.cs
@@ -38,6 +38,18 @@ namespace R2API {
 
         /// <summary>
         /// Duplicates a GameObject and leaves it in a "sleeping" state where it is inactive, but becomes active when spawned.
+        /// Also registers the clone to network.
+        /// </summary>
+        /// <param name="g">The GameObject to clone</param>
+        /// <param name="nameToSet">The name to give the clone (Should be unique)</param>
+        /// <returns>The GameObject of the clone</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static GameObject InstantiateClone(this GameObject g, string nameToSet) {
+            return InstantiateCloneInternal(g, nameToSet, true);
+        }
+
+        /// <summary>
+        /// Duplicates a GameObject and leaves it in a "sleeping" state where it is inactive, but becomes active when spawned.
         /// Also registers the clone to network if registerNetwork is not set to false.
         /// </summary>
         /// <param name="g">The GameObject to clone</param>
@@ -45,7 +57,7 @@ namespace R2API {
         /// <param name="registerNetwork">Should the object be registered to network</param>
         /// <returns>The GameObject of the clone</returns>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static GameObject InstantiateClone(this GameObject g, string nameToSet, bool registerNetwork = true) {
+        public static GameObject InstantiateClone(this GameObject g, string nameToSet, bool registerNetwork) {
             return InstantiateCloneInternal(g, nameToSet, registerNetwork);
         }
 
@@ -125,7 +137,6 @@ namespace R2API {
             public string GoName;
             public string TypeName;
             public string MethodName;
-            public string Offset;
         }
 
         private static void RegisterPrefabInternal(GameObject prefab, StackFrame frame) {
@@ -136,7 +147,6 @@ namespace R2API {
                 GoName = prefab.name,
                 TypeName = method.DeclaringType.AssemblyQualifiedName,
                 MethodName = method.Name,
-                Offset = frame.GetNativeOffset().ToString()
             };
             ThingsToHash.Add(h);
             SetupRegistrationEvent();
@@ -171,7 +181,7 @@ namespace R2API {
         private static void RegisterClientPrefabsNStuff() {
             foreach (var h in ThingsToHash) {
                 if (h.Prefab.GetComponent<NetworkIdentity>() != null) h.Prefab.GetComponent<NetworkIdentity>().SetFieldValue("m_AssetId", NullHash);
-                ClientScene.RegisterPrefab(h.Prefab, NetworkHash128.Parse(MakeHash(h.GoName + h.TypeName + h.MethodName + h.Offset)));
+                ClientScene.RegisterPrefab(h.Prefab, NetworkHash128.Parse(MakeHash(h.GoName + h.TypeName + h.MethodName)));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 
 **Current**
 
+* [Fixed PrefabAPI network registration](https://github.com/risk-of-thunder/R2API/pull/294)
+
+**3.0.43**
+
 * **IMPORTANT FOR MOD DEVS:** [R2API will no longer register mods to network if they don't depend on it with HardDependecy](https://github.com/risk-of-thunder/R2API/pull/286)
 * [Added DeployableAPI](https://github.com/risk-of-thunder/R2API/pull/279)
 * [Added DamageAPI](https://github.com/risk-of-thunder/R2API/pull/284)


### PR DESCRIPTION
Related conversation: https://discord.com/channels/562704639141740588/567836513078083584/854006351696625715
TL;DR;
Using native offset was kinda dumb since it's offset in JIT-compiled code and most likely can differ on different PCs and/or OS.
This change makes that you are not able to register prefab with the same name in one method, but, I think, no one does that anyway.
Also added an overload to InstantiateClone to fix the ambiguity.

I think this should be published asap since it's a pretty big issue for multiplayer.
