### PR TITLE
Fix ItemDisplay issues in R2API SOTV

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -108,6 +108,7 @@ namespace R2API {
             }
             if (xmlSafe) {
                 R2APIContentManager.HandleContentAddition(addingAssembly, item.ItemDef);
+                ItemDefinitions.Add(item);
                 return true;
             }
 
@@ -166,6 +167,7 @@ namespace R2API {
             }
             if (xmlSafe) {
                 R2APIContentManager.HandleContentAddition(addingAssembly, item.EquipmentDef);
+                EquipmentDefinitions.Add(item);
                 return true;
             }
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The most recent changelog can always be found on the [GitHub](https://github.com
 
 **Current**
 
+* [Fix ItemDisplay addition for Items and Equipment](https://github.com/risk-of-thunder/R2API/pull/369)
 * [Fix contentpacks that did not have the correct name in some cases](https://github.com/risk-of-thunder/R2API/pull/366)
 * [Crit damage multiplier is now a float](https://github.com/risk-of-thunder/R2API/pull/365)
 * [ArtifactCode fix, ContentLogging fix](https://github.com/risk-of-thunder/R2API/pull/361)


### PR DESCRIPTION
Someone forgot to re-add the ItemDefinition/EquipmentDefinition adding when they changed ItemAPI to work with the new Contentpack system in R2API. This addresses that error, and fixes ItemDisplay registration as a result.