### PR TITLE
Thunderstore Release with GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - run: dotnet build . --configuration Release --output ./ReleaseOutput
     - name: Cleanup Release Output
       run: |
-        find ./ReleaseOutput ! -name *.dll ! -name *.xml -type f -delete
+        find ./ReleaseOutput ! -name R2API.dll ! -name R2API.xml -type f -delete
     - name: Publish to thunderstore.io
       uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Get the version from the release github tag
-      id: get-version
-      run: echo ::set-output name=ver::${GITHUB_REF#refs/tags/}
-    - name: Update version
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.7
+      with:
+        versionSpec: '5.x'
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v0.9.7
+    - name: Update versions
       run: |
-        sed -i -E "s/(PluginVersion\s*=\s*)\"0.0.1\"/\1\"${{steps.get-version.outputs.ver}}\"/" R2API/R2API.cs
-    - name: Run Tests
-      run: |
-        dotnet test
+        sed -i -E "s/(PluginVersion\s*=\s*)\"0.0.1\"/\1\"$GitVersion_SemVer\"/" R2API/R2API.cs
     - uses: actions/setup-dotnet@v1.7.2
     - run: dotnet build . --configuration Release --output ./ReleaseOutput
     - name: Cleanup Release Output
@@ -30,5 +30,5 @@ jobs:
     - name: Publish to thunderstore.io
       uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
       with:
-        package-version: ${{steps.get-version.outputs.ver}}
+        package-version: $GitVersion_SemVer
         token: ${{ secrets.TCLI_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,4 @@ jobs:
     - name: Publish to thunderstore.io
       uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
       with:
-        package-version: ${{steps.get-version.outputs.ver}}
-        token: ${{ secrets.TCLI_AUTH_TOKEN }}
+        args: --package-version ${{steps.get-version.outputs.ver}} --token ${{ secrets.TCLI_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Thunderstore Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Thunderstore Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  
+    steps:
+          
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get the version from the release github tag
+      id: get-version
+      run: echo ::set-output name=ver::${GITHUB_REF#refs/tags/}
+    - name: Update version
+      run: |
+        sed -i -E "s/(PluginVersion\s*=\s*)\"0.0.1\"/\1\"${{steps.get-version.outputs.ver}}\"/" R2API/R2API.cs
+    - name: Run Tests
+      run: |
+        dotnet test
+    - uses: actions/setup-dotnet@v1.7.2
+    - run: dotnet build . --configuration Release --output ./ReleaseOutput
+    - name: Cleanup Release Output
+      run: |
+        find ./ReleaseOutput ! -name *.dll ! -name *.xml -type f -delete
+    - name: Publish to thunderstore.io
+      uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
+      with:
+        package-version: ${{steps.get-version.outputs.ver}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
       uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
       with:
         package-version: ${{steps.get-version.outputs.ver}}
+        token: ${{ secrets.TCLI_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,5 @@ jobs:
     - name: Publish to thunderstore.io
       uses: xiaoxiao921/thunderstore-cli@0.1.2-alpha.1
       with:
-        args: --package-version ${{steps.get-version.outputs.ver}} --token ${{ secrets.TCLI_AUTH_TOKEN }}
+        package-version: ${{steps.get-version.outputs.ver}}
+        token: ${{ secrets.TCLI_AUTH_TOKEN }}

--- a/R2API.sln
+++ b/R2API.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28606.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API", "R2API\R2API.csproj", "{2F8A40CC-6D15-486D-B689-0A7A472DB89E}"
 EndProject
@@ -12,6 +12,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		manifest.json = manifest.json
 		README.md = README.md
+		thunderstore.toml = thunderstore.toml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{68B36E72-17D9-4D17-8C52-DB612CF24001}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{CFD6888C-DCB1-4D72-9234-02527497750D}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\main.yml = .github\workflows\main.yml
+		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
 Global
@@ -31,6 +40,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{68B36E72-17D9-4D17-8C52-DB612CF24001} = {3A26DDA8-2697-4D64-962B-DB9E2DC00EF6}
+		{CFD6888C-DCB1-4D72-9234-02527497750D} = {68B36E72-17D9-4D17-8C52-DB612CF24001}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25394121-1456-4FD9-A853-060A4DBBB74C}

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -22,5 +22,5 @@ target = "./plugins/R2API"
 
 [publish]
 repository = "https://thunderstore.dev"
-communities = []
+communities = ["riskofrain2"]
 categories = []

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -1,0 +1,26 @@
+[config]
+schemaVersion = "0.0.1"
+
+[package]
+namespace = "xiaoxiao921"
+name = "R2API"
+versionNumber = "0.0.1"
+description = "A modding API for Risk of Rain 2"
+websiteUrl = "https://github.com/risk-of-thunder/R2API"
+containsNsfwContent = false
+
+[package.dependencies]
+
+[build]
+icon = "./icon.png"
+readme = "./README.md"
+outdir = "./build"
+
+[[build.copy]]
+source = "./ReleaseOutput"
+target = "./plugins/R2API"
+
+[publish]
+repository = "https://thunderstore.io"
+communities = []
+categories = []

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -2,7 +2,7 @@
 schemaVersion = "0.0.1"
 
 [package]
-namespace = "xiaoxiao921"
+namespace = "tristanmcpherson"
 name = "R2API"
 versionNumber = "0.0.1"
 description = "A modding API for Risk of Rain 2"
@@ -10,6 +10,8 @@ websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 
 [package.dependencies]
+bbepis-BepInExPack = "5.4.9"
+RiskofThunder-HookGenPatcher = "1.2.1"
 
 [build]
 icon = "./icon.png"
@@ -21,6 +23,6 @@ source = "./ReleaseOutput"
 target = "./plugins/R2API"
 
 [publish]
-repository = "https://thunderstore.dev"
+repository = "https://thunderstore.io"
 communities = ["riskofrain2"]
-categories = []
+categories = ["libraries"]

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -21,6 +21,6 @@ source = "./ReleaseOutput"
 target = "./plugins/R2API"
 
 [publish]
-repository = "https://thunderstore.io"
+repository = "https://thunderstore.dev"
 communities = []
 categories = []


### PR DESCRIPTION
This PR allows the upload of a thunderstore package when a Github Release is made or when the action is manually triggered by an authorized user.

For this to work a repository secret must be added, called `TCLI_AUTH_TOKEN` which must contains the thunderstore api token delivered when completing the following : https://github.com/thunderstore-io/thunderstore-cli/wiki#authentication