### PR TITLE
Null checking the associated buff belonging to a DOT

### DIFF
--- a/R2API/DotAPI.cs
+++ b/R2API/DotAPI.cs
@@ -94,7 +94,8 @@ namespace R2API {
             Array.Resize(ref _customDotVisuals, _customDotVisuals.Length + 1);
             _customDotVisuals[customArrayIndex] = customDotVisual;
 
-            R2API.Logger.LogInfo($"Custom Dot (Index : {dotDefIndex}) that uses Buff : {dotDef.associatedBuff.name} added");
+            string addedDot = dotDef.associatedBuff != null ? $"Custom Dot (Index: {dotDefIndex}) that uses Buff : {dotDef.associatedBuff.name} added" : $"Custom Dot (Index: {dotDefIndex}) with no associated Buff added";
+            R2API.Logger.LogInfo(addedDot);
             return (DotController.DotIndex)dotDefIndex;
         }
 
@@ -105,12 +106,12 @@ namespace R2API {
         /// <param name="interval"></param>
         /// <param name="damageCoefficient"></param>
         /// <param name="colorIndex"></param>
-        /// <param name="associatedBuff"></param>
+        /// <param name="associatedBuff">The buff associated with the DOT, can be null</param>
         /// <param name="customDotBehaviour"></param>
         /// <param name="customDotVisual"></param>
         /// <returns></returns>
         public static DotController.DotIndex RegisterDotDef(float interval, float damageCoefficient,
-            DamageColorIndex colorIndex, BuffDef associatedBuff, CustomDotBehaviour customDotBehaviour = null,
+            DamageColorIndex colorIndex, BuffDef associatedBuff = null, CustomDotBehaviour customDotBehaviour = null,
             CustomDotVisual customDotVisual = null) {
             var dotDef = new DotController.DotDef {
                 associatedBuff = associatedBuff,

--- a/R2API/DotAPI.cs
+++ b/R2API/DotAPI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil.Cil;
@@ -94,8 +94,13 @@ namespace R2API {
             Array.Resize(ref _customDotVisuals, _customDotVisuals.Length + 1);
             _customDotVisuals[customArrayIndex] = customDotVisual;
 
-            string addedDot = dotDef.associatedBuff != null ? $"Custom Dot (Index: {dotDefIndex}) that uses Buff : {dotDef.associatedBuff.name} added" : $"Custom Dot (Index: {dotDefIndex}) with no associated Buff added";
-            R2API.Logger.LogInfo(addedDot);
+            if (dotDef.associatedBuff != null) {
+                R2API.Logger.LogInfo($"Custom Dot (Index: {dotDefIndex}) that uses Buff : {dotDef.associatedBuff.name} added");
+            } else {
+                R2API.Logger.LogInfo($"Custom Dot (Index: {dotDefIndex}) with no associated Buff added");
+            }
+            
+            
             return (DotController.DotIndex)dotDefIndex;
         }
 


### PR DESCRIPTION
Fixes issue number #324, Simply checks if the BuffDef associated to the DOT exists, if not, continues adding it to the dot catalog as normal.

Debug.LogInfo message properly displays this change, with a new message that simply says "Custom Dot (Index: {dotDefIndex}) with no associated Buff added".

Also applied the same changes to the unrolled version, associatedBuff is now null by default and its not mandatory-