### PR TITLE
Fix EliteAPI and bug fix DirectorAPI

### DIFF
--- a/R2API.Test/R2APITest.cs
+++ b/R2API.Test/R2APITest.cs
@@ -2,6 +2,7 @@
 using BepInEx;
 using BepInEx.Logging;
 using HG.Reflection;
+using System;
 
 [assembly: SearchableAttribute.OptIn]
 
@@ -17,6 +18,10 @@ namespace R2API.Test {
 
         private void Awake() {
             Logger = base.Logger;
+
+            if (!R2API.DebugMode) {
+                throw new Exception("R2API.DebugMode is not enabled");
+            }
 
             var awakeRunner = new AwakeRunner();
             awakeRunner.DiscoverAndRun();

--- a/R2API.Test/Tests/AwakeTests/EliteAPITests.cs
+++ b/R2API.Test/Tests/AwakeTests/EliteAPITests.cs
@@ -1,0 +1,93 @@
+using RoR2;
+using System;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using Xunit;
+
+namespace R2API.Test.Tests.AwakeTests {
+    public class EliteAPITests {
+        public EliteAPITests() {
+        }
+
+        // This test a bunch of thing, an elite, with its custom tier def, so also a custom buff, a custom equipment, and language token additions.
+        [Fact]
+        public void Test() {
+
+            var defaultIcon = Addressables.LoadAssetAsync<Sprite>("RoR2/Base/Common/MiscIcons/texMysteryIcon.png").WaitForCompletion();
+            Assert.True(defaultIcon);
+
+            var eliteBuffDef = ScriptableObject.CreateInstance<BuffDef>();
+            eliteBuffDef.name = "R2APITest_EliteBuffDef";
+            eliteBuffDef.buffColor = new Color32(255, 255, 255, byte.MaxValue);
+            eliteBuffDef.iconSprite = defaultIcon;
+            eliteBuffDef.canStack = false;
+
+            const string EliteAffixToken = "R2APITEST_eliteEquipmentDefAffixToken";
+            const string RegisteredToken = "_REGISTERED";
+            LanguageAPI.Add(EliteAffixToken, EliteAffixToken + RegisteredToken);
+
+            var eliteEquipmentDef = ScriptableObject.CreateInstance<EquipmentDef>();
+            eliteEquipmentDef.name = "ELITE_EQUIPMENT_" + EliteAffixToken;
+            LanguageAPI.Add(eliteEquipmentDef.name, eliteEquipmentDef.name + RegisteredToken);
+
+            eliteEquipmentDef.nameToken = "ELITE_EQUIPMENT_" + EliteAffixToken + "_NAME";
+            LanguageAPI.Add(eliteEquipmentDef.nameToken, eliteEquipmentDef.nameToken + RegisteredToken);
+
+            eliteEquipmentDef.pickupToken = "ELITE_EQUIPMENT_" + EliteAffixToken + "_PICKUP";
+            LanguageAPI.Add(eliteEquipmentDef.pickupToken, eliteEquipmentDef.pickupToken + RegisteredToken);
+
+            eliteEquipmentDef.descriptionToken = "ELITE_EQUIPMENT_" + EliteAffixToken + "_DESCRIPTION";
+            LanguageAPI.Add(eliteEquipmentDef.descriptionToken, eliteEquipmentDef.descriptionToken + RegisteredToken);
+
+            eliteEquipmentDef.loreToken = "ELITE_EQUIPMENT_" + EliteAffixToken + "_LORETOKEN";
+            LanguageAPI.Add(eliteEquipmentDef.loreToken, eliteEquipmentDef.loreToken + RegisteredToken);
+
+            eliteEquipmentDef.pickupModelPrefab = null;
+            eliteEquipmentDef.pickupIconSprite = defaultIcon;
+            eliteEquipmentDef.appearsInSinglePlayer = true;
+            eliteEquipmentDef.appearsInMultiPlayer = true;
+            eliteEquipmentDef.canDrop = true;
+            eliteEquipmentDef.cooldown = 2;
+            eliteEquipmentDef.enigmaCompatible = false;
+            eliteEquipmentDef.isBoss = false;
+            eliteEquipmentDef.isLunar = false;
+            eliteEquipmentDef.passiveBuffDef = eliteBuffDef;
+
+            ItemDisplayRule[] itemDisplayRules = null;
+            var customEquipment = new CustomEquipment(eliteEquipmentDef, itemDisplayRules);
+            Assert.True(ItemAPI.Add(customEquipment));
+
+            var customEliteTierDefs = new CombatDirector.EliteTierDef[]
+            {
+                new CombatDirector.EliteTierDef()
+                {
+                    costMultiplier = CombatDirector.baseEliteCostMultiplier,
+                    eliteTypes = Array.Empty<EliteDef>(),
+                    isAvailable = SetAvailability,
+                },
+            };
+
+            foreach (var eliteTierDef in customEliteTierDefs) {
+                EliteAPI.AddCustomEliteTier(eliteTierDef);
+            }
+
+            var customEliteDef = ScriptableObject.CreateInstance<EliteDef>();
+            customEliteDef.healthBoostCoefficient = 2;
+            customEliteDef.color = new Color32(255, 0, 0, byte.MaxValue);
+            customEliteDef.eliteEquipmentDef = eliteEquipmentDef;
+            customEliteDef.damageBoostCoefficient = 2;
+            customEliteDef.modifierToken = "R2API_TEST_ELITEDEF_MODIFIERTOKEN";
+            LanguageAPI.Add(customEliteDef.modifierToken, customEliteDef.modifierToken + RegisteredToken);
+
+            customEliteDef.shaderEliteRampIndex = 0;
+
+            eliteBuffDef.eliteDef = customEliteDef;
+
+            Assert.True(EliteAPI.Add(new CustomElite(customEliteDef, customEliteTierDefs)));
+        }
+
+        private bool SetAvailability(SpawnCard.EliteRules arg) {
+            return arg == SpawnCard.EliteRules.Default;
+        }
+    }
+}

--- a/R2API.Test/Tests/AwakeTests/EliteAPITests.cs
+++ b/R2API.Test/Tests/AwakeTests/EliteAPITests.cs
@@ -84,6 +84,14 @@ namespace R2API.Test.Tests.AwakeTests {
             eliteBuffDef.eliteDef = customEliteDef;
 
             Assert.True(EliteAPI.Add(new CustomElite(customEliteDef, customEliteTierDefs)));
+
+            // this may break, but right now thats the index where our custom tier should end up
+            const int ourIndex = 1;
+            Assert.True(CombatDirector.eliteTiers[ourIndex].costMultiplier == 6);
+
+            // Should be length 0 if its our custom tier def,
+            // the eliteDef will be added when content packs get added to game content. (EliteAPI.AddElitesToGame)
+            Assert.True(CombatDirector.eliteTiers[ourIndex].eliteTypes.Length == 0);
         }
 
         private bool SetAvailability(SpawnCard.EliteRules arg) {

--- a/R2API/Director/DirectorAPIinternal.cs
+++ b/R2API/Director/DirectorAPIinternal.cs
@@ -398,7 +398,9 @@ namespace R2API {
                 MaxStageCompletion = family.maximumStageCompletion,
                 MinStageCompletion = family.minimumStageCompletion,
                 FamilySelectionWeight = family.selectionWeight,
-                SelectionChatString = family.familySelectionChatString
+                SelectionChatString = family.familySelectionChatString,
+                MonsterCategoryToMonsterCards = new(),
+                MonsterCategoryToSelectionWeights = new()
             };
 
             var monsterCategories = family.monsterFamilyCategories.categories;
@@ -424,6 +426,8 @@ namespace R2API {
                     cards = monsterCategoryCards.ToArray()
                 });
             }
+
+            dccs.categories = monsterCategories.ToArray();
 
             return new ClassicStageInfo.MonsterFamily {
                 familySelectionChatString = holder.SelectionChatString,

--- a/R2API/Director/DirectorAPIinternal.cs
+++ b/R2API/Director/DirectorAPIinternal.cs
@@ -104,13 +104,16 @@ namespace R2API {
             RestoreClassicStageInfoToOriginalState(classicStageInfo, stageInfo);
 
             List<DirectorCardHolder> oldDccs = null;
+            List<MonsterFamilyHolder> oldMonsterFamilies = null;
+
             var isUsingOldSystem = !classicStageInfo.monsterDccsPool && classicStageInfo.monsterCategories;
             if (isUsingOldSystem) {
                 oldDccs = GetDirectorCardHoldersFromDCCS(classicStageInfo.monsterCategories);
-            }
 
-            List<MonsterFamilyHolder> oldMonsterFamilies = null;
-            oldMonsterFamilies = classicStageInfo.possibleMonsterFamilies.Select(GetMonsterFamilyHolder).ToList();
+                if (classicStageInfo.possibleMonsterFamilies != null) {
+                    oldMonsterFamilies = classicStageInfo.possibleMonsterFamilies.Select(GetMonsterFamilyHolder).ToList();
+                }
+            }
 
             InitCustomMixEnemyArtifactDccs();
             var cardHoldersMixEnemyArtifact = GetDirectorCardHoldersFromDCCS(_dccsMixEnemyArtifact);

--- a/R2API/EliteAPI.cs
+++ b/R2API/EliteAPI.cs
@@ -31,6 +31,9 @@ namespace R2API {
 
         private static bool _loaded;
 
+        /// <summary>
+        /// See <see cref="CombatDirectorInitNoTimingIssue"/>
+        /// </summary>
         static EliteAPI() {
             CombatDirectorInitNoTimingIssue();
 
@@ -63,9 +66,14 @@ namespace R2API {
             CombatDirectorInitNoTimingIssue();
         }
 
-        // Only hope at this point is HG using extensible code and not hard coding
-        // Before we were loading all hard refs earlier, but we removed that in favor of a bit better loading screen
-        // Bandaid fix for now for the api to work again : replace the RoR2Content hard refs with Addressables Load Asset
+        /// <summary>
+        /// Only hope at this point is HG using extensible code and not hard coding.
+        /// Before we were loading all hard refs earlier, but we removed that in favor of a bit better loading screen.
+        /// Bandaid fix for now for the api to work again : replace the RoR2Content hard refs with Addressables Load Asset.
+        /// Todo : investigate if adding an event like the other catalogs have + putting code inside a GenerateContentPackAsync
+        /// would be a cleaner fix or not.
+        /// Note: Will be breaking as opposed to current solution below which doesnt change anything on how the old mods were operating.
+        /// </summary>
         private static void CombatDirectorInitNoTimingIssue() {
             if (_combatDirectorInitialized) {
                 return;


### PR DESCRIPTION
- Fix EliteAPI : Was not working anymore because we are calling the CombatDirector.Init and it fill the arrays with null references since we are not early loading the game content anymore, the easy fix is to early load those specific defs which makes the whole thing work again, this is not proper and ideally everything should probably happen inside a IContentPackProvider, I added a todo comment which talks about this a bit more.
- Add a test to verify if the EliteAPI works or not.
- Fix a null ref that could happen with old stages with DirectorAPI