### PR TITLE
Added SerializableDifficultyDef

### DIFF
--- a/R2API/ContentManagement/ContentAddition.cs
+++ b/R2API/ContentManagement/ContentAddition.cs
@@ -222,7 +222,7 @@ namespace R2API {
             if (CatalogBlockers.GetAvailability<ItemDef>()) {
                 R2API.Logger.LogInfo($"Assembly {asm.GetName().Name} is adding an {itemDef} via {nameof(ContentAddition)}.{nameof(AddItemDef)}()" +
                     $"The assembly should ideally add them via {nameof(ItemAPI)} so that they can use ItemAPI's IDRS systems, adding anyways.");
-                ItemAPI.Add(new CustomItem(itemDef, Array.Empty<ItemDisplayRule>()));
+                ItemAPI.AddInternal(new CustomItem(itemDef, Array.Empty<ItemDisplayRule>()), asm);
                 return true;
             }
             RejectContent(itemDef, asm, "ItemDef", "but the ItemCatalog has already initialized!");
@@ -289,7 +289,7 @@ namespace R2API {
             if (CatalogBlockers.GetAvailability<EquipmentDef>()) {
                 R2API.Logger.LogInfo($"Assembly {asm.GetName().Name} is adding an {equipmentDef} via {nameof(ContentAddition)}.{nameof(AddEquipmentDef)}()" +
                     $"The assembly should ideally add them via {nameof(ItemAPI)} so that they can use ItemAPI's IDRS systems, adding anyways.");
-                ItemAPI.Add(new CustomEquipment(equipmentDef, Array.Empty<ItemDisplayRule>()));
+                ItemAPI.AddInternal(new CustomEquipment(equipmentDef, Array.Empty<ItemDisplayRule>()), asm);
                 return true;
             }
             RejectContent(equipmentDef, asm, "EquipmentDef", "but the EquipmnetCatalog has already initialized!");
@@ -329,7 +329,7 @@ namespace R2API {
             if (CatalogBlockers.GetAvailability<EliteDef>()) {
                 R2API.Logger.LogInfo($"Assembly {asm.GetName().Name} is adding an {eliteDef} via {nameof(ContentAddition)}.{nameof(AddEliteDef)}()" +
                     $"The assembly should ideally add them via {nameof(EliteAPI)} so that they can use EliteAPI's elite tier systems, adding the elite anyways as Tier1 elite.");
-                EliteAPI.Add(new CustomElite(eliteDef, new List<CombatDirector.EliteTierDef> { EliteAPI.VanillaEliteTiers[1], EliteAPI.VanillaEliteTiers[2] }));
+                EliteAPI.AddInternal(new CustomElite(eliteDef, new List<CombatDirector.EliteTierDef> { EliteAPI.VanillaEliteTiers[1], EliteAPI.VanillaEliteTiers[2] }), asm);
                 return true;
             }
             RejectContent(eliteDef, asm, "EliteDef", "but the EliteCatalog has already initialized!");

--- a/R2API/DifficultyAPI.cs
+++ b/R2API/DifficultyAPI.cs
@@ -1,3 +1,4 @@
+using R2API.ScriptableObjects;
 using R2API.Utils;
 using RoR2;
 using System;
@@ -91,6 +92,18 @@ namespace R2API {
             }
             difficultyDefinitions[pendingIndex] = difficulty;
             return pendingIndex;
+        }
+
+        /// <summary>
+        /// Add a DifficultyDef to the list of available difficulties using a SerializableDifficultyDef
+        /// This must be called before the DifficultyCatalog inits, so before plugin.Start()
+        /// You can get the DifficultyIndex from the SerializableDifficultyDef's DifficultyIndex property
+        /// If this is called after the DifficultyCatalog inits, then the DifficultyIndex will return -1/DifficultyIndex.Invalid and ignore the difficulty
+        /// </summary>
+        /// <param name="serializableDifficultyDef">The SerializableDifficultyDef from which to create the DifficultyDef</param>
+        public static void AddDifficulty(SerializableDifficultyDef serializableDifficultyDef) {
+            serializableDifficultyDef.CreateDifficultyDef();
+            serializableDifficultyDef.DifficultyIndex = AddDifficulty(serializableDifficultyDef.DifficultyDef, serializableDifficultyDef.preferPositiveIndex);
         }
 
         [R2APISubmoduleInit(Stage = InitStage.SetHooks)]

--- a/R2API/EliteAPI.cs
+++ b/R2API/EliteAPI.cs
@@ -116,6 +116,10 @@ namespace R2API {
         /// <param name="elite">The elite to add.</param>
         /// <returns>true if added, false otherwise</returns>
         public static bool Add(CustomElite? elite) {
+            return AddInternal(elite, Assembly.GetCallingAssembly());
+        }
+
+        internal static bool AddInternal(CustomElite elite, Assembly addingAssembly) {
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(EliteAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(EliteAPI)})]");
             }
@@ -130,7 +134,7 @@ namespace R2API {
 
             }
 
-            R2APIContentManager.HandleContentAddition(Assembly.GetCallingAssembly(), elite.EliteDef);
+            R2APIContentManager.HandleContentAddition(addingAssembly, elite.EliteDef);
             EliteDefinitions.Add(elite);
             return true;
         }

