### PR TITLE
RecalculateStatsAPI: Add Extra stat customization points.

### DIFF
--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -184,7 +184,7 @@ namespace R2API {
         private static void ModifyCurseStat(ILCursor c) {
             c.Index = 0;
 
-            bool ILFound = c.TryGotoNext(
+            bool ILFound = c.TryGotoNext( MoveType.After,
         x => x.MatchLdarg(0),
                 x => x.MatchLdcR4(1),
                 x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.cursePenalty))

--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -61,7 +61,7 @@ namespace R2API {
             /// <summary>Added reduction multiplier to move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd / MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
             public float moveSpeedReductionMultAdd = 0f;
 
-            /// <summary>Added to the direct multiplier to jump power. JUMP_POWER ~ BASE_JUMP_POWER * (JUMP_POWER_MULT + jumpPowerMultAdd)</summary>
+            /// <summary>Added to the direct multiplier to jump power. JUMP_POWER ~ (BASE_JUMP_POWER + baseJumpPowerAdd) * (JUMP_POWER_MULT + jumpPowerMultAdd)</summary>
             public float jumpPowerMultAdd = 0f;
 
             /// <summary>Added to the direct multiplier to base damage. DAMAGE ~ (BASE_DAMAGE + baseDamageAdd) * (DAMAGE_MULT + damageMultAdd).</summary>
@@ -105,6 +105,9 @@ namespace R2API {
 
             /// <summary>Added to the direct multiplier to base shield</summary>
             public float shieldMultAdd = 0f;
+
+            /// <summary>Added to base jump power. JUMP_POWER ~ (BASE_JUMP_POWER + baseJumpPowerAdd)* (JUMP_POWER_MULT + jumpPowerMultAdd)</summary>
+            public float baseJumpPowerAdd = 0f;
         }
 
         /// <summary>
@@ -352,7 +355,7 @@ namespace R2API {
 
             if (ILFound) {
                 c.EmitDelegate<Func<float, float>>((origJumpPower) => {
-                    return origJumpPower * (1 + StatMods.jumpPowerMultAdd);
+                    return (origJumpPower + StatMods.baseJumpPowerAdd) * (1 + StatMods.jumpPowerMultAdd);
                 });
             }
             else {


### PR DESCRIPTION
Adds more things to RecalculateStatsAPI.
Currently the following:
 Curse
 Shield Multiplier
 All manner of Cooldown Reduction
 Flat Jump Power (someone probably has a use for this,somewhere)
 Level Scaling (How much each level matters,rather than modifying the current level,since that can already be changed)
 Root,the implementation of which might have been better,but I hope that the way it is ends up working well.

These are all seperate commits for convenience reasons.While I haven't tested them seperately all the commits should be buildable by themselves.
 