### PR TITLE
Improve reflection utils speed  (#377)

### DIFF
--- a/R2API/Utils/Reflection.cs
+++ b/R2API/Utils/Reflection.cs
@@ -16,15 +16,15 @@ namespace R2API.Utils {
         private const BindingFlags AllFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static |
                                               BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
-        private delegate T GetDelegate<out T>(object instance);
+        public delegate T GetDelegate<out T>(object instance);
 
-        private delegate void SetDelegate<in T>(object instance, T value);
+        public delegate void SetDelegate<in T>(object instance, T value);
 
         //private delegate object CallDelegate(object instance, object[] arguments);
 
-        private delegate void SetDelegateRef<TInstance, in TValue>(ref TInstance instance, TValue value) where TInstance : struct;
+        public delegate void SetDelegateRef<TInstance, in TValue>(ref TInstance instance, TValue value) where TInstance : struct;
 
-        private delegate T GetDelegateRef<TInstance, out T>(ref TInstance instance) where TInstance : struct;
+        public delegate T GetDelegateRef<TInstance, out T>(ref TInstance instance) where TInstance : struct;
 
         #region Caches
 
@@ -192,15 +192,15 @@ namespace R2API.Utils {
             return null;
         }
 
-        private static GetDelegate<TReturn> GetFieldGetDelegate<TReturn>(this FieldInfo field) =>
+        public static GetDelegate<TReturn> GetFieldGetDelegate<TReturn>(this FieldInfo field) =>
             FieldGetDelegateCache.GetOrAdd(field, x => x.CreateGetDelegate<TReturn>())
                 .CastDelegate<GetDelegate<TReturn>>();
 
-        private static SetDelegate<TValue> GetFieldSetDelegate<TValue>(this FieldInfo field) =>
+        public static SetDelegate<TValue> GetFieldSetDelegate<TValue>(this FieldInfo field) =>
             FieldSetDelegateCache.GetOrAdd(field, x => x.CreateSetDelegate<TValue>())
                 .CastDelegate<SetDelegate<TValue>>();
 
-        private static SetDelegateRef<TInstance, TValue> GetFieldSetDelegateRef<TInstance, TValue>(this FieldInfo field) where TInstance : struct =>
+        public static SetDelegateRef<TInstance, TValue> GetFieldSetDelegateRef<TInstance, TValue>(this FieldInfo field) where TInstance : struct =>
             FieldSetDelegateCache.GetOrAdd(field, x => x.CreateSetDelegateRef<TInstance, TValue>())
                 .CastDelegate<SetDelegateRef<TInstance, TValue>>();
 
@@ -325,16 +325,16 @@ namespace R2API.Utils {
         public static MethodInfo GetPropertySetter(this Type type, string nameOfProperty) =>
             type.GetProperty(nameOfProperty, AllFlags).GetSetMethod(true);
 
-        private static GetDelegate<TReturn> GetPropertyGetDelegate<TReturn>(this PropertyInfo property) =>
+        public static GetDelegate<TReturn> GetPropertyGetDelegate<TReturn>(this PropertyInfo property) =>
             PropertyGetDelegateCache.GetOrAdd(property, prop => prop.CreateGetDelegate<TReturn>())
                 .CastDelegate<GetDelegate<TReturn>>();
 
-        private static GetDelegateRef<TInstance, TReturn> GetPropertyGetDelegateRef<TInstance, TReturn>(this PropertyInfo property)
+        public static GetDelegateRef<TInstance, TReturn> GetPropertyGetDelegateRef<TInstance, TReturn>(this PropertyInfo property)
             where TInstance : struct =>
             PropertyGetDelegateCache.GetOrAdd(property, prop => prop.CreateGetDelegate<TInstance, TReturn>())
                 .CastDelegate<GetDelegateRef<TInstance, TReturn>>();
 
-        private static SetDelegate<TValue> GetPropertySetDelegate<TValue>(this PropertyInfo property) =>
+        public static SetDelegate<TValue> GetPropertySetDelegate<TValue>(this PropertyInfo property) =>
             PropertySetDelegateCache.GetOrAdd(property, prop => prop.CreateSetDelegate<TValue>())
                 .CastDelegate<SetDelegate<TValue>>();
 
@@ -506,7 +506,7 @@ namespace R2API.Utils {
         public static void InvokeMethod(this Type? staticType, string? methodName, params object?[]? methodParams) =>
             staticType.InvokeMethod<object>(methodName, methodParams);
 
-        private static FastReflectionDelegate GetMethodDelegateCached(this MethodInfo methodInfo) =>
+        public static FastReflectionDelegate GetMethodDelegateCached(this MethodInfo methodInfo) =>
             DelegateCache.GetOrAdd(methodInfo, method => method.GenerateCallDelegate());
 
         #endregion Method


### PR DESCRIPTION
here is the benchmark
```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1620 (21H2)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host]   : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  Mono x64 : Mono 6.12.0 (Visual Studio), X64 

Job=Mono x64  Runtime=Mono x64  

|                          Method |        Mean |     Error |     StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|-------------------------------- |------------:|----------:|-----------:|------:|--------:|-------:|----------:|
|                       DirectSet |   0.6177 ns | 0.0482 ns |  0.0427 ns | 0.002 |    0.00 |      - |         - |
|               FieldInfoSetValue | 297.2050 ns | 5.6635 ns |  5.0206 ns | 1.000 |    0.00 |      - |         - |
|             R2API.SetFieldValue | 227.2970 ns | 4.5213 ns | 10.7454 ns | 0.802 |    0.04 | 0.0391 |         - |
| R2API.SetFieldValueAfterImprove |  90.1908 ns | 1.8251 ns |  3.5163 ns | 0.301 |    0.01 |      - |         - |
|   R2API.DirectInvokeSetDelegate |   2.7984 ns | 0.0871 ns |  0.1548 ns | 0.009 |    0.00 |      - |         - |
```