### PR TITLE
Handle ReflectionTypeLoadException

### DIFF
--- a/R2API/ContentManagement/R2APIContentManager.cs
+++ b/R2API/ContentManagement/R2APIContentManager.cs
@@ -140,7 +140,8 @@ namespace R2API.ContentManagement {
             try {
                 Assembly assembly = Assembly.GetCallingAssembly();
                 if (!AssemblyToBepInModName.ContainsKey(assembly)) {
-                    Type mainClass = assembly.GetTypes()
+                    _ = Reflection.GetTypesSafe(assembly, out var types);
+                    Type mainClass = types
                         .Where(t => t.GetCustomAttribute<BepInPlugin>() != null)
                         .FirstOrDefault();
 
@@ -397,7 +398,8 @@ namespace R2API.ContentManagement {
                     R2API.Logger.LogWarning($"The assembly {assembly.FullName} is not a loaded BepInEx plugin, falling back to looking for attribute in assembly");
 
                     try {
-                        var infoAttribute = assembly.GetTypes().Select(x => x.GetCustomAttribute<BepInPlugin>()).First(x => x != null);
+                        _ = Reflection.GetTypesSafe(assembly, out var types);
+                        var infoAttribute = types.Select(x => x.GetCustomAttribute<BepInPlugin>()).First(x => x != null);
                         modName = infoAttribute.GUID;
                     }
                     catch {

--- a/R2API/Utils/APISubmodule.cs
+++ b/R2API/Utils/APISubmodule.cs
@@ -81,7 +81,8 @@ namespace R2API.Utils {
             }
 
             void CallWhenAssembliesAreScanned() {
-                var moduleTypes = Assembly.GetExecutingAssembly().GetTypes().Where(APISubmoduleFilter).ToList();
+                _ = Reflection.GetTypesSafe(Assembly.GetExecutingAssembly(), out var types);
+                var moduleTypes = types.Where(APISubmoduleFilter).ToList();
 
                 foreach (var moduleType in moduleTypes) {
                     R2API.Logger.LogInfo($"Enabling R2API Submodule: {moduleType.Name}");

--- a/R2API/Utils/CommandHelper.cs
+++ b/R2API/Utils/CommandHelper.cs
@@ -75,10 +75,10 @@ namespace R2API.Utils {
         }
 
         private static void RegisterCommands(Assembly assembly) {
-            var types = assembly?.GetTypes();
-            if (types == null) {
+            if (assembly == null) {
                 return;
             }
+            _ = Reflection.GetTypesSafe(assembly, out var types);
 
             try {
                 var catalog = _console.concommandCatalog;
@@ -112,9 +112,14 @@ namespace R2API.Utils {
         }
 
         private static void RegisterConVars(Assembly assembly) {
+            if (assembly == null) {
+                return;
+            }
+            _ = Reflection.GetTypesSafe(assembly, out var types);
+
             try {
                 var customVars = new List<BaseConVar>();
-                foreach (var type in assembly.GetTypes()) {
+                foreach (var type in types) {
                     foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)) {
                         if (field.FieldType.IsSubclassOf(typeof(BaseConVar))) {
                             if (field.IsStatic) {

--- a/R2API/Utils/Reflection.cs
+++ b/R2API/Utils/Reflection.cs
@@ -1034,6 +1034,24 @@ namespace R2API.Utils {
 
         #endregion Fast Reflection
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="assemblyTypes"></param>
+        /// <returns>true if a ReflectionTypeLoadException was caught</returns>
+        public static bool GetTypesSafe(Assembly assembly, out Type[] assemblyTypes) {
+            try {
+                assemblyTypes = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException re) {
+                assemblyTypes = re.Types.Where(t => t != null).ToArray();
+                return true;
+            }
+
+            return false;
+        }
+
         public static System.Reflection.FieldInfo GetNestedField(Type type, string fieldName) {
             var nestedTypes = type.GetNestedTypes(AllFlags);
             foreach (Type nestedType in nestedTypes) {

--- a/R2API/Utils/Reflection.cs
+++ b/R2API/Utils/Reflection.cs
@@ -1039,17 +1039,17 @@ namespace R2API.Utils {
         /// </summary>
         /// <param name="assembly"></param>
         /// <param name="assemblyTypes"></param>
-        /// <returns>true if a ReflectionTypeLoadException was caught</returns>
+        /// <returns>false if a ReflectionTypeLoadException was caught</returns>
         public static bool GetTypesSafe(Assembly assembly, out Type[] assemblyTypes) {
             try {
                 assemblyTypes = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException re) {
                 assemblyTypes = re.Types.Where(t => t != null).ToArray();
-                return true;
+                return false;
             }
 
-            return false;
+            return true;
         }
 
         public static System.Reflection.FieldInfo GetNestedField(Type type, string fieldName) {


### PR DESCRIPTION
Sometimes assembly.GetTypes() can throw ReflectionTypeLoadException when some types cannot be loaded because of missing assembly dependencies for example, apis should still try to handle the types that were properly loaded and not completly die like CommandHelper was doing