### PR TITLE
Fixed empty lobby browser

### DIFF
--- a/R2API.Difficulty/DifficultyAPI.cs
+++ b/R2API.Difficulty/DifficultyAPI.cs
@@ -144,7 +144,7 @@ public partial class DifficultyAPI
     private static DifficultyDef GetExtendedDifficultyDef(On.RoR2.DifficultyCatalog.orig_GetDifficultyDef orig, DifficultyIndex difficultyIndex)
     {
         if (difficultyAlreadyAdded)
-            return difficultyDefinitions[difficultyIndex];
+            return difficultyDefinitions.TryGetValue(difficultyIndex, out var difficultyDef) ? difficultyDef : null;
         return orig(difficultyIndex);
     }
 

--- a/R2API.Difficulty/README.md
+++ b/R2API.Difficulty/README.md
@@ -16,6 +16,9 @@ DifficultyAPI also comes bundled with the SerializableDifficultyDef, a Scriptabl
 
 ## Changelog
 
+### '1.0.2'
+* Fix multiplayer lobby being empty (including if you selected to show incompatible games).
+
 ### '1.0.1'
 * Fix hooks not being properly enabled.
 

--- a/R2API.Difficulty/thunderstore.toml
+++ b/R2API.Difficulty/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Difficulty"
-versionNumber = "1.0.1"
+versionNumber = "1.0.2"
 description = "API for adding custom in-game difficulties"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
The vanilla implementation of `DifficultyCatalog.GetDifficultyDef()` was handling out of bounds indices and just return null. And lobby browser would (I assume) display default difficulty which is rainstorm.
R2API on the other hand was throwing an exception in such cases, but there's a catch, it all was executed in a not awaited Task, so any exception was just silent.

Logged stackTrace myself just out of curiosity:
<details>
<summary>StackTrace</summary>
[Error  :R2API.Difficulty]   at R2API.DifficultyAPI.GetExtendedDifficultyDef (On.RoR2.DifficultyCatalog+orig_GetDifficultyDef orig, RoR2.DifficultyIndex difficultyIndex) [0x00000] in <9a72a7ea04974316b97f295c869a8f3a>:IL_0000 
  at DMD<>?503022336.Hook<RoR2.DifficultyCatalog::GetDifficultyDef>?-678958208 (RoR2.DifficultyIndex ) [0x00000] in <677b786581c54a81b079c89f1b51cf9f>:IL_0000 
  at RoR2.RemoteGameBrowser.AdvancedFilterRemoteGameProvider.<CreateTask>g__PassesFilters|5_1 (RoR2.RemoteGameBrowser.RemoteGameInfo& remoteGameInfo, RoR2.RemoteGameBrowser.AdvancedFilterRemoteGameProvider+<>c__DisplayClass5_1& ) [0x00000] in <abee4f3b46184662b4d0bd0bc9965114>:IL_0000 
  at RoR2.RemoteGameBrowser.AdvancedFilterRemoteGameProvider+<>c__DisplayClass5_0.<CreateTask>b__0 () [0x00000] in <abee4f3b46184662b4d0bd0bc9965114>:IL_0000 
  at System.Threading.Tasks.Task`1[TResult].InnerInvoke () [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.Tasks.Task.Execute () [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.Tasks.Task.ExecutionContextCallback (System.Object obj) [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task& currentTaskSlot) [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.Tasks.Task.ExecuteEntry (System.Boolean bPreventDoubleExecution) [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <44afb4564e9347cf99a1865351ea8f4a>:IL_0000
</details>