### PR TITLE
Premade UnlockableDefs in AddUnlockable

### DIFF
--- a/R2API/UnlockableAPI.cs
+++ b/R2API/UnlockableAPI.cs
@@ -200,14 +200,18 @@ namespace R2API {
 
         internal static UnlockableDef CreateNewUnlockable(UnlockableInfo unlockableInfo) {
             var newUnlockableDef = ScriptableObject.CreateInstance<UnlockableDef>();
+            return SetupUnlockable(unlockableInfo, newUnlockableDef);
+        }
 
-            newUnlockableDef.cachedName = unlockableInfo.Name;
-            newUnlockableDef.nameToken = unlockableInfo.Name;
-            newUnlockableDef.getHowToUnlockString = unlockableInfo.HowToUnlockString;
-            newUnlockableDef.getUnlockedString = unlockableInfo.UnlockedString;
-            newUnlockableDef.sortScore = unlockableInfo.SortScore;
+        internal static UnlockableDef SetupUnlockable(UnlockableInfo unlockableInfo, UnlockableDef unlockableDef) {
 
-            return newUnlockableDef;
+            unlockableDef.cachedName = unlockableInfo.Name;
+            unlockableDef.nameToken = unlockableInfo.Name;
+            unlockableDef.getHowToUnlockString = unlockableInfo.HowToUnlockString;
+            unlockableDef.getUnlockedString = unlockableInfo.UnlockedString;
+            unlockableDef.sortScore = unlockableInfo.SortScore;
+
+            return unlockableDef;
         }
 
         [Obsolete("The bool parameter serverTracked is redundant. Instead, pass in a Type that inherits from BaseServerAchievement if it is server tracked, or nothing if it's not")]
@@ -251,13 +255,17 @@ namespace R2API {
             }
 
             if (unlockableDef == null) {
-                unlockableDef = CreateNewUnlockable(new UnlockableInfo {
-                    Name = instance.UnlockableIdentifier,
-                    HowToUnlockString = instance.GetHowToUnlock,
-                    UnlockedString = instance.GetUnlocked,
-                    SortScore = 200
-                });
+                unlockableDef = ScriptableObject.CreateInstance<UnlockableDef>();
             }
+
+            UnlockableInfo unlockableInfo = new UnlockableInfo {
+                Name = instance.UnlockableIdentifier,
+                HowToUnlockString = instance.GetHowToUnlock,
+                UnlockedString = instance.GetUnlocked,
+                SortScore = 200
+            };
+
+            unlockableDef = SetupUnlockable(unlockableInfo, unlockableDef);
 
             var achievementDef = new AchievementDef {
                 identifier = instance.AchievementIdentifier,

--- a/R2API/UnlockableAPI.cs
+++ b/R2API/UnlockableAPI.cs
@@ -213,7 +213,15 @@ namespace R2API {
         [Obsolete("The bool parameter serverTracked is redundant. Instead, pass in a Type that inherits from BaseServerAchievement if it is server tracked, or nothing if it's not")]
         public static UnlockableDef AddUnlockable<TUnlockable>(bool serverTracked) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
         {
-            return AddUnlockable<TUnlockable>(null);
+            return AddUnlockable<TUnlockable>(null, null);
+        }
+        public static UnlockableDef AddUnlockable<TUnlockable>(Type serverTrackerType) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
+        {
+            return AddUnlockable<TUnlockable>(serverTrackerType, null);
+        }
+        public static UnlockableDef AddUnlockable<TUnlockable>(UnlockableDef unlockableDef) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
+        {
+            return AddUnlockable<TUnlockable>(null, unlockableDef);
         }
 
         /// <summary>
@@ -222,8 +230,9 @@ namespace R2API {
         /// </summary>
         /// <typeparam name="TUnlockable">Class that inherits from BaseAchievement and implements IModdedUnlockableDataProvider</typeparam>
         /// <param name="serverTrackerType">Type that inherits from BaseServerAchievement for achievements that the server needs to track</param>
+        /// <param name="unlockableDef">For UnlockableDefs created in advance. Leaving null will generate an UnlockableDef instead.</param>
         /// <returns></returns>
-        public static UnlockableDef AddUnlockable<TUnlockable>(Type serverTrackerType = null) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
+        public static UnlockableDef AddUnlockable<TUnlockable>(Type serverTrackerType = null, UnlockableDef unlockableDef = null) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
         {
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(UnlockableAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(UnlockableAPI)})]");
@@ -241,12 +250,14 @@ namespace R2API {
                 throw new InvalidOperationException($"The unlockable identifier '{unlockableIdentifier}' is already used by another mod.");
             }
 
-            var unlockableDef = CreateNewUnlockable(new UnlockableInfo {
-                Name = instance.UnlockableIdentifier,
-                HowToUnlockString = instance.GetHowToUnlock,
-                UnlockedString = instance.GetUnlocked,
-                SortScore = 200
-            });
+            if (unlockableDef == null) {
+                unlockableDef = CreateNewUnlockable(new UnlockableInfo {
+                    Name = instance.UnlockableIdentifier,
+                    HowToUnlockString = instance.GetHowToUnlock,
+                    UnlockedString = instance.GetUnlocked,
+                    SortScore = 200
+                });
+            }
 
             var achievementDef = new AchievementDef {
                 identifier = instance.AchievementIdentifier,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 **Current**
 
 * [Add NetworkSoundEventDef registration to SoundAPI](https://github.com/risk-of-thunder/R2API/pull/301)
+* [Added support for using existing UnlockableDefs in UnlockableAPI](https://github.com/risk-of-thunder/R2API/pull/304)
 
 **3.0.50**
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 
 **Current**
 
-* [Add NetworkSoundEventDef registration to SoundAPI](https://github.com/risk-of-thunder/R2API/pull/301)
 * [Added support for using existing UnlockableDefs in UnlockableAPI](https://github.com/risk-of-thunder/R2API/pull/304)
+
+**3.0.52**
+
+* [Add NetworkSoundEventDef registration to SoundAPI](https://github.com/risk-of-thunder/R2API/pull/301)
 
 **3.0.50**
 


### PR DESCRIPTION
Added support for created UnlockableDefs being passed into AddUnlockable, along with some overloads for compatibility. This should add support for ThunderKit workflows, which creates UnlockableDefs inside Unity directly and not in code.