### PR TITLE
Add NetworkSoundEventDef registration to SoundAPI

### DIFF
--- a/R2API/SoundAPI.cs
+++ b/R2API/SoundAPI.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using MonoMod.RuntimeDetour;
 using R2API.Utils;
 using RoR2;
@@ -17,7 +17,6 @@ namespace R2API {
     /// </summary>
     [R2APISubmodule]
     public static class SoundAPI {
-
         private static readonly List<NetworkSoundEventDef> NetworkSoundEventDefs = new List<NetworkSoundEventDef>();
 
         private static bool _NetworkSoundEventCatalogInitialized;
@@ -296,6 +295,5 @@ namespace R2API {
         }
 
         #endregion NetworkSoundEventCatalog Setup
-
     }
 }

--- a/R2API/SoundAPI.cs
+++ b/R2API/SoundAPI.cs
@@ -222,12 +222,12 @@ namespace R2API {
         #region NetworkSoundEventCatalog Setup
 
         [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
-        internal static void SetHooks() {
+        internal static void NetworkSetHooks() {
             R2APIContentPackProvider.WhenContentPackReady += AddNetworkSoundEventDefsToGame;
         }
 
         [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
-        internal static void UnsetHooks() {
+        internal static void NetworkUnsetHooks() {
             R2APIContentPackProvider.WhenContentPackReady -= AddNetworkSoundEventDefsToGame;
         }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 
 **Current**
 
+* [Add NetworkSoundEventDef registration to SoundAPI](https://github.com/risk-of-thunder/R2API/pull/301)
+
+**3.0.50**
+
 * [Added ArtifactCodeAPI](https://github.com/risk-of-thunder/R2API/pull/299)
 * [Added support for new Artifact Code compounds](https://github.com/risk-of-thunder/R2API/pull/300)
 


### PR DESCRIPTION
## What is it?
This PR adds a way for developers to register `NetworkSoundEventDef` instances to the r2apiContentPack via the SoundAPI along with a few sanity checks for good measure.

## Why?
Currently under `SoundAPI` there is not a way to add in sounds that are network ready. This utilizes the content pack system to register these at runtime under the R2API content pack which will then allow them to be used with RoR2's `EntitySoundManager` class.

## How do I use it?

Similar to `ItemAPI` or `ArtifactAPI`, there are two ways of properly adding a `NetworkSoundEventDef`.

 1. `SoundAPI.AddNetworkedSoundEvent(NetworkedSoundEventDef? networkSoundEventDef)` - allows you to pass in your own `NetworkSoundEventDef` to SoundAPI and if it passes the sanity checks, into the r2apiContentPack.  Useful for when you want to save a reference to said `NetworkSoundEventDef` which you can grab the event ID from when you need to pass one into `EntitySoundManager`.
 
 2. `SoundAPI.AddNetworkedSoundEvent(string eventName)` - Allows you to pass in the name of the WWise sound event and SoundAPI will create its own `NetworkSoundEventDef` from it. If this passes the sanity checks, it is also added into the r2apiContentPack. This is less useful, as you will have to provide the eventID to `EntitySoundManager` when you go to emit the sound via it.

