### PR TITLE
RecalculateStatsAPI: Shield Documentation Fix + New Crit Damage Modifier

### DIFF
--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -112,8 +112,8 @@ namespace R2API {
             /// <summary>Amount of Root effects currently applied. MOVE_SPEED ~ (moveSpeedRootCount > 0) ? 0 : MOVE_SPEED </summary>
             public int moveSpeedRootCount = 0;
 
-            /// <summary>Added to the direct multiplier to crit damage. CRIT_DAMAGE ~ DAMAGE * (BASE_CRIT_MULT + critDamageAdd) </summary>
-            public int critDamageAdd = 0;
+            /// <summary>Added to the direct multiplier to crit damage. CRIT_DAMAGE ~ DAMAGE * (BASE_CRIT_MULT + critDamageMultAdd) </summary>
+            public int critDamageMultAdd = 0;
         }
 
         /// <summary>
@@ -355,16 +355,12 @@ namespace R2API {
                 x => x.MatchLdloc(out locOrigCrit),
                 x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.crit)))
             ) && c.TryGotoPrev( MoveType.After,
-                x => x.MatchLdloc(out _),
-                x => x.MatchConvR4(),
-                x => x.MatchMul(),
-                x => x.MatchAdd(),
                 x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.critMultiplier)))
                 );
 
             if (ILFound) {
                 c.Index--;
-                c.EmitDelegate<Func<float,float>>((origCritMult) => {return origCritMult + StatMods.critDamageAdd;});
+                c.EmitDelegate<Func<float,float>>((origCritMult) => {return origCritMult + StatMods.critDamageMultAdd;});
                 c.GotoNext(MoveType.After,x => x.MatchStloc(locOrigCrit));
                 c.Emit(OpCodes.Ldloc, locOrigCrit);
                 c.EmitDelegate<Func<float, float>>((origCrit) => { return origCrit + StatMods.critAdd; });

--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -40,7 +40,7 @@ namespace R2API {
             /// <summary>Added to base health. MAX_HEALTH ~ (BASE_HEALTH + baseHealthAdd) * (HEALTH_MULT + healthMultAdd).</summary>
             public float baseHealthAdd = 0f;
 
-            /// <summary>Added to base shield. MAX_SHIELD ~ BASE_SHIELD + baseShieldAdd.</summary>
+            /// <summary>Added to base shield. MAX_SHIELD ~ (BASE_SHIELD + baseShieldAdd) * (SHIELD_MULT + shieldMultAdd).</summary>
             public float baseShieldAdd = 0f;
 
             /// <summary>Added to the direct multiplier to base health regen. HEALTH_REGEN ~ (BASE_REGEN + baseRegenAdd) * (REGEN_MULT + regenMultAdd).</summary>
@@ -100,7 +100,7 @@ namespace R2API {
             /// <summary> (Special) Added to the direct multiplier to cooldown timers. COOLDOWN ~ BASE_COOLDOWN * (BASE_COOLDOWN_MULT + cooldownMultAdd + specialCooldownMultAdd) - (BASE_FLAT_REDUCTION + cooldownReductionAdd)</summary>
             public float specialCooldownMultAdd = 0f;
 
-            /// <summary>Added to the direct multiplier to base shield</summary>
+            /// <summary>Added to the direct multiplier to shields MAX_SHIELD ~ (BASE_SHIELD + baseShieldAdd) * (SHIELD_MULT + shieldMultAdd).</summary>
             public float shieldMultAdd = 0f;
 
             /// <summary>Added to base jump power. JUMP_POWER ~ (BASE_JUMP_POWER + baseJumpPowerAdd)* (JUMP_POWER_MULT + jumpPowerMultAdd)</summary>

--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -111,6 +111,9 @@ namespace R2API {
 
             /// <summary>Amount of Root effects currently applied. MOVE_SPEED ~ (moveSpeedRootCount > 0) ? 0 : MOVE_SPEED </summary>
             public int moveSpeedRootCount = 0;
+
+            /// <summary>Added to the direct multiplier to crit damage. CRIT_DAMAGE ~ DAMAGE * (BASE_CRIT_MULT + critDamageAdd) </summary>
+            public int critDamageAdd = 0;
         }
 
         /// <summary>
@@ -350,9 +353,19 @@ namespace R2API {
             bool ILFound = c.TryGotoNext(
                 x => x.MatchLdarg(0),
                 x => x.MatchLdloc(out locOrigCrit),
-                x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.crit))));
+                x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.crit)))
+            ) && c.TryGotoPrev( MoveType.After,
+                x => x.MatchLdloc(out _),
+                x => x.MatchConvR4(),
+                x => x.MatchMul(),
+                x => x.MatchAdd(),
+                x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.critMultiplier)))
+                );
 
             if (ILFound) {
+                c.Index--;
+                c.EmitDelegate<Func<float,float>>((origCritMult) => {return origCritMult + StatMods.critDamageAdd;});
+                c.GotoNext(MoveType.After,x => x.MatchStloc(locOrigCrit));
                 c.Emit(OpCodes.Ldloc, locOrigCrit);
                 c.EmitDelegate<Func<float, float>>((origCrit) => { return origCrit + StatMods.critAdd; });
                 c.Emit(OpCodes.Stloc, locOrigCrit);

--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 * [NetworkingAPI now has Send overloads for sending to specific network connections. Also have some documentation now](https://github.com/risk-of-thunder/R2API/pull/333)
 * [Allow character mods to opt out from default item display rules](https://github.com/risk-of-thunder/R2API/pull/330)
 * [Make dotAPI parts accessible for modders](https://github.com/risk-of-thunder/R2API/pull/339)
+* [RecalculateStatsAPI can now modify Critical Hit Damage](https://github.com/risk-of-thunder/R2API/pull/346)


### PR DESCRIPTION
Adds a crit damage modifier to RecalculateStatsAPI,since the newest update moved the relevant values from OnHit to the Body.
Also includes a quick fix to the documentation/summary comments on the shield modifiers, since they previously lacked a correct formula which has caused at least one case of someone misidentifying what shieldMultAdd does, my bad for missing that one last time.