### PR TITLE
ItemAPI: Add custom ItemTag support.

### DIFF
--- a/R2API/ItemAPI.cs
+++ b/R2API/ItemAPI.cs
@@ -29,6 +29,8 @@ namespace R2API {
 
         private static ICollection<string> noDefaultIDRSCharacterList = new List<string>();
 
+        private static List<string> customItemTags = new List<string>();
+
         public static int CustomItemCount, CustomEquipmentCount;
 
         /// <summary>
@@ -47,10 +49,12 @@ namespace R2API {
         internal static void SetHooks() {
             IL.RoR2.CharacterModel.UpdateMaterials += MaterialFixForItemDisplayOnCharacter;
             On.RoR2.ItemDisplayRuleSet.Init += AddingItemDisplayRulesToCharacterModels;
+            IL.RoR2.ItemCatalog.SetItemDefs += AddCustomTagsToItemCatalog;
         }
 
         [R2APISubmoduleInit(Stage = InitStage.UnsetHooks)]
         internal static void UnsetHooks() {
+            IL.RoR2.ItemCatalog.SetItemDefs -= AddCustomTagsToItemCatalog;
             IL.RoR2.CharacterModel.UpdateMaterials -= MaterialFixForItemDisplayOnCharacter;
             On.RoR2.ItemDisplayRuleSet.Init -= AddingItemDisplayRulesToCharacterModels;
         }
@@ -183,6 +187,29 @@ namespace R2API {
             return false;
         }
 
+        /// <summary>
+        /// Add a custom item tag to the list of item tags.
+        /// If this is called after the ItemCatalog inits then this will return -1 and ignore the custom item tag.
+        /// </summary>
+        /// <param name="name">The tag to add.</param>
+        /// <returns>ItemTag value if added or already existent, (-1) cast to ItemTag otherwise</returns>
+        public static ItemTag AddItemTag(string name){
+            if (!Loaded) {
+                throw new InvalidOperationException($"{nameof(ItemAPI)} is not loaded. Please use [{nameof(R2APISubmoduleDependency)}(nameof({nameof(ItemAPI)})]");
+            }
+
+            if (!CatalogBlockers.GetAvailability<ItemDef>()) {
+                R2API.Logger.LogError($"Too late ! Tried to add itemTag: {name} after the ItemCatalog has Initialized!");
+                return (ItemTag)(-1);
+            }
+            var result = customItemTags.IndexOf(name) + 1;
+            if(result == 0){
+               customItemTags.Add(name);
+               result = customItemTags.Count;
+            }
+            return (ItemTag)(result + ItemTag.Count);
+        }
+
         #endregion Add Methods
 
         #region Other Modded Content Support
@@ -206,6 +233,45 @@ namespace R2API {
             }
         }
 
+        /// <summary>
+        /// Gets ItemTag value for tag of given name
+        /// </summary>
+        /// <param name="name">The tag name string to match</param>
+        /// <returns>ItemTag value if found,(-1) cast to ItemTag otherwise</returns>
+        public static ItemTag FindItemTagByName(string name){
+            ItemTag result = (ItemTag)customItemTags.IndexOf(name);
+            if((int)result == -1){
+              if(Enum.TryParse(name,out result)){
+                return result;
+              }
+              else{
+                return (ItemTag)(-1);
+              }
+            }
+            return (ItemTag)(result + 1 + (int)ItemTag.Count);
+        }
+
+
+        /// <summary>
+        /// Applies given ItemTag to the ItemDef (by Tag Name Overload)
+        /// </summary>
+        /// <param name="tagName">The name of the tag to apply</param>
+        /// <param name="item"> The ItemDef to apply the tag to</param>
+        public static void ApplyTagToItem(string tagName,ItemDef item){
+            ApplyTagToItem(FindItemTagByName(tagName),item);
+        }
+
+        /// <summary>
+        /// Applies given ItemTag to the ItemDef
+        /// </summary>
+        /// <param name="tag">The ItemTag to apply</param>
+        /// <param name="item"> The ItemDef to apply the tag to</param>
+        public static void ApplyTagToItem(ItemTag tag,ItemDef item){
+            HG.ArrayUtils.ArrayAppend(ref item.tags,tag);
+            if (!CatalogBlockers.GetAvailability<ItemDef>()){
+               HG.ArrayUtils.ArrayAppend(ref ItemCatalog.itemIndicesByTag[(int)tag],item.itemIndex);
+            }
+        }
         #endregion
 
         #region ItemDisplay Hooks
@@ -305,6 +371,16 @@ namespace R2API {
         }
 
         #endregion ItemDisplay Hooks
+
+        #region ItemTag Hooks
+        private static void AddCustomTagsToItemCatalog(ILContext il){
+            ILCursor c = new ILCursor(il);
+            if(c.TryGotoNext(MoveType.After,x => x.MatchLdcI4((int)ItemTag.Count))){
+                c.EmitDelegate<Func<int>>(() => customItemTags.Count + 1);
+                c.Emit(OpCodes.Add);
+            }
+        }
+        #endregion
 
     }
 


### PR DESCRIPTION
Adds AddItemTag to register new ItemTag values,which can later be used either through vanilla methods or the helpers defined below:
 FindItemTagByName - Returns ItemTag value for given tag name(works for vanilla ItemTags too),facilitates cross compatibility without requiring specific value references.
ApplyTagToItem - Utility to add given tag to item,helps when dealing with items you can't mess with during their setup.
Closes #420 