### PR TITLE
TempVisualEffectAPI changes

### DIFF
--- a/R2API.Legacy/TypeForwards.cs
+++ b/R2API.Legacy/TypeForwards.cs
@@ -24,7 +24,6 @@ using TF = System.Runtime.CompilerServices.TypeForwardedToAttribute;
 [assembly: TF(typeof(R2API.SceneAssetAPI))]
 [assembly: TF(typeof(R2API.SoundAPI))]
 [assembly: TF(typeof(R2API.TempVisualEffectAPI))]
-[assembly: TF(typeof(R2API.R2APITVEController))]
 [assembly: TF(typeof(R2API.IModdedUnlockableDataProvider))]
 [assembly: TF(typeof(R2API.ModdedUnlockable))]
 [assembly: TF(typeof(R2API.UnlockableAPI))]

--- a/R2API.TempVisualEffect/README.md
+++ b/R2API.TempVisualEffect/README.md
@@ -1,4 +1,4 @@
-# R2API.TempVisualEffect - Custom temproary visual effects for characters.
+# R2API.TempVisualEffect - Custom temporary visual effects for characters.
 
 ## About
 
@@ -11,6 +11,8 @@ R2API.TempVisualEffect works via the method AddTemporaryVisualEffect, which allo
 For the condition you use the EffectCondition delegate, which returns true if the visual effect should appear for the body.
 
 You can also specify if the effect should be scaled using the body's best fit radius, or if the effect should spawn in a specific ChildLocator entry.
+
+A separate overload for AddTemporaryVisualEffect takes an EffectRadius delegate, which returns a specific radius for the visual effect. 
 
 ## Related Pages
 


### PR DESCRIPTION
* Switches the component system to a dictionary and array pool to reduce GetComponent calls, should boost performance
* Added optional EffectRadius delegate to support any options past radius and bestFitRadius
* Removed unnecessary restrictions on adding TemporaryVisualEffects after content packs are loaded
* Update readme
I wasn't able to test these changes so hopefully nothing is too broken. Ideally they can be tested sometime before split assemblies release