### PR TITLE
Fix MusicAPI

### DIFF
--- a/R2API/SoundAPI.cs
+++ b/R2API/SoundAPI.cs
@@ -497,9 +497,6 @@ namespace R2API {
 
             private static bool GameMusicBankInUse;
 
-            private static SceneDef LastSceneDef;
-            private static MusicController MusicControllerInstance;
-
             private static bool IsVanillaMusicTrack(MusicTrackDef self) =>
                 self && self.soundBank != null && self.soundBank.Name == GameMusicBankName;
 
@@ -513,9 +510,16 @@ namespace R2API {
                 On.RoR2.MusicController.Start += EnableCustomMusicSystems;
                 SceneCatalog.onMostRecentSceneDefChanged += OnSceneChangeReplaceMusic;
 
-                IL.RoR2.MusicController.LateUpdate += PauseMusicIfGameMusicBankNotInUse;
+                On.RoR2.MusicController.UpdateState += IsGameMusicBankInUse;
 
-                IL.RoR2.MusicTrackOverride.PickMusicTrack += CheckIfTrackOverrideIsVanilla;
+                IL.RoR2.MusicController.LateUpdate += PauseMusicIfGameMusicBankNotInUse;
+            }
+
+            private static void IsGameMusicBankInUse(On.RoR2.MusicController.orig_UpdateState orig, MusicController self) {
+                orig(self);
+
+                if (self && self.currentTrack)
+                    GameMusicBankInUse = IsVanillaMusicTrack(self.currentTrack);
             }
 
             internal static void UnsetHooks() {
@@ -524,9 +528,9 @@ namespace R2API {
                 On.RoR2.MusicController.Start -= EnableCustomMusicSystems;
                 SceneCatalog.onMostRecentSceneDefChanged -= OnSceneChangeReplaceMusic;
 
-                IL.RoR2.MusicController.LateUpdate -= PauseMusicIfGameMusicBankNotInUse;
+                On.RoR2.MusicController.UpdateState -= IsGameMusicBankInUse;
 
-                IL.RoR2.MusicTrackOverride.PickMusicTrack -= CheckIfTrackOverrideIsVanilla;
+                IL.RoR2.MusicController.LateUpdate -= PauseMusicIfGameMusicBankNotInUse;
             }
 
             private static bool AddCustomMusicDatas(Func<bool> orig) {
@@ -584,9 +588,6 @@ namespace R2API {
                 foreach (var playMusicSystemEventName in PlayMusicSystemEventNames) {
                     AkSoundEngine.PostEvent(playMusicSystemEventName, self.gameObject);
                 }
-
-                MusicControllerInstance = self;
-                GameMusicBankInUse = true;
             }
 
             private static void OnSceneChangeReplaceMusic(SceneDef sceneDef) {
@@ -595,10 +596,6 @@ namespace R2API {
                 }
 
                 ReplaceSceneMusicWithCustomTracks(sceneDef);
-
-                UpdateIsGameMusicBankInUse(sceneDef);
-
-                LastSceneDef = sceneDef;
             }
 
             private static void ReplaceSceneMusicWithCustomTracks(SceneDef sceneDef) {
@@ -612,11 +609,6 @@ namespace R2API {
                         var selectedTracks = customTracks[RoR2Application.rng.RangeInt(0, customTracks.Count)];
 
                         if (selectedTracks.MainTrack) {
-                            if (IsVanillaMusicTrack(sceneDef.mainTrack) ||
-                                LastSceneDef && IsVanillaMusicTrack(LastSceneDef.mainTrack)) {
-                                GameMusicBankInUse = false;
-                            }
-
                             sceneDef.mainTrack = selectedTracks.MainTrack;
                         }
                         if (selectedTracks.BossTrack) {
@@ -626,48 +618,21 @@ namespace R2API {
                 }
             }
 
-            private static void UpdateIsGameMusicBankInUse(SceneDef sceneDef) {
-                if (IsVanillaMusicTrack(sceneDef.mainTrack) ||
-                    IsVanillaMusicTrack(sceneDef.bossTrack)) {
-                    GameMusicBankInUse = true;
-                }
-            }
-
+            /// <summary>
+            /// Needed otherwise the vanilla music system plays the default track of the bank on top of the custom music
+            /// </summary>
             private static void PauseMusicIfGameMusicBankNotInUse(ILContext il) {
                 var cursor = new ILCursor(il);
 
-                static bool PauseMusicIfGameMusicBankNotInUse(bool b) {
-                    if (b)
-                        return true;
+                static bool PauseMusicIfGameMusicBankNotInUse(bool shouldPauseMusic) {
+                    if (shouldPauseMusic)
+                        return shouldPauseMusic;
 
                     return !GameMusicBankInUse;
                 }
 
                 cursor.GotoNext(i => i.MatchStloc(out _));
                 cursor.EmitDelegate<Func<bool, bool>>(PauseMusicIfGameMusicBankNotInUse);
-            }
-
-            private static void CheckIfTrackOverrideIsVanilla(ILContext il) {
-                var cursor = new ILCursor(il);
-
-                static MusicTrackDef CheckIfTrackOverrideIsVanilla(MusicTrackDef overrideTrack) {
-                    if (overrideTrack) {
-                        GameMusicBankInUse = IsVanillaMusicTrack(overrideTrack);
-                    }
-
-                    return overrideTrack;
-                }
-
-                if (cursor.TryGotoNext(
-                    i => i.MatchLdfld<MusicTrackOverride>(nameof(MusicTrackOverride.track)),
-                    i => i.MatchStindRef())) {
-                    cursor.Index++;
-                    cursor.EmitDelegate<Func<MusicTrackDef, MusicTrackDef>>(CheckIfTrackOverrideIsVanilla);
-                }
-                else {
-                    R2API.Logger.LogError("Failed finding IL Instructions. " +
-                        $"Aborting {nameof(MusicTrackOverride.PickMusicTrack)} IL Hook");
-                }
             }
 
             /// <summary>
@@ -772,13 +737,9 @@ namespace R2API {
                 foreach (var scene in SceneCatalog.allSceneDefs) {
                     if (scene.mainTrack == customTracks.MainTrack) {
                         scene.mainTrack = SceneDefToOriginalTracks[scene].MainTrack;
-
-                        GameMusicBankInUse = true;
                     }
                     if (scene.bossTrack == customTracks.BossTrack) {
                         scene.bossTrack = SceneDefToOriginalTracks[scene].BossTrack;
-
-                        GameMusicBankInUse = true;
                     }
                 }
             }


### PR DESCRIPTION
The bool that was responsible for letting the vanilla music bank or not was not always properly synced.
Now check in Update to be always synced and simplify a lot the overall logic

this PR cancel https://github.com/risk-of-thunder/R2API/pull/318