### PR TITLE
[Artifact Code API] Custom artifact codes for Bulwark's Ambry

### DIFF
--- a/R2API/ArtifactCodeAPI.cs
+++ b/R2API/ArtifactCodeAPI.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using R2API.Utils;
+using RoR2;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace R2API {
+
+    /// <summary>
+    /// API for adding custom artifact codes to the game.
+    /// </summary>
+    [R2APISubmodule]
+    public static class ArtifactCodeAPI {
+
+        private static readonly List<(ArtifactDef, Sha256HashAsset)> ArtifactsCodes = new List<(ArtifactDef, Sha256HashAsset)>();
+
+        /// <summary>
+        /// Return true if the submodule is loaded.
+        /// </summary>
+        public static bool Loaded {
+            get => _loaded;
+            internal set => _loaded = value;
+        }
+
+        private static bool _loaded;
+
+        #region Hooks
+        //[R2APISubmoduleInit(Stage = InitStage.SetHooks)]
+        internal static void SetHooks() {
+            On.RoR2.PortalDialerController.Awake += AddCodes;
+            On.RoR2.PortalDialerController.PerformActionServer += PrintSha256HashCode;
+            RoR2.ContentManagement.ContentManager.onContentPacksAssigned += CheckForInvalidEntries;
+        }
+
+        private static void CheckForInvalidEntries(HG.ReadOnlyArray<RoR2.ContentManagement.ReadOnlyContentPack> obj) {
+            foreach ((ArtifactDef, Sha256HashAsset) entry in ArtifactsCodes) {
+                ArtifactDef artifactDef = entry.Item1;
+                if((bool)!ArtifactCatalog.GetArtifactDef(artifactDef.artifactIndex)) {
+                    R2API.Logger.LogMessage($"Removing {artifactDef.cachedName} from ArtifactCodes since it's not in the Artifact catalog.");
+                    ArtifactsCodes.Remove(entry);
+                }
+            }
+        }
+
+        //[R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
+        /*internal static void UnsetHooks() {
+            On.RoR2.PortalDialerController.Awake -= AddCodes;
+            On.RoR2.PortalDialerController.PerformActionServer -= PrintSha256HashCode;
+        }*/
+
+        /// <summary>
+        /// Prints the Artifact Code that the player inputs in the dialer. Useful for mod creators.
+        /// </summary>
+        /// <param name="orig"></param>
+        /// <param name="self"></param>
+        /// <param name="sequence"></param>
+        /// <returns></returns>
+        private static bool PrintSha256HashCode(On.RoR2.PortalDialerController.orig_PerformActionServer orig, PortalDialerController self, byte[] sequence) {
+            var result = self.GetResult(sequence);
+            R2API.Logger.LogInfo("Inputted Artifact Code:");
+            R2API.Logger.LogInfo("_00_07: " + result._00_07);
+            R2API.Logger.LogInfo("_08_15: " + result._08_15);
+            R2API.Logger.LogInfo("_16_23: " + result._16_23);
+            R2API.Logger.LogInfo("_24_31: " + result._24_31);
+            return orig(self, sequence);
+        }
+
+        /// <summary>
+        /// Adds custom ArtifactCodes to the portal dialer controller instance found in sky meadow.
+        /// </summary>
+        /// <param name="orig"></param>
+        /// <param name="self"></param>
+        private static void AddCodes(On.RoR2.PortalDialerController.orig_Awake orig, PortalDialerController self) {
+            foreach ((ArtifactDef, Sha256HashAsset) entry in ArtifactsCodes) {
+                var artifactDef = entry.Item1;
+                var artifactCode = entry.Item2;
+
+                PortalDialerController.DialedAction dialedAction = new PortalDialerController.DialedAction();
+                dialedAction.hashAsset = artifactCode;
+                dialedAction.action = new UnityEvent();
+                dialedAction.action.AddListener(Wrapper);
+
+                void Wrapper() => self.OpenArtifactPortalServer(artifactDef);
+                R2API.Logger.LogInfo("Added code for " + artifactDef.cachedName);
+                HG.ArrayUtils.ArrayAppend(ref self.actions, dialedAction);
+            }
+            orig(self);
+        }
+        #endregion Hooks
+
+        #region Methods
+
+        /// <summary>
+        /// Add a custom Artifact code to the SkyMeadow Artifact portal dialer.
+        /// The artifactDef must exist within the initialized ArtifactCatalog for it to properly added to the portal dialer.
+        /// </summary>
+        /// <param name="artifactDef">The artifactDef tied to the artifact code,</param>
+        /// <param name="sha256HashAsset">The artifact code.</param>
+        public static void Add(ArtifactDef? artifactDef, Sha256HashAsset? sha256HashAsset) {
+            if(!Loaded) {
+                throw new InvalidOperationException($"{nameof(ArtifactCodeAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ArtifactCodeAPI)})]");
+            }
+            ArtifactsCodes.Add((artifactDef, sha256HashAsset));
+        }
+
+        /// <summary>
+        /// Add a custom Artifact code to the SkyMeadow Artifact portal dialer.
+        /// The artifactDef must exist within the initialized ArtifactCatalog for it to properly added to the portal dialer.
+        /// </summary>
+        /// <param name="artifactDef"></param>
+        /// <param name="artifactCode"></param>
+        public static void Add(ArtifactDef? artifactDef, ArtifactCodeScriptableObject? artifactCode) {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(ArtifactCodeAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ArtifactCodeAPI)})]");
+            }
+            ArtifactsCodes.Add((artifactDef, artifactCode.hashAsset));
+        }
+
+        /// <summary>
+        /// Add a custom Artifact code to the SkyMeadow Artifact portal dialer.
+        /// The artifactDef must exist within the initialized Artifactcatalog for it to be properly added to the portal dialer.
+        /// </summary>
+        /// <param name="artifactDef">The artifactDef tied to the artifact code,</param>
+        /// <param name="code_00_07"></param>
+        /// <param name="code_08_15"></param>
+        /// <param name="code_16_23"></param>
+        /// <param name="code_24_31"></param>
+        public static void Add(ArtifactDef? artifactDef, ulong code_00_07, ulong code_08_15, ulong code_16_23, ulong code_24_31) {
+
+            if(!Loaded) {
+                throw new InvalidOperationException($"{nameof(ArtifactCodeAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ArtifactCodeAPI)})]");
+            }
+            Sha256HashAsset hashAsset = ScriptableObject.CreateInstance<Sha256HashAsset>();
+            hashAsset.value._00_07 = code_00_07;
+            hashAsset.value._08_15 = code_08_15;
+            hashAsset.value._16_23 = code_16_23;
+            hashAsset.value._24_31 = code_24_31;
+
+            ArtifactsCodes.Add((artifactDef, hashAsset));
+        }
+        #endregion Methods
+
+        #region CompoundEnum
+        /// <summary>
+        /// RoR2's Artifact compounds used for ArtifactCodeAPI's ArtifactCode scriptable object.
+        /// </summary>
+        public enum ArtifactCompound {
+            /// <summary>
+            /// Value: 11
+            /// </summary>
+            None,
+            /// <summary>
+            /// Value: 7
+            /// </summary>
+            Square,
+            /// <summary>
+            /// Value: 1
+            /// </summary>
+            Circle,
+            /// <summary>
+            /// Value: 3
+            /// </summary>
+            Triangle,
+            /// <summary>
+            /// Value: 5
+            /// </summary>
+            Diamond
+        }
+        #endregion CompoundEnum
+    }
+}

