### PR TITLE
Fix DamageAPI projectile hooks

### DIFF
--- a/R2API.DamageType/DamageAPI.cs
+++ b/R2API.DamageType/DamageAPI.cs
@@ -260,7 +260,7 @@ public static partial class DamageAPI
 
         c.GotoNext(
             MoveType.After,
-            x => x.MatchNewobj<OverlapAttack>());
+            x => x.MatchStfld<ProjectileOverlapAttack>(nameof(ProjectileOverlapAttack.attack)));
 
         c.Emit(OpCodes.Ldarg_0);
         c.Emit<ProjectileOverlapAttack>(OpCodes.Ldfld, nameof(ProjectileOverlapAttack.attack));
@@ -300,7 +300,7 @@ public static partial class DamageAPI
 
         c.GotoNext(
             MoveType.After,
-            x => x.MatchNewobj<OverlapAttack>());
+            x => x.MatchStfld<ProjectileDotZone>(nameof(ProjectileDotZone.attack)));
 
         c.Emit(OpCodes.Ldarg_0);
         c.Emit<ProjectileDotZone>(OpCodes.Ldfld, nameof(ProjectileDotZone.attack));

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -22,6 +22,9 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 
 ## Changelog
 
+### '1.0.2'
+* Fix projectile IL hooks
+
 ### '1.0.1'
 * Made IL hooks more robust to stop API failing because of other mods
 

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.0.1"
+versionNumber = "1.0.2"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Previous fix moved damageTypeHolder copy before damageInfo initialization for some projectile components