### PR TITLE
ArtifactCode fix, ContentLogging fix

### DIFF
--- a/R2API/ContentManagement/R2APIContentPackProvider.cs
+++ b/R2API/ContentManagement/R2APIContentPackProvider.cs
@@ -35,8 +35,8 @@ namespace R2API.ContentManagement {
         private void LogContentsFromContentPack() {
             if (logged)
                 return;
-            logged = true;
 
+            logged = true;
             List<string> log = new List<string>();
             log.Add($"Content added from {contentPack.identifier}:");
             log.AddRange(contentPack.bodyPrefabs.assetInfos.Select(ai => $"{ai.assetName} ({ai.asset.GetType().Name})"));

--- a/R2API/ContentManagement/R2APIContentPackProvider.cs
+++ b/R2API/ContentManagement/R2APIContentPackProvider.cs
@@ -14,14 +14,16 @@ namespace R2API.ContentManagement {
 
         private ContentPack contentPack;
 
+        private bool logged = false;
+
         public IEnumerator FinalizeAsync(FinalizeAsyncArgs args) {
+            LogContentsFromContentPack();
             args.ReportProgress(1f);
             yield break;
         }
 
         public IEnumerator GenerateContentPackAsync(GetContentPackAsyncArgs args) {
             ContentPack.Copy(contentPack, args.output);
-            LogContentsFromContentPack();
             args.ReportProgress(1f);
             yield break;
         }
@@ -31,6 +33,10 @@ namespace R2API.ContentManagement {
             yield break;
         }
         private void LogContentsFromContentPack() {
+            if (logged)
+                return;
+            logged = true;
+
             List<string> log = new List<string>();
             log.Add($"Content added from {contentPack.identifier}:");
             log.AddRange(contentPack.bodyPrefabs.assetInfos.Select(ai => $"{ai.assetName} ({ai.asset.GetType().Name})"));

--- a/R2API/PrefabAPI.cs
+++ b/R2API/PrefabAPI.cs
@@ -35,7 +35,7 @@ namespace R2API {
         private static GameObject _parent;
         private static readonly List<HashStruct> ThingsToHash = new List<HashStruct>();
 
-        internal static bool IsPrefabHashed(GameObject prefabToCheck) => ThingsToHash.Select(hash => hash.Prefab).Contains(prefabToCheck);
+        public static bool IsPrefabHashed(GameObject prefabToCheck) => ThingsToHash.Select(hash => hash.Prefab).Contains(prefabToCheck);
 
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 

--- a/R2API/ScriptableObjects/ArtifactCode.cs
+++ b/R2API/ScriptableObjects/ArtifactCode.cs
@@ -87,8 +87,8 @@ namespace R2API.ScriptableObjects {
             sequence.Add(middleRow.z);
             sequence.Add(bottomRow.z);
             sequence.Add(topRow.y);
-            sequence.Add(middleRow.y);
             sequence.Add(bottomRow.y);
+            sequence.Add(middleRow.y);
             sequence.Add(topRow.x);
             sequence.Add(middleRow.x);
             sequence.Add(bottomRow.x);


### PR DESCRIPTION
This PR fixes 2 issues.

1- Fixes issue #360, where the ArtifactCode's Vector3 rows where badly implemented.
2- Issue with how R2API logs the content of ContentPacks added to it, It'll no longer Log content multiple times.