--- a/R2API/ArtifactCodeScriptableObject.cs
+++ b/R2API/ArtifactCodeScriptableObject.cs
@@ -1,0 +1,75 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+using static R2API.ArtifactCodeAPI;
+
+namespace R2API {
+    [CreateAssetMenu(fileName = "New Artifact Code", menuName = "R2API/ArtifactCodeAPI/ArtifactCode", order = 0)]
+    public class ArtifactCodeScriptableObject : ScriptableObject {
+
+        /// <summary>
+        /// List that contains your Artifact code. for information on how to fill this list, check this wiki page:
+        /// <para>https://github.com/risk-of-thunder/R2Wiki/wiki/Creating-Custom-Artifacts</para>
+        /// </summary>
+        public List<ArtifactCompound> ArtifactCompounds = new List<ArtifactCompound>();
+
+        private int[] artifactSequence;
+
+        private SHA256 hasher;
+
+        /// <summary>
+        /// The Sha256HashAsset stored in this scriptable object.
+        /// </summary>
+        [HideInInspector]
+        public Sha256HashAsset hashAsset;
+
+        private void Awake() {
+            hasher = SHA256.Create();
+
+            List<int> sequence = new List<int>();
+
+            foreach (ArtifactCompound compound in ArtifactCompounds) {
+                switch (compound) {
+                    case ArtifactCompound.None:
+                        sequence.Add(11);
+                        break;
+                    case ArtifactCompound.Square:
+                        sequence.Add(7);
+                        break;
+                    case ArtifactCompound.Circle:
+                        sequence.Add(1);
+                        break;
+                    case ArtifactCompound.Triangle:
+                        sequence.Add(3);
+                        break;
+                    case ArtifactCompound.Diamond:
+                        sequence.Add(5);
+                        break;
+                }
+            }
+
+            artifactSequence = sequence.ToArray();
+
+            hashAsset = CreateHashAsset(CreateHash());
+        }
+
+        internal Sha256Hash CreateHash() {
+            byte[] array = new byte[artifactSequence.Length];
+            for (int i = 0; i < array.Length; i++) {
+                array[i] = (byte)artifactSequence[i];
+            }
+            return Sha256Hash.FromBytes(hasher.ComputeHash(array));
+        }
+        internal Sha256HashAsset CreateHashAsset(Sha256Hash hash) {
+            var asset = ScriptableObject.CreateInstance<Sha256HashAsset>();
+            asset.value._00_07 = hash._00_07;
+            asset.value._08_15 = hash._08_15;
+            asset.value._16_23 = hash._16_23;
+            asset.value._24_31 = hash._24_31;
+            return asset;
+        }
+    }
+}

