### PR TITLE
attackSpeedReductionMultAdd for RecalculateStatsAPI

### DIFF
--- a/R2API.RecalculateStats/README.md
+++ b/R2API.RecalculateStats/README.md
@@ -29,5 +29,8 @@ These stat changes are represented in the StatHookEventArgs, which includes argu
 
 ## Changelog
 
+### '1.0.1'
+* Added `attackSpeedReductionMultAdd` stat for reducing attack speed.
+
 ### '1.0.0'
 * Split from the main R2API.dll into its own submodule.

--- a/R2API.RecalculateStats/README.md
+++ b/R2API.RecalculateStats/README.md
@@ -29,7 +29,7 @@ These stat changes are represented in the StatHookEventArgs, which includes argu
 
 ## Changelog
 
-### '1.0.1'
+### '1.1.0'
 * Added `attackSpeedReductionMultAdd` stat for reducing attack speed.
 
 ### '1.0.0'

--- a/R2API.RecalculateStats/RecalculateStatsAPI.cs
+++ b/R2API.RecalculateStats/RecalculateStatsAPI.cs
@@ -21,7 +21,7 @@ public static partial class RecalculateStatsAPI
     /// <summary>
     /// Return true if the submodule is loaded.
     /// </summary>
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsoleteD
     [Obsolete(R2APISubmoduleDependency.PropertyObsolete)]
 #pragma warning restore CS0618 // Type or member is obsolete
     public static bool Loaded => true;
@@ -67,13 +67,13 @@ public static partial class RecalculateStatsAPI
         /// <summary>Added to base health regen. HEALTH_REGEN ~ (BASE_REGEN + baseRegenAdd) * (REGEN_MULT + regenMultAdd).</summary>
         public float baseRegenAdd = 0f;
 
-        /// <summary>Added to base move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd / MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
+        /// <summary>Added to base move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd) / (MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
         public float baseMoveSpeedAdd = 0f;
 
-        /// <summary>Added to the direct multiplier to move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd / MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
+        /// <summary>Added to the direct multiplier to move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd) / (MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
         public float moveSpeedMultAdd = 0f;
 
-        /// <summary>Added reduction multiplier to move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd / MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
+        /// <summary>Added reduction multiplier to move speed. MOVE_SPEED ~ (BASE_MOVE_SPEED + baseMoveSpeedAdd) * (MOVE_SPEED_MULT + moveSpeedMultAdd) / (MOVE_SPEED_REDUCTION_MULT + moveSpeedReductionMultAdd)</summary>
         public float moveSpeedReductionMultAdd = 0f;
 
         /// <summary>Added to the direct multiplier to jump power. JUMP_POWER ~ (BASE_JUMP_POWER + baseJumpPowerAdd) * (JUMP_POWER_MULT + jumpPowerMultAdd)</summary>
@@ -85,11 +85,14 @@ public static partial class RecalculateStatsAPI
         /// <summary>Added to base damage. DAMAGE ~ (BASE_DAMAGE + baseDamageAdd) * (DAMAGE_MULT + damageMultAdd).</summary>
         public float baseDamageAdd = 0f;
 
-        /// <summary>Added to attack speed. ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd).</summary>
+        /// <summary>Added to attack speed. ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd) / (ATTACK_SPEED_REDUCTION_MULT + attackSpeedReductionMultAdd).</summary>
         public float baseAttackSpeedAdd = 0f;
 
-        /// <summary>Added to the direct multiplier to attack speed. ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd).</summary>
+        /// <summary>Added to the direct multiplier to attack speed. ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd) / (ATTACK_SPEED_REDUCTION_MULT + attackSpeedReductionMultAdd).</summary>
         public float attackSpeedMultAdd = 0f;
+
+        /// <summary>Added reduction multiplier to attack speed. ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd) / (ATTACK_SPEED_REDUCTION_MULT + attackSpeedReductionMultAdd).</summary>
+        public float attackSpeedReductionMultAdd = 0f;
 
         /// <summary>Added to crit chance. CRIT_CHANCE ~ BASE_CRIT_CHANCE + critAdd.</summary>
         public float critAdd = 0f;
@@ -390,6 +393,8 @@ public static partial class RecalculateStatsAPI
             {
                 return origSpeedMult + StatMods.attackSpeedMultAdd;
             });
+            c.GotoNext(x => x.MatchDiv(), x => x.MatchStloc(locAttackSpeedMultIndex));
+            c.EmitDelegate<Func<float, float>>((origSpeedReductionMult) => origSpeedReductionMult + StatMods.attackSpeedReductionMultAdd);
         }
         else
         {

--- a/R2API.RecalculateStats/RecalculateStatsAPI.cs
+++ b/R2API.RecalculateStats/RecalculateStatsAPI.cs
@@ -21,7 +21,7 @@ public static partial class RecalculateStatsAPI
     /// <summary>
     /// Return true if the submodule is loaded.
     /// </summary>
-#pragma warning disable CS0618 // Type or member is obsoleteD
+#pragma warning disable CS0618 // Type or member is obsolete
     [Obsolete(R2APISubmoduleDependency.PropertyObsolete)]
 #pragma warning restore CS0618 // Type or member is obsolete
     public static bool Loaded => true;

--- a/R2API.RecalculateStats/RecalculateStatsAPI.cs
+++ b/R2API.RecalculateStats/RecalculateStatsAPI.cs
@@ -394,7 +394,7 @@ public static partial class RecalculateStatsAPI
                 return origSpeedMult + StatMods.attackSpeedMultAdd;
             });
             c.GotoNext(x => x.MatchDiv(), x => x.MatchStloc(locAttackSpeedMultIndex));
-            c.EmitDelegate<Func<float, float>>((origSpeedReductionMult) => origSpeedReductionMult + StatMods.attackSpeedReductionMultAdd);
+            c.EmitDelegate<Func<float, float>>((origSpeedReductionMult) => UnityEngine.Mathf.Max(UnityEngine.Mathf.Epsilon, origSpeedReductionMult + StatMods.attackSpeedReductionMultAdd));
         }
         else
         {

--- a/R2API.RecalculateStats/thunderstore.toml
+++ b/R2API.RecalculateStats/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_RecalculateStats"
-versionNumber = "1.0.0"
+versionNumber = "1.1.0"
 description = "API for manipulating Character Stats"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Try saying that five times fast..Implements #406. An attack speed reduction value exists in vanilla exclusively for Light Flux Pauldron. Works the same as `moveSpeedReductionMultAdd` where `ATTACK_SPEED ~ (BASE_ATTACK_SPEED + baseAttackSpeedAdd) * (ATTACK_SPEED_MULT + attackSpeedMultAdd) / (ATTACK_SPEED_REDUCTION_MULT + attackSpeedReductionMultAdd)`. Seems to perform as expected through basic testing.