### PR TITLE
Remove BuildCI from build configurations.

### DIFF
--- a/R2API.sln
+++ b/R2API.sln
@@ -201,10 +201,6 @@ Global
 		{C085C476-2882-49CD-8FE4-71F88E4E5EEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C085C476-2882-49CD-8FE4-71F88E4E5EEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C085C476-2882-49CD-8FE4-71F88E4E5EEB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{238ED894-932A-40B8-BD59-0E0F16242C10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{238ED894-932A-40B8-BD59-0E0F16242C10}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{238ED894-932A-40B8-BD59-0E0F16242C10}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{238ED894-932A-40B8-BD59-0E0F16242C10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
BuildCI is only involved in preparing a thunderstore release (which manually invokes it with `dotnet run` ) so having it within the normal build does nothing of benefit beyond erroring out compilation on LTS compilers.