### PR TITLE
Adding TempVisualEffectAPI

### DIFF
--- a/R2API/TempVisualEffectAPI.cs
+++ b/R2API/TempVisualEffectAPI.cs
@@ -54,7 +54,7 @@ namespace R2API {
         /// <param name="useBestFitRadius"></param>
         /// /// <param name="condition"></param>
         /// <param name="childLocatorOverride"></param>
-        public static bool AddTemporaryVisualEffect(GameObject effectPrefab, bool useBestFitRadius, EffectCondition condition, string childLocatorOverride = "") {
+        public static bool AddTemporaryVisualEffect(GameObject effectPrefab, EffectCondition condition, bool useBestFitRadius = false, string childLocatorOverride = "") {
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(TempVisualEffectAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(TempVisualEffectAPI)})]");
             }

--- a/R2API/TempVisualEffectAPI.cs
+++ b/R2API/TempVisualEffectAPI.cs
@@ -110,7 +110,6 @@ namespace R2API {
         }
 
         private static void BodyStart(CharacterBody body) {
-
             if (!body.gameObject.GetComponent<R2APITVEController>()) {
                 body.gameObject.AddComponent<R2APITVEController>();
             }

--- a/R2API/TempVisualEffectAPI.cs
+++ b/R2API/TempVisualEffectAPI.cs
@@ -1,0 +1,169 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using R2API.Utils;
+using RoR2;
+using RoR2.ContentManagement;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace R2API {
+    /// <summary>
+    /// API for adding custom TemporaryVisualEffects to CharacterBody components.
+    /// </summary>
+    [R2APISubmodule]
+    public static class TempVisualEffectAPI {
+
+        /// <summary>
+        /// Return true if the submodule is loaded.
+        /// </summary>
+        public static bool Loaded {
+            get => _loaded;
+            internal set => _loaded = value;
+        }
+
+        private static bool _loaded;
+        private static bool _TVEsAdded;
+
+        /// <summary>
+        /// Delegate used for checking if TVE should be active (bool active). <see cref="CharacterBody.UpdateSingleTemporaryVisualEffect(ref TemporaryVisualEffect, string, float, bool, string)"/>
+        /// </summary>
+        /// <param name="body"></param>
+        public delegate bool EffectCondition(CharacterBody body);
+        public struct TemporaryVisualEffectStruct {
+            public TemporaryVisualEffect effect;
+            public GameObject effectPrefab;
+            public bool useBestFitRadius;
+            public EffectCondition condition;
+            public string childLocatorOverride;
+            public string effectName;
+        }
+
+        internal static List<TemporaryVisualEffectStruct> tves = new List<TemporaryVisualEffectStruct>();
+        internal static Dictionary<string, TemporaryVisualEffectStruct> tveDict = new Dictionary<string, TemporaryVisualEffectStruct>();
+        internal static readonly string moddedString = "R2APIModded:";
+
+        /// <summary>
+        /// Adds a custom TemporaryVisualEffect (TVEs) to the static tves List and Dict.
+        /// Custom TVEs are used and updated in the CharacterBody just after vanilla TVEs.
+        /// Must be called before R2APIContentPackProvider.WhenContentPackReady. Will fail if called after.
+        /// Returns true if successful.
+        /// </summary>
+        /// <param name="effectPrefab">MUST contain a TemporaryVisualEffect component.</param>
+        /// <param name="useBestFitRadius"></param>
+        /// /// <param name="condition"></param>
+        /// <param name="childLocatorOverride"></param>
+        public static bool AddTemporaryVisualEffect(GameObject effectPrefab, bool useBestFitRadius, EffectCondition condition, string childLocatorOverride = "") {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(TempVisualEffectAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(TempVisualEffectAPI)})]");
+            }
+            if (_TVEsAdded) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab} after TVE list was created");
+                return false;
+            }
+
+            var newTVE = new TemporaryVisualEffectStruct();
+
+            if (effectPrefab == null) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab.name} GameObject is null"); return false;
+            }
+            if (condition == null) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab.name} no condition attached"); return false;
+            }
+            if (tves.Any(effect => effect.effectPrefab == effectPrefab)) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab.name} gameObject already exists in list"); return false;
+            }
+            if (tves.Any(name => name.effectName == effectPrefab.name)) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab.name} name already exists in list"); return false;
+            }
+            if (!effectPrefab.GetComponent<TemporaryVisualEffect>()) {
+                R2API.Logger.LogError($"Tried to add TVE: {effectPrefab.name} GameObject has no TemporaryVisualEffect component"); return false;
+            }
+
+            newTVE.effectPrefab = effectPrefab;
+            newTVE.useBestFitRadius = useBestFitRadius;
+            newTVE.condition = condition;
+            newTVE.childLocatorOverride = childLocatorOverride;
+            newTVE.effectName = effectPrefab.name;
+
+            tves.Add(newTVE);
+            tveDict.Add(moddedString + effectPrefab.name, newTVE);
+            R2API.Logger.LogMessage($"Added new TVE: {newTVE}");
+            return true;
+        }
+
+        [R2APISubmoduleInit(Stage = InitStage.SetHooks)]
+        internal static void SetHooks() {
+            On.RoR2.CharacterBody.UpdateAllTemporaryVisualEffects += UpdateAllHook;
+            IL.RoR2.CharacterBody.UpdateSingleTemporaryVisualEffect += UpdateSingleHook;
+            R2APIContentPackProvider.WhenContentPackReady += DontAllowNewEntries;
+            CharacterBody.onBodyStartGlobal += BodyStart;
+        }
+
+        [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
+        internal static void UnsetHooks() {
+            On.RoR2.CharacterBody.UpdateAllTemporaryVisualEffects -= UpdateAllHook;
+            IL.RoR2.CharacterBody.UpdateSingleTemporaryVisualEffect += UpdateSingleHook;
+            R2APIContentPackProvider.WhenContentPackReady -= DontAllowNewEntries;
+            CharacterBody.onBodyStartGlobal -= BodyStart;
+        }
+
+        private static void BodyStart(CharacterBody body) {
+
+            if (!body.gameObject.GetComponent<R2APITVEController>()) {
+                body.gameObject.AddComponent<R2APITVEController>();
+            }
+        }
+
+        private static void DontAllowNewEntries(ContentPack r2apiContentPack) {
+            _TVEsAdded = true;
+        }
+
+        private static void UpdateAllHook(On.RoR2.CharacterBody.orig_UpdateAllTemporaryVisualEffects orig, CharacterBody self) {
+            orig(self);
+            var controller = self.gameObject.GetComponent<R2APITVEController>();
+            if (controller) {
+                for (int i = 0; i < controller.localTVEs.Count; i++) {
+                    TempVisualEffectAPI.TemporaryVisualEffectStruct temp = controller.localTVEs[i];
+                    self.UpdateSingleTemporaryVisualEffect(ref temp.effect, moddedString + temp.effectPrefab.name, temp.useBestFitRadius ? self.radius : self.bestFitRadius, temp.condition.Invoke(self), temp.childLocatorOverride);
+                    controller.localTVEs[i] = temp;
+                }
+            }
+        }
+
+        private static void UpdateSingleHook(ILContext il) {
+            var cursor = new ILCursor(il);
+
+            GameObject GetCustomTVE(GameObject vanillaLoaded, string ResourceString)
+                {
+                if (!vanillaLoaded) {
+                    if (tveDict.TryGetValue(ResourceString, out var customTVEPrefab)) {
+                        return customTVEPrefab.effectPrefab;
+                    }
+                }
+                return vanillaLoaded;
+
+            }
+
+            var resourceStringIndex = -1;
+            if (cursor.TryGotoNext(MoveType.After,
+                x => x.MatchLdarg(out resourceStringIndex),
+                x => x.MatchCallOrCallvirt<Resources>(nameof(Resources.Load))
+            )) {
+                cursor.Emit(OpCodes.Ldarg, resourceStringIndex);
+                cursor.EmitDelegate<Func<GameObject, string, GameObject>>(GetCustomTVE);
+            }
+            else {
+                R2API.Logger.LogError($"{nameof(UpdateSingleHook)} failed.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Contains a local list of custom TemporaryVisualEffects for each CharacterBody.
+    /// </summary>
+    public class R2APITVEController : MonoBehaviour {
+        public List<TempVisualEffectAPI.TemporaryVisualEffectStruct> localTVEs = new List<TempVisualEffectAPI.TemporaryVisualEffectStruct>(TempVisualEffectAPI.tves);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 * [EliteAPI now exposes the default elite tiers array (through VanillaEliteTiers) before any changes are made to it for modder that want to change the vanilla elite tiers. Also, adding to the custom elite tier array now by default insert based on the cost multiplier of the elite tier.](https://github.com/risk-of-thunder/R2API/pull/308)
 * [RecalculateStatsAPI now warns modders that the submodule could be not loaded](https://github.com/risk-of-thunder/R2API/pull/307)
 * [Fix SoundAPI throwing on dedicated server](https://github.com/risk-of-thunder/R2API/pull/306)
+* [Added VisualTempAPI](https://github.com/risk-of-thunder/R2API/pull/313)
 
 **3.0.59**
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 * [EliteAPI now exposes the default elite tiers array (through VanillaEliteTiers) before any changes are made to it for modder that want to change the vanilla elite tiers. Also, adding to the custom elite tier array now by default insert based on the cost multiplier of the elite tier.](https://github.com/risk-of-thunder/R2API/pull/308)
 * [RecalculateStatsAPI now warns modders that the submodule could be not loaded](https://github.com/risk-of-thunder/R2API/pull/307)
 * [Fix SoundAPI throwing on dedicated server](https://github.com/risk-of-thunder/R2API/pull/306)
-* [Added VisualTempAPI](https://github.com/risk-of-thunder/R2API/pull/313)
+* [Added TempVisualEffectAPI](https://github.com/risk-of-thunder/R2API/pull/313)
 
 **3.0.59**
 


### PR DESCRIPTION
Allows for adding custom TemporaryVisualEffects (TVEs) to every CharacterBody spawned that functions the same as vanilla TVEs.

Use `TempVisualEffectAPI.AddTemporaryVisualEffect()` before `WhenContentPackLoaded` (usually in mod's `Awake()`) to add a custom TVE to a static List and Dictionary. Custom TVE list is copied into `R2APITVEController` components which are added on `CharacterBody.onBodyStartGlobal`. Hooks onto CharacterBody's `UpdateAllTemporaryVisualEffects()` and `UpdateSingleTemporaryVisualEffect` to update custom TVEs just like vanilla ones. Compares the latter method's `resourceString` input with the dictionary's string key in order to instantiate the correct TVE GameObject.

`AddTemporaryVisualEffect()` requires a CharacterBody input, bool output delegate parameter. This delegate is used for the 'active' of the TVE - if it returns true, the TVE will be created/activated for the instance.

Example use:
![2vkS6zR](https://user-images.githubusercontent.com/58179315/143333826-3bc968bc-62a4-4487-a15d-cacde5d369ce.png)
