### PR TITLE
CompressedFlagArrayUtilities optimization

### DIFF
--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -18,6 +18,9 @@ Do not hestiate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ## Changelog
 
+### '5.0.5'
+* CompressedFlagArrayUtilities optimization
+
 ### '5.0.4'
 * Added SystemInitializerInjector class to the Utils namespace
 

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.0.4"
+versionNumber = "5.0.5"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.DamageType/DamageAPI.cs
+++ b/R2API.DamageType/DamageAPI.cs
@@ -961,7 +961,7 @@ public static partial class DamageAPI
     /// </summary>
     public class ModdedDamageTypeHolder
     {
-        private byte[] values;
+        private byte[] values = Array.Empty<byte>();
 
         public ModdedDamageTypeHolder() { SetHooks(); }
 
@@ -969,7 +969,10 @@ public static partial class DamageAPI
         {
             SetHooks();
 
-            this.values = values?.ToArray();
+            if (values.Length > 0)
+            {
+                this.values = values.ToArray();
+            }
         }
 
         /// <summary>
@@ -1057,21 +1060,23 @@ public static partial class DamageAPI
             DamageAPI.SetHooks();
             var holder = new ModdedDamageTypeHolder
             {
-                values = values?.ToArray()
+                values = values.Length == 0 ? values : values.ToArray()
             };
             return holder;
         }
 
         /// <summary>
-        /// Reads compressed value from the NerworkReader. More info about that can be found in the PR: https://github.com/risk-of-thunder/R2API/pull/284
+        /// Reads compressed value from the NerworkReader. More info about that can be found in the PRs:
+        /// https://github.com/risk-of-thunder/R2API/pull/284
+        /// https://github.com/risk-of-thunder/R2API/pull/464
         /// </summary>
         /// <param name="reader"></param>
         /// <returns></returns>
         public static ModdedDamageTypeHolder ReadFromNetworkReader(NetworkReader reader)
         {
             DamageAPI.SetHooks();
-            var values = CompressedFlagArrayUtilities.ReadFromNetworkReader(reader);
-            if (values == null)
+            var values = CompressedFlagArrayUtilities.ReadFromNetworkReader(reader, ModdedDamageTypeCount);
+            if (values.Length == 0)
             {
                 return null;
             }
@@ -1083,10 +1088,12 @@ public static partial class DamageAPI
         }
 
         /// <summary>
-        /// Writes compressed value to the NerworkWriter. More info about that can be found in the PR: https://github.com/risk-of-thunder/R2API/pull/284
+        /// Writes compressed value to the NerworkWriter. More info about that can be found in the PRs:
+        /// https://github.com/risk-of-thunder/R2API/pull/284
+        /// https://github.com/risk-of-thunder/R2API/pull/464
         /// </summary>
         /// <param name="writer"></param>
-        public void WriteToNetworkWriter(NetworkWriter writer) => CompressedFlagArrayUtilities.WriteToNetworkWriter(values, writer);
+        public void WriteToNetworkWriter(NetworkWriter writer) => CompressedFlagArrayUtilities.WriteToNetworkWriter(values, writer, ModdedDamageTypeCount);
     }
 
     /// <summary>
@@ -1099,7 +1106,7 @@ public static partial class DamageAPI
         //I can't just use ModdedDamageTypeHolder instead of byte[] because Unity can't serialize classes that come from assemblies
         //that are not present at startup (basically every mod) even if they use [Serializable] attribute.
         //Though Unity can serialize class if it inherit from MonoBehaviour or ScriptableObject.
-        private byte[] values;
+        private byte[] values = Array.Empty<byte>();
 
         /// <summary>
         /// Enable ModdedDamageType for this instance

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -22,6 +22,9 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 
 ## Changelog
 
+### '1.0.3'
+* Optimization
+
 ### '1.0.2'
 * Fix projectile IL hooks
 

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.0.2"
+versionNumber = "1.0.3"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Was there any need to? No. Did I do it anyways? Yes.

There is more optimization to be had in cases of 64+ reserved damage types (mainly memory efficiency), but I doubt we have that much even with deprecated mods, so it can wait for indefinite amount of time.

Changed a bit format of the data sent over network, compared to #284. Now:
* If there's 8 or less damage types reserved, only one byte will be sent. Purely flag values, no compression.
* If there's 64 or less damage types reserved, 1 section byte and 1-8 value bytes will be sent.
* Otherwise it's the same as in #284 except instead of 1-4 block part bytes and then 1-18 value bytes, now value bytes are written after each block part, i.e. 1 section byte [1 block part byte 1-6 value bytes] [1 block part byte 1-5 value bytes] 1 block part byte 1-4 value bytes] 1 block part byte 1-3 value bytes]