--- a/R2API/ArtifactCodeScriptableObject.cs
+++ b/R2API/ArtifactCodeScriptableObject.cs
@@ -14,7 +14,7 @@ namespace R2API {
         /// List that contains your Artifact code. for information on how to fill this list, check this wiki page:
         /// <para>https://github.com/risk-of-thunder/R2Wiki/wiki/Creating-Custom-Artifacts</para>
         /// </summary>
-        public List<ArtifactCompound> ArtifactCompounds = new List<ArtifactCompound>();
+        public List<int> ArtifactCompounds = new List<int>();
 
         private int[] artifactSequence;
 
@@ -26,30 +26,20 @@ namespace R2API {
         [HideInInspector]
         public Sha256HashAsset hashAsset;
 
-        private void Awake() {
+        public void Start() {
             hasher = SHA256.Create();
 
             List<int> sequence = new List<int>();
 
-            foreach (ArtifactCompound compound in ArtifactCompounds) {
-                switch (compound) {
-                    case ArtifactCompound.None:
-                        sequence.Add(11);
-                        break;
-                    case ArtifactCompound.Square:
-                        sequence.Add(7);
-                        break;
-                    case ArtifactCompound.Circle:
-                        sequence.Add(1);
-                        break;
-                    case ArtifactCompound.Triangle:
-                        sequence.Add(3);
-                        break;
-                    case ArtifactCompound.Diamond:
-                        sequence.Add(5);
-                        break;
-                }
-            }
+            sequence.Add(ArtifactCompounds[2]);
+            sequence.Add(ArtifactCompounds[5]);
+            sequence.Add(ArtifactCompounds[8]);
+            sequence.Add(ArtifactCompounds[1]);
+            sequence.Add(ArtifactCompounds[7]);
+            sequence.Add(ArtifactCompounds[4]);
+            sequence.Add(ArtifactCompounds[0]);
+            sequence.Add(ArtifactCompounds[3]);
+            sequence.Add(ArtifactCompounds[6]);
 
             artifactSequence = sequence.ToArray();
 

--- a/R2API/ScriptableObjects/ArtifactCode.cs
+++ b/R2API/ScriptableObjects/ArtifactCode.cs
@@ -6,9 +6,9 @@ using System.Text;
 using UnityEngine;
 using static R2API.ArtifactCodeAPI;
 
-namespace R2API {
+namespace R2API.ScriptableObjects {
     [CreateAssetMenu(fileName = "New Artifact Code", menuName = "R2API/ArtifactCodeAPI/ArtifactCode", order = 0)]
-    public class ArtifactCodeScriptableObject : ScriptableObject {
+    public class ArtifactCode : ScriptableObject {
 
         /// <summary>
         /// List that contains your Artifact code. for information on how to fill this list, check this wiki page:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Note that such builds may be **unstable**.
 ## Changelog
 
 The most recent changelog can always be found on the [GitHub](https://github.com/risk-of-thunder/R2API/blob/master/Archived%20changelogs.md). In this readme, only the most recent *minor* version will have a changelog.
+**3.0.49**
+* [Added ArtifactCodeAPI](https://github.com/risk-of-thunder/R2API/pull/299)
 
-**Current**
+**3.0.48**
 
 * [Documentation for ItemDropAPI](https://github.com/risk-of-thunder/R2API/blob/master/ItemDropAPI%20Instructions%20For%20Use.txt)
 * [ItemDropAPI Overhall](https://github.com/risk-of-thunder/R2API/pull/295)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note that such builds may be **unstable**.
 ## Changelog
 
 The most recent changelog can always be found on the [GitHub](https://github.com/risk-of-thunder/R2API/blob/master/Archived%20changelogs.md). In this readme, only the most recent *minor* version will have a changelog.
-**3.0.49**
+**Current**
 * [Added ArtifactCodeAPI](https://github.com/risk-of-thunder/R2API/pull/299)
 
 **3.0.48**


### PR DESCRIPTION
Allows the creation of new Artifact codes to be used in the artifact portal found in sky meadow.
Works by storing an array of DialedActions and appending them to the Portal Dialer Controller instance of SkyMeadow on Awake.
There are 3 public classes
* `ArtifactCodeAPI`: Handles the overall storing and creation of new artifact codes
* `ArtifactCodeScriptableObject`: Allows the ease of creation of codes by simply inputting the Artifact Compound's values into a list. Works both for Code use and Editor use.
* `CompoundValues`: Contains the values of Vanilla Risk of Rain 2 Artifact Compounds (Empty, Square, Circle, Triangle and Diamond.)

# Detailed information:

## Hooks

The API works by mainly hooking into 2 methods inside the PortalDialerController class.

* `awake`: Reads through the list of ArtifactCodes (Composed by an ArtifactDef and a Sha256HashAsset) and checks if the artifact Def is in the ArtifactCatalog. If true, it adds a new DialedAction that calls the `OpenArtifactPortalServer(artifactDef)`, which allows for the Portal to open. Creating these dialed actions must be done in the `awake` function, since the UnityEvent found inside DialedAction needs a direct reference to the PortalDialerController instance in SkyMeadow.
* `PerformActionServer`: While not completely necesary for the API to function, `PerformActionServer`prints out the necessary values for a modder to use in their Sha256Asset, assuming they desire to create their artifact code this way.

## Methods

The main method to use for adding new codes is the `Add()` Method, having a total of 5 Overloads for a myriad of different methods of implementing codes.

* Implement a code by giving an ArtifactDef and a Sha256Hash asset as arguments.
* Implement a code by giving an ArtifactDef and an ArtifactCodeScriptableObject asset as Arguments.
* Implement a code by giving an ArtifactDef and 4 ulongs, each ulong matches the ulongs a Sha256Hash requires.
* Implement a code by giving an ArtifactDef and an array of int. This array must be filled with the compound's values.
* Implement a code by giving an ArtifactDef and a list of ints. This list must be filled with the compound's values.