### PR TITLE
Add ProcTypeAPI

### DIFF
--- a/R2API/Director/DirectorAPIinternal.cs
+++ b/R2API/Director/DirectorAPIinternal.cs
@@ -50,7 +50,7 @@ namespace R2API {
             if (cursor.TryGotoNext(
                 i => i.MatchCallOrCallvirt<DirectorCardCategorySelection>(nameof(DirectorCardCategorySelection.CopyFrom))
                 )) {
-                cursor.EmitDelegate(SwapDccs);
+                //cursor.EmitDelegate(SwapDccs);
             }
 
             static DirectorCardCategorySelection SwapDccs(DirectorCardCategorySelection vanillaDccs) {

--- a/R2API/Director/DirectorAPIinternal.cs
+++ b/R2API/Director/DirectorAPIinternal.cs
@@ -50,7 +50,7 @@ namespace R2API {
             if (cursor.TryGotoNext(
                 i => i.MatchCallOrCallvirt<DirectorCardCategorySelection>(nameof(DirectorCardCategorySelection.CopyFrom))
                 )) {
-                //cursor.EmitDelegate(SwapDccs);
+                cursor.EmitDelegate(SwapDccs);
             }
 
             static DirectorCardCategorySelection SwapDccs(DirectorCardCategorySelection vanillaDccs) {

--- a/R2API/ProcTypeAPI.cs
+++ b/R2API/ProcTypeAPI.cs
@@ -1,0 +1,42 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using R2API.ContentManagement;
+using R2API.Utils;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace R2API {
+    /// <summary>
+    /// API for reserving unique ProcTypes.
+    /// </summary>
+    [R2APISubmodule]
+    public static class ProcTypeAPI {
+
+        /// <summary>
+        /// Return true if the submodule is loaded.
+        /// </summary>
+        public static bool Loaded {
+            get => _loaded;
+            internal set => _loaded = value;
+        }
+
+        private static bool _loaded;
+
+        internal static uint currentProcTypeIndex = (uint)ProcType.Count;
+
+        /// <summary>
+        /// Reserve a unique ProcType for use with ProcChainMask.
+        /// </summary>
+        public static ProcType ReserveProcType() {
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(ProcTypeAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ProcTypeAPI)})]");
+            }
+
+
+            return (ProcType)currentProcTypeIndex++;
+        }
+    }
+}

--- a/R2API/ProcTypeAPI.cs
+++ b/R2API/ProcTypeAPI.cs
@@ -25,16 +25,16 @@ namespace R2API {
 
         private static bool _loaded;
 
-        internal static uint currentProcTypeIndex = (uint)ProcType.Count;
+        internal static uint currentProcTypeIndex = (uint)ProcType.Count + 1;
 
         /// <summary>
         /// Reserve a unique ProcType for use with ProcChainMask.
         /// </summary>
         public static ProcType ReserveProcType() {
-            if (!Loaded) {
+            if (!Loaded)
+            {
                 throw new InvalidOperationException($"{nameof(ProcTypeAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ProcTypeAPI)})]");
             }
-
 
             return (ProcType)currentProcTypeIndex++;
         }


### PR DESCRIPTION
A simple implementation of modded proc types through extending the `ProcType` enum, enabling coordination between different mods. Proc types are then handled through `ProcChainMask` at the user's digression.