### PR TITLE
Allow default idrs opt out

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -213,12 +213,7 @@ namespace R2API {
             var characterModel = bodyPrefab.GetComponentInChildren<CharacterModel>();
             if (characterModel) {
                 DoNotAutoIDRSFor(bodyPrefab.name);
-                DoNotAutoIDRSFor(characterModel);
             }
-        }
-
-        public static void DoNotAutoIDRSFor(CharacterModel characterModel) {
-            DoNotAutoIDRSFor(characterModel.name);
         }
         #endregion
 

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -205,10 +205,18 @@ namespace R2API {
         #endregion Add Methods
 
         #region Other Modded Content Support
+        /// <summary>
+        /// Prevents bodies and charactermodels matching this name from having nonspecific item display rules applied to them
+        /// </summary>
+        /// <param name="bodyPrefabOrCharacterModelName">The string to match</param>
         public static void DoNotAutoIDRSFor(string bodyPrefabOrCharacterModelName) {
             noDefaultIDRSCharacterList.Add(bodyPrefabOrCharacterModelName);
         }
 
+        /// <summary>
+        /// Prevent prefabs with this name having nonspecific item display rules applied to them
+        /// </summary>
+        /// <param name="bodyPrefab">The body prefab to match</param>
         public static void DoNotAutoIDRSFor(GameObject bodyPrefab) {
             var characterModel = bodyPrefab.GetComponentInChildren<CharacterModel>();
             if (characterModel) {

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -204,7 +204,7 @@ namespace R2API {
 
         #endregion Add Methods
 
-        #region otherModdedContentSupport
+        #region Other Modded Content Support
         public static void DoNotAutoIDRSFor(string bodyPrefabOrCharacterModelName) {
             noDefaultIDRSCharacterList.Add(bodyPrefabOrCharacterModelName);
         }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Note that such builds may be **unstable**.
 The most recent changelog can always be found on the [GitHub](https://github.com/risk-of-thunder/R2API/blob/master/Archived%20changelogs.md). In this readme, only the most recent *minor* version will have a changelog.
 
 **Current**
+* [Allow character mods to opt out from default item display rules](https://github.com/risk-of-thunder/R2API/pull/330)
+
+**3.0.71**
 * [ItemAPI now warns that ItemDef/EquipmentDef.pickupModelPrefab should have an ItemDisplay attached to them when they have ParentedPrefab display rules linked to them](https://github.com/risk-of-thunder/R2API/pull/311)
 * [EliteAPI now exposes the default elite tiers array (through VanillaEliteTiers) before any changes are made to it for modder that want to change the vanilla elite tiers. Also, adding to the custom elite tier array now by default insert based on the cost multiplier of the elite tier.](https://github.com/risk-of-thunder/R2API/pull/308)
 * [RecalculateStatsAPI now warns modders that the submodule could be not loaded](https://github.com/risk-of-thunder/R2API/pull/307)


### PR DESCRIPTION
Some character mods have exported their model really tiny (or large) and this messes with default IDRS on those characters. The resulting default rulesets will blow up making the game unplayable when such an item is picked up.

So while those mods should really fix their model, it's a minor effort on our end to let them opt out of being assigned default rulesets.

(Also stops allocating memory bodyprefab * 2 * (items+equipment) times for `.name` and instead just is bodyprefab * 2 allocations)