### PR TITLE
check if args are null for R2APISubmoduleDependency

### DIFF
--- a/R2API/Utils/APISubmodule.cs
+++ b/R2API/Utils/APISubmodule.cs
@@ -74,8 +74,12 @@ namespace R2API.Utils {
 
             void AddModuleToSet(IEnumerable<CustomAttributeArgument> arguments) {
                 foreach (var arg in arguments) {
-                    foreach (var stringElement in (CustomAttributeArgument[])arg.Value) {
-                        _moduleSet.Add((string)stringElement.Value);
+                    if (arg.Value != null) {
+                        foreach (var stringElement in (CustomAttributeArgument[])arg.Value) {
+                            if (stringElement.Value != null) {
+                                _moduleSet.Add((string)stringElement.Value);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
a modder could incorrectly have their attribute with a null parameter in it

fix https://github.com/risk-of-thunder/R2API/issues/315