### PR TITLE
RecalculateStatsAPI:critDamageMultAdd is now float , Fixes #363 

### DIFF
--- a/R2API/RecalculateStatsAPI.cs
+++ b/R2API/RecalculateStatsAPI.cs
@@ -113,7 +113,7 @@ namespace R2API {
             public int moveSpeedRootCount = 0;
 
             /// <summary>Added to the direct multiplier to crit damage. CRIT_DAMAGE ~ DAMAGE * (BASE_CRIT_MULT + critDamageMultAdd) </summary>
-            public int critDamageMultAdd = 0;
+            public float critDamageMultAdd = 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Necessary but A Breaking Change nonetheless :(
Fixes #363 