### PR TITLE
add back EnumerableExtensions

### DIFF
--- a/R2API.Core/MiscHelpers/EnumerableExtensions.cs
+++ b/R2API.Core/MiscHelpers/EnumerableExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+// This file namespace must be unchanged due to legacy purposes.
+
+namespace R2API.Utils;
+
+public static class EnumerableExtensions
+{
+
+    /// <summary>
+    /// ForEach but with a try catch in it.
+    /// </summary>
+    /// <param name="list">the enumerable object</param>
+    /// <param name="action">the action to do on it</param>
+    /// <param name="exceptions">the exception dictionary that will get filled, null by default if you simply want to silence the errors if any pop.</param>
+    /// <typeparam name="T"></typeparam>
+    public static void ForEachTry<T>(this IEnumerable<T>? list, Action<T>? action, IDictionary<T, Exception?>? exceptions = null)
+    {
+        list.ToList().ForEach(element => {
+            try
+            {
+                action(element);
+            }
+            catch (Exception exception)
+            {
+                exceptions?.Add(element, exception);
+            }
+        });
+    }
+}

--- a/R2API.Legacy/TypeForwards.cs
+++ b/R2API.Legacy/TypeForwards.cs
@@ -32,6 +32,7 @@ using TF = System.Runtime.CompilerServices.TypeForwardedToAttribute;
 [assembly: TF(typeof(R2API.Utils.ChatMessage))]
 [assembly: TF(typeof(R2API.Utils.CommandHelper))]
 [assembly: TF(typeof(R2API.Utils.DirectMessage))]
+[assembly: TF(typeof(R2API.Utils.EnumerableExtensions))]
 [assembly: TF(typeof(R2API.Utils.EmbeddedResources))]
 [assembly: TF(typeof(R2API.Utils.ManualLogSourceExtension))]
 [assembly: TF(typeof(R2API.Utils.CompatibilityLevel))]


### PR DESCRIPTION
Class got deleted in the refactor by mistake. Adding it back

![Error containing exception related to missing class EnumerableExtensions](https://cdn.discordapp.com/attachments/567836513078083584/1054181917689389126/image-3.png)