--- a/R2API/EliteAPI.cs
+++ b/R2API/EliteAPI.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 // ReSharper disable MemberCanBePrivate.Global
@@ -115,6 +116,7 @@ namespace R2API {
         /// </summary>
         /// <param name="elite">The elite to add.</param>
         /// <returns>true if added, false otherwise</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static bool Add(CustomElite? elite) {
             return AddInternal(elite, Assembly.GetCallingAssembly());
         }

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -64,6 +64,11 @@ namespace R2API {
         /// <param name="item">The item to add.</param>
         /// <returns>true if added, false otherwise</returns>
         public static bool Add(CustomItem? item) {
+            return AddInternal(item, Assembly.GetCallingAssembly());
+        }
+
+        internal static bool AddInternal(CustomItem item, Assembly addingAssembly) {
+
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(ItemAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ItemAPI)})]");
             }
@@ -100,11 +105,12 @@ namespace R2API {
                 R2API.Logger.LogError($"Custom item '{item.ItemDef.name}' is not XMLsafe. Item not added.");
             }
             if (xmlSafe) {
-                R2APIContentManager.HandleContentAddition(Assembly.GetCallingAssembly(), item.ItemDef);
+                R2APIContentManager.HandleContentAddition(addingAssembly, item.ItemDef);
                 return true;
             }
 
             return false;
+
         }
 
         /// <summary>
@@ -116,6 +122,10 @@ namespace R2API {
         /// <param name="item">The equipment item to add.</param>
         /// <returns>true if added, false otherwise</returns>
         public static bool Add(CustomEquipment? item) {
+            return AddInternal(item, Assembly.GetCallingAssembly());
+        }
+
+        internal static bool AddInternal(CustomEquipment item, Assembly addingAssembly) {
             if (!Loaded) {
                 throw new InvalidOperationException($"{nameof(ItemAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ItemAPI)})]");
             }
@@ -152,7 +162,7 @@ namespace R2API {
                 R2API.Logger.LogError($"Custom equipment '{item.EquipmentDef.name}' is not XMLsafe. Item not added.");
             }
             if (xmlSafe) {
-                R2APIContentManager.HandleContentAddition(Assembly.GetCallingAssembly(), item.EquipmentDef);
+                R2APIContentManager.HandleContentAddition(addingAssembly, item.EquipmentDef);
                 return true;
             }
 

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -63,6 +64,7 @@ namespace R2API {
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>true if added, false otherwise</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static bool Add(CustomItem? item) {
             return AddInternal(item, Assembly.GetCallingAssembly());
         }
@@ -121,6 +123,7 @@ namespace R2API {
         /// </summary>
         /// <param name="item">The equipment item to add.</param>
         /// <returns>true if added, false otherwise</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static bool Add(CustomEquipment? item) {
             return AddInternal(item, Assembly.GetCallingAssembly());
         }

--- a/R2API/ScriptableObjects/SerializableDifficultyDef.cs
+++ b/R2API/ScriptableObjects/SerializableDifficultyDef.cs
@@ -1,0 +1,32 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.ScriptableObjects {
+    [CreateAssetMenu(fileName = "new SerializableDifficultyDef", menuName = "R2API/SerializableDifficultyDef")]
+    public class SerializableDifficultyDef : ScriptableObject {
+        [Tooltip("Scaling value of the difficulty, Drizzle is 1, Rainstorm is 2, Monsoon is 3")]
+        public float scalingValue;
+        public string descriptionToken;
+        public string nameToken;
+        [Tooltip("Unique identifier for this Difficulty")]
+        public string serverTag;
+        [Tooltip("If true, beating the game on this difficulty will unlock the survivor's Mastery skin")]
+        public bool countsAsHardMode;
+        [Tooltip("If set to true, the difficulty index will be a possitive number, this causes the difficulty to have all the Eclipse modifiers (From 1 to 8)")]
+        public bool preferPositiveIndex = false;
+        public Color difficultyColor;
+        public Sprite iconSprite;
+
+        public DifficultyDef DifficultyDef { get; private set; }
+        public DifficultyIndex DifficultyIndex { get; internal set; }
+
+        internal void CreateDifficultyDef() {
+            DifficultyDef = new DifficultyDef(scalingValue, nameToken, string.Empty, descriptionToken, difficultyColor, serverTag, countsAsHardMode);
+            DifficultyDef.foundIconSprite = true;
+            DifficultyDef.iconSprite = iconSprite;
+        }
+    }
+}

--- a/R2API/ScriptableObjects/SerializableDifficultyDef.cs
+++ b/R2API/ScriptableObjects/SerializableDifficultyDef.cs
@@ -1,7 +1,4 @@
 ﻿using RoR2;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 
 namespace R2API.ScriptableObjects {


### PR DESCRIPTION
A piece of code that was originally created on MSU, the SerializableDifficultyDef simply acts, as the name implies, as a Serializable version of DifficultyDef.

This can be used to pre-create difficultyDefs on thunderkit mods and then have them added by R2API's AddDifficulty() methods. The "finalized" difficultyDef is a property on the ScriptableObject and the DifficultyIndex can be obtained from another property on the ScriptableObject itself.