### PR TITLE
ItemAPI tier fix

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -330,45 +330,49 @@ namespace R2API {
             bool hidden,
             bool canRemove,
             UnlockableDef unlockableDef,
-            ItemDisplayRule[]? itemDisplayRules,
-            ItemTierDef itemTierDef = null) {
-
-            ItemDef = ScriptableObject.CreateInstance<ItemDef>();
-            ItemDef.canRemove = canRemove;
-            ItemDef.descriptionToken = descriptionToken;
-            ItemDef.hidden = hidden;
-            ItemDef.loreToken = loreToken;
-            ItemDef.name = name;
-            ItemDef.nameToken = nameToken;
-            ItemDef.pickupIconSprite = pickupIconSprite;
-            ItemDef.pickupModelPrefab = pickupModelPrefab;
-            ItemDef.pickupToken = pickupToken;
-            ItemDef.tags = tags;
-            ItemDef.unlockableDef = unlockableDef;
-
-            //If the tier isnt assigned at runtime, load tier from addressables, this should make it so mods that add items dont break.
-            //We dont want to set the .tier directly, because that'll attempt to load the itemTierDef via the itemTierCatalog, and we cant
-            //Guarantee said catalog has been initialized at that point
-            if (tier != ItemTier.AssignedAtRuntime) {
-                ItemDef._itemTierDef = LoadTierFromAddress(tier);
-                return;
-            }
-            else {
-                //If the itemTier is AssignedAtRuntime, but an itemTierDef is not assigned, default to noTier and warn the user
-                if(!itemTierDef) {
-                    ItemDef._itemTierDef = null;
-                    R2API.Logger.LogWarning($"Trying to create an itemDef ({name}), but the \"tier\" argument is set to {nameof(ItemTier.AssignedAtRuntime)}" +
-                        $"And the argument \"itemTierDef\" is null! Resorting to setting tier to NoTier");
-                }
-                else {
-                    ItemDef._itemTierDef = itemTierDef;
-                }
-            }
-
-            ItemDisplayRules = new ItemDisplayRuleDict(itemDisplayRules);
+            ItemDisplayRule[]? itemDisplayRules) {
+            SetupItem(name, nameToken, descriptionToken, loreToken, pickupToken, pickupIconSprite, pickupModelPrefab, tier, tags, canRemove, hidden, unlockableDef, new ItemDisplayRuleDict(itemDisplayRules));
         }
 
         public CustomItem(string name, string nameToken,
+            string descriptionToken, string loreToken,
+            string pickupToken,
+            Sprite pickupIconSprite, GameObject pickupModelPrefab,
+            ItemTag[] tags, ItemTier tier,
+            bool hidden,
+            bool canRemove,
+            UnlockableDef unlockableDef,
+            ItemDisplayRule[]? itemDisplayRules,
+            ItemTierDef itemTierDef = null) {
+            SetupItem(name, nameToken, descriptionToken, loreToken, pickupToken, pickupIconSprite, pickupModelPrefab, tier, tags, canRemove, hidden, unlockableDef, new ItemDisplayRuleDict(itemDisplayRules), itemTierDef);
+        }
+
+        public CustomItem(string name, string nameToken,
+            string descriptionToken, string loreToken,
+            string pickupToken,
+            Sprite pickupIconSprite, GameObject pickupModelPrefab,
+            ItemTier tier, ItemTag[] tags,
+            bool canRemove,
+            bool hidden,
+            UnlockableDef unlockableDef = null,
+            ItemDisplayRuleDict? itemDisplayRules = null){
+            SetupItem(name, nameToken, descriptionToken, loreToken, pickupToken, pickupIconSprite, pickupModelPrefab, tier, tags, canRemove, hidden, unlockableDef, itemDisplayRules);
+        }
+
+        public CustomItem(string name, string nameToken,
+            string descriptionToken, string loreToken,
+            string pickupToken,
+            Sprite pickupIconSprite, GameObject pickupModelPrefab,
+            ItemTier tier, ItemTag[] tags,
+            bool canRemove,
+            bool hidden,
+            UnlockableDef unlockableDef = null,
+            ItemDisplayRuleDict? itemDisplayRules = null,
+            ItemTierDef itemTierDef = null) {
+            SetupItem(name, nameToken, descriptionToken, loreToken, pickupToken, pickupIconSprite, pickupModelPrefab, tier, tags, canRemove, hidden, unlockableDef, itemDisplayRules, itemTierDef);
+        }
+
+        private void SetupItem(string name, string nameToken,
             string descriptionToken, string loreToken,
             string pickupToken,
             Sprite pickupIconSprite, GameObject pickupModelPrefab,
@@ -396,13 +400,13 @@ namespace R2API {
             //If the tier isnt assigned at runtime, load tier from addressables, this should make it so mods that add items dont break.
             //We dont want to set the .tier directly, because that'll attempt to load the itemTierDef via the itemTierCatalog, and we cant
             //Guarantee said catalog has been initialized at that point
-            if(tier != ItemTier.AssignedAtRuntime) {
+            if (tier != ItemTier.AssignedAtRuntime) {
                 ItemDef._itemTierDef = LoadTierFromAddress(tier);
                 return;
             }
             else {
                 //If the itemTier is AssignedAtRuntime, but an itemTierDef is not assigned, default to noTier and warn the user
-                if(!itemTierDef) {
+                if (!itemTierDef) {
                     ItemDef._itemTierDef = null;
                     R2API.Logger.LogWarning($"Trying to create an itemDef ({name}), but the \"tier\" argument is set to {nameof(ItemTier.AssignedAtRuntime)}" +
                         $"And the argument \"itemTierDef\" is null! Resorting to setting tier to NoTier");
@@ -411,33 +415,24 @@ namespace R2API {
                     ItemDef._itemTierDef = itemTierDef;
                 }
             }
+
         }
-
         private ItemTierDef LoadTierFromAddress(ItemTier itemTierToLoad) {
-            switch(itemTierToLoad) {
-                case ItemTier.Tier1:
-                    return LoadTier("RoR2/Base/Common/Tier1Def.asset");
-                case ItemTier.Tier2:
-                    return LoadTier("RoR2/Base/Common/Tier2Def.asset");
-                case ItemTier.Tier3:
-                    return LoadTier("RoR2/Base/Common/Tier3Def.asset");
-                case ItemTier.Lunar:
-                    return LoadTier("RoR2/Base/Common/LunarTierDef.asset");
-                case ItemTier.Boss:
-                    return LoadTier("RoR2/Base/Common/BossTierDef.asset");
-
+            return itemTierToLoad switch {
+                ItemTier.Tier1 => LoadTier("RoR2/Base/Common/Tier1Def.asset"),
+                ItemTier.Tier2 => LoadTier("RoR2/Base/Common/Tier2Def.asset"),
+                ItemTier.Tier3 => LoadTier("RoR2/Base/Common/Tier3Def.asset"),
+                ItemTier.Lunar => LoadTier("RoR2/Base/Common/LunarTierDef.asset"),
+                ItemTier.Boss => LoadTier("RoR2/Base/Common/BossTierDef.asset"),
                 //Void
-                case ItemTier.VoidTier1:
-                    return LoadTier("RoR2/DLC1/Common/VoidTier1Def.asset");
-                case ItemTier.VoidTier2:
-                    return LoadTier("RoR2/DLC1/Common/VoidTier2Def.asset");
-                case ItemTier.VoidTier3:
-                    return LoadTier("RoR2/DLC1/Common/VoidTier3Def.asset");
-                case ItemTier.VoidBoss:
-                    return LoadTier("RoR2/DLC1/Common/VoidBossDef.asset");
-                default:
-                    return null;
-            }
+                ItemTier.VoidTier1 => LoadTier("RoR2/DLC1/Common/VoidTier1Def.asset"),
+                ItemTier.VoidTier2 => LoadTier("RoR2/DLC1/Common/VoidTier2Def.asset"),
+                ItemTier.VoidTier3 => LoadTier("RoR2/DLC1/Common/VoidTier3Def.asset"),
+                ItemTier.VoidBoss => LoadTier("RoR2/DLC1/Common/VoidBossDef.asset"),
+                ItemTier.NoTier => null,
+                ItemTier.AssignedAtRuntime => null,
+                _ => null,
+            };
         }
 
         private ItemTierDef LoadTier(string address) => Addressables.LoadAssetAsync<ItemTierDef>(address).WaitForCompletion();

--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -331,7 +331,7 @@ namespace R2API {
             bool canRemove,
             UnlockableDef unlockableDef,
             ItemDisplayRule[]? itemDisplayRules,
-            ItemTierDef itemTierDef) {
+            ItemTierDef itemTierDef = null) {
 
             ItemDef = ScriptableObject.CreateInstance<ItemDef>();
             ItemDef.canRemove = canRemove;
@@ -347,8 +347,9 @@ namespace R2API {
             ItemDef.unlockableDef = unlockableDef;
 
             //If the tier isnt assigned at runtime, load tier from addressables, this should make it so mods that add items dont break.
-            //We dont want to set the .tier directly, because that'll attem
-            if(tier != ItemTier.AssignedAtRuntime) {
+            //We dont want to set the .tier directly, because that'll attempt to load the itemTierDef via the itemTierCatalog, and we cant
+            //Guarantee said catalog has been initialized at that point
+            if (tier != ItemTier.AssignedAtRuntime) {
                 ItemDef._itemTierDef = LoadTierFromAddress(tier);
                 return;
             }
@@ -393,7 +394,8 @@ namespace R2API {
             ItemDisplayRules = itemDisplayRules;
 
             //If the tier isnt assigned at runtime, load tier from addressables, this should make it so mods that add items dont break.
-            //We dont want to set the .tier directly, because that'll attem
+            //We dont want to set the .tier directly, because that'll attempt to load the itemTierDef via the itemTierCatalog, and we cant
+            //Guarantee said catalog has been initialized at that point
             if(tier != ItemTier.AssignedAtRuntime) {
                 ItemDef._itemTierDef = LoadTierFromAddress(tier);
                 return;


### PR DESCRIPTION
Update 1.2.3 to Risk of Rain made the itemDef's "tier" into a property (Was originally a field). the Property's Set method causes issues when the itemTier catalog as not initialized yet (set method calls ItemTierCatalog.GetItemTierDef(itemTierEnum), and at that point no itemTierDefs exist in the catalog yet.) 

This update fixes this issue by doing the following check on the tierargument, while also adding a new optional argument (For itemTierDefs)

When the tier argument is not assignedAtRuntime, the ItemDef's _itemTierDef gets loaded via Addressables by doing a switch case on the given tier argument.

If the tier argument is assignedAtRuntime, but no itemTierDef is specified, R2API throws a warning that the itemDef has the tier argument to assignedAtRuntime, but itemTierDef argument is null, afterwards it sets the ItemDef._itemTierDef to null (AKA: No tier)

if both the tier is AssignedAtRuntime, and the itemTierDef argument is not null, then it simpplpy sets the itemDef's _itemTierDef to the argument's value

I am unsure if this counts as a breaking change, some testing is needed