### PR TITLE
Fix CombineHashCode return the same result on arrays of different order

### DIFF
--- a/R2API.Test/Tests/AwakeTests/ReflectionTests.cs
+++ b/R2API.Test/Tests/AwakeTests/ReflectionTests.cs
@@ -91,6 +91,18 @@ namespace R2API.Test.Tests.AwakeTests {
         }
 
         [Fact]
+        public void TestReflectionCombineHashCode() {
+            var hashcode1 = Reflection.CombineHashCode(new Type[]
+                {typeof(string), typeof(int), typeof(string), typeof(int)});
+            var hashcode2 = Reflection.CombineHashCode(new Type[]
+                {typeof(string), typeof(string), typeof(int), typeof(int)});
+            var hashcode3 = Reflection.CombineHashCode(new Type[]
+                {typeof(string), typeof(string), typeof(int), typeof(int)});
+            Assert.NotEqual(hashcode1, hashcode2);
+            Assert.Equal(hashcode2, hashcode3);
+        }
+
+        [Fact]
         public void TestReflectionConstructorCache() {
             var cacheDict = typeof(Reflection).GetFieldValue<ConcurrentDictionary<(Type, int), ConstructorInfo>>("ConstructorCache");
             var key = (typeof(ReflectionTestObject), Reflection.CombineHashCode(new Type[]{}));

--- a/R2API/Utils/Reflection.cs
+++ b/R2API/Utils/Reflection.cs
@@ -71,16 +71,11 @@ namespace R2API.Utils {
             new ConcurrentDictionary<(Type T, string name), Type>();
 
         // Helper methods
-        public static int CombineHashCode<T>(IList<T> list) {
+        public static int CombineHashCode<T>(IEnumerable<T> enumerable) {
             unchecked {
                 var hash = 0;
-                var last = list.Count - 1;
-                for (var i = 0; i < list.Count; i++) {
-                    if (i == last) {
-                        hash += EqualityComparer<T>.Default.GetHashCode(list[i]);
-                    } else {
-                        hash += EqualityComparer<T>.Default.GetHashCode(list[i]) * -1521134295;
-                    }
+                foreach (var item in enumerable) {
+                    hash = hash * 486187739 + EqualityComparer<T>.Default.GetHashCode(item);
                 }
 
                 return hash;


### PR DESCRIPTION
the previous algorithm resulted in the following hashcodes being equal
```cs
var hashcode1 = Reflection.CombineHashCode(new Type[]{typeof(string), typeof(int), typeof(string), typeof(int)});
var hashcode2 = Reflection.CombineHashCode(new Type[]{typeof(string), typeof(string), typeof(int), typeof(int)});
```