### PR TITLE
Don't use cecil backend for monomod

### DIFF
--- a/R2API/R2API.cs
+++ b/R2API/R2API.cs
@@ -47,8 +47,6 @@ namespace R2API {
             AddHookLogging();
             CheckForIncompatibleAssemblies();
 
-            Environment.SetEnvironmentVariable("MONOMOD_DMD_TYPE", "Cecil");
-
             if (Environment.GetEnvironmentVariable("R2API_DEBUG") == "true") {
                 EnableDebug();
             }


### PR DESCRIPTION
Doesnt seem to be needed anymore, add extra init time and seems to be causing fps issue on some linux install https://github.com/risk-of-thunder/R2API/issues/314