### PR TITLE
EliteAPI: Fix default/unset rampindex

### DIFF
--- a/R2API.Elites/EliteRamp.cs
+++ b/R2API.Elites/EliteRamp.cs
@@ -87,9 +87,7 @@ public static class EliteRamp
         EliteRamp.SetHooks();
         try
         {
-            if (eliteDef.shaderEliteRampIndex > 0)
-                eliteDef.shaderEliteRampIndex = 0;
-
+            eliteDef.shaderEliteRampIndex = 0;
             elitesAndRamps.Add((eliteDef, ramp));
         }
         catch (Exception ex)


### PR DESCRIPTION
Value for shaderEliteRampIndex initializes to -1.
Supporting negatives in the existing check renders it equivalent to `if(x!=0) x = 0` ,at which point just setting it no matter what is more efficent.