### PR TITLE
[ArtifactCodeAPI] Minor changes to the ArtifactCode scriptable object

### DIFF
--- a/R2API/ArtifactCodeAPI.cs
+++ b/R2API/ArtifactCodeAPI.cs
@@ -47,18 +47,12 @@ namespace R2API {
             }
         }
 
-        /// <summary>
-        /// Prints the Artifact Code that the player inputs in the dialer. Useful for mod creators.
-        /// </summary>
         private static bool PrintSha256HashCode(On.RoR2.PortalDialerController.orig_PerformActionServer orig, PortalDialerController self, byte[] sequence) {
             var result = self.GetResult(sequence);
             R2API.Logger.LogInfo("Inputted Artifact Code:\n_00_07: " + result._00_07 + "\n_08_15: " + result._08_15 + "\n_16_23: " + result._16_23 + "\n_24_31: " + result._24_31);
             return orig(self, sequence);
         }
 
-        /// <summary>
-        /// Adds custom ArtifactCodes to the portal dialer controller instance found in sky meadow.
-        /// </summary>
         private static void AddCodes(On.RoR2.PortalDialerController.orig_Awake orig, PortalDialerController self) {
             foreach ((ArtifactDef artifactDef, Sha256HashAsset artifactCode) in ArtifactsCodes) {
                 if (!ArtifactCatalog.GetArtifactDef(artifactDef.artifactIndex)) {

--- a/R2API/ScriptableObjects/ArtifactCode.cs
+++ b/R2API/ScriptableObjects/ArtifactCode.cs
@@ -31,6 +31,7 @@ namespace R2API {
         public Vector3Int bottomRow = new Vector3Int();
 
         [Obsolete("The artifact compounds list is obsolete, please use the topRow, middleRow and bottomRow Vector3Int.")]
+        [HideInInspector]
         public List<int> ArtifactCompounds = new List<int>();
 
         private int[] artifactSequence;

--- a/R2API/ScriptableObjects/ArtifactCode.cs
+++ b/R2API/ScriptableObjects/ArtifactCode.cs
@@ -13,7 +13,7 @@ namespace R2API {
     public class ArtifactCode : ScriptableObject {
 
         private const string constant = "For a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues";
-
+        [Header(constant)]
         /// <summary>
         /// Compound values that represent the top 3 compounds. For a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues
         /// </summary>

--- a/R2API/ScriptableObjects/ArtifactCode.cs
+++ b/R2API/ScriptableObjects/ArtifactCode.cs
@@ -1,4 +1,5 @@
 ﻿using RoR2;
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using UnityEngine;
@@ -11,9 +12,25 @@ namespace R2API {
     [CreateAssetMenu(fileName = "ArtifactCode", menuName = "R2API/ArtifactCodeAPI/ArtifactCode", order = 0)]
     public class ArtifactCode : ScriptableObject {
 
+        private const string constant = "For a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues";
+
         /// <summary>
-        /// The code for the Artifact. for a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues
+        /// Compound values that represent the top 3 compounds. For a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues
         /// </summary>
+        [Tooltip($"Compound values that represent the top 3 compounds.\n{constant}")]
+        public Vector3Int topRow = new Vector3Int();
+        /// <summary>
+        /// Compound values that represent the middle 3 compounds. For a list of accepted vanilla compound values, check ArtifactCodeAPI.CompoundValues
+        /// </summary>
+        [Tooltip($"Compound values that represent the middle 3 compounds.\n{constant}")]
+        public Vector3Int middleRow = new Vector3Int();
+        /// <summary>
+        /// Compound values that represent the bottom 3 compounds. For a list of accepted vanila compound values, check ArtifactCodeAPI.CompoundValues
+        /// </summary>
+        [Tooltip($"Compounds values that represent the bottom 3 compounds.\n{constant}")]
+        public Vector3Int bottomRow = new Vector3Int();
+
+        [Obsolete("The artifact compounds list is obsolete, please use the topRow, middleRow and bottomRow Vector3Int.")]
         public List<int> ArtifactCompounds = new List<int>();
 
         private int[] artifactSequence;
@@ -29,8 +46,21 @@ namespace R2API {
         /// <summary>
         /// Creates the Sha256HashAsset
         /// </summary>
-        public void Start() {
+        internal void Start() {
             hasher = SHA256.Create();
+
+            if (ArtifactCompounds.Count > 0) {
+                R2API.Logger.LogWarning($"Artifact Code of name {name} is using the deprecated ArtifactCompounds list.");
+                artifactSequence = CreateSequenceFromList();
+                hashAsset = CreateHashAsset(CreateHash());
+            }
+            else {
+                artifactSequence = CreateSequenceFromVectors();
+                hashAsset = CreateHashAsset(CreateHash());
+            }
+        }
+
+        private int[] CreateSequenceFromList() {
 
             List<int> sequence = new List<int>();
 
@@ -44,12 +74,25 @@ namespace R2API {
             sequence.Add(ArtifactCompounds[3]);
             sequence.Add(ArtifactCompounds[6]);
 
-            artifactSequence = sequence.ToArray();
-
-            hashAsset = CreateHashAsset(CreateHash());
+            return sequence.ToArray();
         }
 
-        internal Sha256Hash CreateHash() {
+        private int[] CreateSequenceFromVectors() {
+            List<int> sequence = new List<int>();
+            sequence.Add(topRow.z);
+            sequence.Add(middleRow.z);
+            sequence.Add(bottomRow.z);
+            sequence.Add(topRow.y);
+            sequence.Add(middleRow.y);
+            sequence.Add(bottomRow.y);
+            sequence.Add(topRow.x);
+            sequence.Add(middleRow.x);
+            sequence.Add(bottomRow.x);
+
+            return sequence.ToArray();
+        }
+
+        private Sha256Hash CreateHash() {
             byte[] array = new byte[artifactSequence.Length];
             for (int i = 0; i < array.Length; i++) {
                 array[i] = (byte)artifactSequence[i];
@@ -57,7 +100,7 @@ namespace R2API {
             return Sha256Hash.FromBytes(hasher.ComputeHash(array));
         }
 
-        internal Sha256HashAsset CreateHashAsset(Sha256Hash hash) {
+        private Sha256HashAsset CreateHashAsset(Sha256Hash hash) {
             var asset = ScriptableObject.CreateInstance<Sha256HashAsset>();
             asset.value._00_07 = hash._00_07;
             asset.value._08_15 = hash._08_15;


### PR DESCRIPTION
After using the ArtifactCode scriptable object, while it works decently for creating the code from the usual VS method of mod creation, working with the scriptable object itself in the unity editor is a pain, this is due to the fact that the field that's show in the inspector is a list, and working with lists is difficult without a proper custom inspector (something that's outside of the realm of R2API for now i imagine)
![](https://cdn.discordapp.com/attachments/575431803523956746/902366414671872000/df427a09b23869a6859761594a313816.png)
Due to this, i've decided to do the following changes to the ArtifactCode scriptable object:

* Create 3 new fields of type Vector3Int
* Mark `List<int> ArtifactCompounds` as Obsolete, and mark it with the HideInInspector attribute (As the 3 new fields is supposed to replace it)
* Throw a warning when a code still has values in the ArtifactCompounds list, the code still gets created and still gets added to the api.

The final result is an ArtifactCode scriptable object that, in my opinion, is way more readable in an editor standpoint
![](https://cdn.discordapp.com/attachments/575431803523956746/902366421433069578/561090bbd6a6b85cd69f6d3af113894d.png)