### PR TITLE
UnlockableAPI Improvements

### DIFF
--- a/R2API/UnlockableAPI.cs
+++ b/R2API/UnlockableAPI.cs
@@ -6,6 +6,7 @@ using RoR2.Achievements;
 using RoR2.ContentManagement;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 using BF = System.Reflection.BindingFlags;
@@ -178,8 +179,7 @@ namespace R2API {
             );
 
             void AddOurDefs(List<AchievementDef> achievementDefs, Dictionary<string, AchievementDef> stringToAchievementDef, List<string> identifiers) {
-                for (var i = 0; i < Unlockables.Count; i++) {
-                    var unlockable = Unlockables[i];
+                for (var i = 0; i < Achievements.Count; i++) {
                     var achievement = Achievements[i];
 
                     if (achievement is null) {
@@ -232,6 +232,31 @@ namespace R2API {
         }
         public static UnlockableDef AddUnlockable(Type unlockableType, UnlockableDef unlockableDef) {
             return AddUnlockable(unlockableType, null, unlockableDef);
+        }
+
+        /// <summary>
+        /// Adds an AchievementDef to the list of achievements to add to the game
+        /// </summary>
+        /// <param name="achievementDef">The achievementDef to add</param>
+        /// <returns>True if succesful, false otherwise</returns>
+        public static bool AddAchievement(AchievementDef achievementDef) {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(UnlockableAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(UnlockableAPI)})]");
+            }
+            var identifiers = Achievements.Select(achievementDef => achievementDef.identifier);
+            try {
+                if(identifiers.Contains(achievementDef.identifier)) {
+                    throw new InvalidOperationException($"The achievement identifier '{achievementDef.identifier}' is already used by another mod.");
+                }
+                else {
+                    Achievements.Add(achievementDef);
+                    return true;
+                }
+            }
+            catch (Exception e){
+                R2API.Logger.LogError($"An error has occured while trying to add a new AchievementDef: {e}");
+                return false;
+            }
         }
 
         /// <summary>

--- a/R2API/UnlockableAPI.cs
+++ b/R2API/UnlockableAPI.cs
@@ -227,6 +227,12 @@ namespace R2API {
         {
             return AddUnlockable<TUnlockable>(null, unlockableDef);
         }
+        public static UnlockableDef AddUnlockable(Type unlockableType, Type serverTrackerType) {
+            return AddUnlockable(unlockableType, serverTrackerType, null);
+        }
+        public static UnlockableDef AddUnlockable(Type unlockableType, UnlockableDef unlockableDef) {
+            return AddUnlockable(unlockableType, null, unlockableDef);
+        }
 
         /// <summary>
         /// Add an unlockable tied to an achievement.
@@ -236,13 +242,24 @@ namespace R2API {
         /// <param name="serverTrackerType">Type that inherits from BaseServerAchievement for achievements that the server needs to track</param>
         /// <param name="unlockableDef">For UnlockableDefs created in advance. Leaving null will generate an UnlockableDef instead.</param>
         /// <returns></returns>
-        public static UnlockableDef AddUnlockable<TUnlockable>(Type serverTrackerType = null, UnlockableDef unlockableDef = null) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new()
-        {
+        public static UnlockableDef AddUnlockable<TUnlockable>(Type serverTrackerType = null, UnlockableDef unlockableDef = null) where TUnlockable : BaseAchievement, IModdedUnlockableDataProvider, new() {
+            return AddUnlockable(typeof(TUnlockable), serverTrackerType, unlockableDef);
+        }
+
+        /// <summary>
+        /// Add an unlockable tied to an achievement.
+        /// For an example usage check <see href="https://github.com/ArcPh1r3/HenryTutorial/blob/master/HenryMod/Modules/Achievements/HenryMasteryAchievement.cs">rob repository</see>
+        /// </summary>
+        /// <param name="unlockableType">Class that inherits from BaseAchievement and implements IModdedUnlockableDataProvider</typeparam>
+        /// <param name="serverTrackerType">Type that inherits from BaseServerAchievement for achievements that the server needs to track</param>
+        /// <param name="unlockableDef">For UnlockableDefs created in advance. Leaving null will generate an UnlockableDef instead.</param>
+        /// <returns></returns>
+        public static UnlockableDef AddUnlockable(Type unlockableType, Type serverTrackerType = null, UnlockableDef unlockableDef = null) {
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(UnlockableAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(UnlockableAPI)})]");
             }
 
-            var instance = new TUnlockable();
+            var instance = Activator.CreateInstance(unlockableType) as IModdedUnlockableDataProvider;
 
             if (_unlockableCatalogInitialized) {
                 throw new InvalidOperationException($"Too late ! Tried to add unlockable: {instance.UnlockableIdentifier} after the unlockable list was created");


### PR DESCRIPTION
# UnlockableAPI Improvements

This pull request has the commits found in King Enderbrine's "Additional overloads for AddUnlockable" #317, Information on said parts can be found on his pull request.

The main improvement i've done to UnlockableAPI is in the form of the AddAchievement method, which allows the end user to add an already pre-made AchievementDef to the game.

This is mainly useful on systems where the Unlockables are done thru different methods outside of the default r2api one, such as in MSU's [MSUnlockableDef](https://github.com/TeamMoonstorm/MoonstormSharedUtils/blob/main/MSU/ScriptableObjects/MSUnlockableDef.cs) (Which handles the creation of the achievementDef automatically)