### PR TITLE
Skins Submodule

### DIFF
--- a/R2API.Core/AssemblyInfo.cs
+++ b/R2API.Core/AssemblyInfo.cs
@@ -43,3 +43,4 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
 [assembly: IVT("R2API.CommandHelper")]
 [assembly: IVT("R2API.Colors")]
 [assembly: IVT("R2API.Rules")]
+[assembly: IVT("R2API.Skins")]

--- a/R2API.Loadout/LoadoutAPI.cs
+++ b/R2API.Loadout/LoadoutAPI.cs
@@ -10,7 +10,7 @@ using RoR2.Skills;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
-
+using SkinDefInfoNew = R2API.SkinDefInfo;
 // ReSharper disable UnusedMember.Global
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -25,30 +25,18 @@ public static partial class LoadoutAPI
     public const string PluginGUID = R2API.PluginGUID + ".loadout";
     public const string PluginName = R2API.PluginName + ".Loadout";
 
-    public const string ObsoleteMessage = "The R2API version 4.x.x has made LoadoutAPI's Skill and entity state related methods and implementations obsolette.\n" +
-        "For adding new SkillDefs, SkillFamilies and EntityStates, use the ContentAddition class found in the R2API.ContentManagement assembly.\n" +
-        "The Skin methods of LoadoutAPI will be salvaged into an upcoming SkinAPI";
-    /// <summary>
-    /// Return true if the submodule is loaded.
-    /// </summary>
+    public const string ObsoleteMessage = "R2API 4.x.x has made LoadoutAPI Obsolete.\n" +
+        "For adding Skills, SkillFamilies and EntityStates, utilize the \"R2API.ContentManagement\" submodule.\n" +
+        "For adding Skins, utilize the \"R2API.Skins\" submodule.\n" +
+        "This submodule will be removed on the next major R2API release";
     // ReSharper disable once ConvertToAutoProperty
 #pragma warning disable CS0618 // Type or member is obsolete
     [Obsolete(R2APISubmoduleDependency.PropertyObsolete)]
 #pragma warning restore CS0618 // Type or member is obsolete
     public static bool Loaded => true;
-
-    private static readonly HashSet<SkinDef> AddedSkins = new HashSet<SkinDef>();
-
     #region Adding Skills
 
-    /// <summary>
-    /// Adds a type for a skill EntityState to the SkillsCatalog.
-    /// State must derive from EntityStates.EntityState.
-    /// Note that SkillDefs and SkillFamiles must also be added seperately.
-    /// </summary>
-    /// <param name="t">The type to add</param>
-    /// <returns>True if succesfully added</returns>
-    [Obsolete($"AddSkill is obsolete, please add your SkillTypes via R2API.ContentManagement.ContentAdditionHelpers.AddEntityState<T>()")]
+    [Obsolete($"AddSkill() is obsolete, please add your SkillTypes via R2API.ContentAddition.AddEntityState(Type, bool)")]
     public static bool AddSkill(Type? t)
     {
         if (!CatalogBlockers.GetAvailability<EntityState>())
@@ -66,13 +54,7 @@ public static partial class LoadoutAPI
         return true;
     }
 
-    /// <summary>
-    /// Creates a SerializableEntityStateType with a much simpler syntax
-    /// Effectively the same as new SerializableEntityStateType(typeof(T))
-    /// </summary>
-    /// <typeparam name="T">The state type</typeparam>
-    /// <returns>The created SerializableEntityStateType</returns>
-    [Obsolete($"StateTypeOf<T> is obsolete, please add your SkillTypes via R2API.ContentManagement.ContentAdditionHelpers.AddEntityState<T>()")]
+    [Obsolete($"StateTypeOf<T> is obsolete, please add your SkillTypes via R2API.ContentAddition.AddEntityState<T>(bool)")]
     public static SerializableEntityStateType StateTypeOf<T>()
         where T : EntityState, new()
     {
@@ -85,13 +67,7 @@ public static partial class LoadoutAPI
         return new SerializableEntityStateType(typeof(T));
     }
 
-    /// <summary>
-    /// Registers an event to add a SkillDef to the SkillDefCatalog.
-    /// Must be called before Catalog init (during Awake() or OnEnable())
-    /// </summary>
-    /// <param name="s">The SkillDef to add</param>
-    /// <returns>True if the event was registered</returns>
-    [Obsolete($"AddSkillDef is obsolete, please add your SkillDefs via R2API.ContentManagement.ContentAdditionHelpers.AddSkillDef()")]
+    [Obsolete($"AddSkillDef is obsolete, please add your SkillDefs via R2API.ContentAddition.AddSkillDef(SkillDef)")]
     public static bool AddSkillDef(SkillDef? s)
     {
         if (!CatalogBlockers.GetAvailability<SkillDef>())
@@ -108,13 +84,7 @@ public static partial class LoadoutAPI
         return true;
     }
 
-    /// <summary>
-    /// Registers an event to add a SkillFamily to the SkillFamiliesCatalog
-    /// Must be called before Catalog init (during Awake() or OnEnable())
-    /// </summary>
-    /// <param name="sf">The skillfamily to add</param>
-    /// <returns>True if the event was registered</returns>
-    [Obsolete($"AddSkillFamily is obsolete, please add your SkillFamilies via R2API.ContentManagement.ContentAdditionHelpers.AddSkillFamily()")]
+    [Obsolete($"AddSkillFamily is obsolete, please add your SkillFamilies via R2API.ContentAddition.AddSkillFamily(SkillFamily)")]
     public static bool AddSkillFamily(SkillFamily? sf)
     {
         if (!CatalogBlockers.GetAvailability<SkillFamily>())
@@ -134,101 +104,19 @@ public static partial class LoadoutAPI
 
     #region Adding Skins
 
-    /// <summary>
-    /// Creates a skin icon sprite styled after the ones already in the game.
-    /// </summary>
-    /// <param name="top">The color of the top portion</param>
-    /// <param name="right">The color of the right portion</param>
-    /// <param name="bottom">The color of the bottom portion</param>
-    /// <param name="left">The color of the left portion</param>
-    /// <returns>The icon sprite</returns>
+    [Obsolete($"Create Skin Icons using R2API.Skins.CreateSkinIcon(Color, Color, Color, Color)")]
     public static Sprite CreateSkinIcon(Color top, Color right, Color bottom, Color left)
     {
-        return CreateSkinIcon(top, right, bottom, left, new Color(0.6f, 0.6f, 0.6f));
+        return Skins.CreateSkinIcon(top, right, bottom, left, new Color(0.6f, 0.6f, 0.6f));
     }
 
-    /// <summary>
-    /// Creates a skin icon sprite styled after the ones already in the game.
-    /// </summary>
-    /// <param name="top">The color of the top portion</param>
-    /// <param name="right">The color of the right portion</param>
-    /// <param name="bottom">The color of the bottom portion</param>
-    /// <param name="left">The color of the left portion</param>
-    /// <param name="line">The color of the dividing lines</param>
-    /// <returns></returns>
+    [Obsolete($"Create Skin Icons using R2API.Skins.CreateSkinIcon(Color, Color, Color, Color, Color)")]
     public static Sprite CreateSkinIcon(Color top, Color right, Color bottom, Color left, Color line)
     {
-        var tex = new Texture2D(128, 128, TextureFormat.RGBA32, false);
-        new IconTexJob
-        {
-            Top = top,
-            Bottom = bottom,
-            Right = right,
-            Left = left,
-            Line = line,
-            TexOutput = tex.GetRawTextureData<Color32>()
-        }.Schedule(16384, 1).Complete();
-        tex.wrapMode = TextureWrapMode.Clamp;
-        tex.Apply();
-        return Sprite.Create(tex, new Rect(0, 0, 128, 128), new Vector2(0.5f, 0.5f));
+        return Skins.CreateSkinIcon(top, right, bottom, left, new Color(0.6f, 0.6f, 0.6f));
     }
 
-    private struct IconTexJob : IJobParallelFor
-    {
-
-        [ReadOnly]
-        public Color32 Top;
-
-        [ReadOnly]
-        public Color32 Right;
-
-        [ReadOnly]
-        public Color32 Bottom;
-
-        [ReadOnly]
-        public Color32 Left;
-
-        [ReadOnly]
-        public Color32 Line;
-
-        public NativeArray<Color32> TexOutput;
-
-        public void Execute(int index)
-        {
-            int x = index % 128 - 64;
-            int y = index / 128 - 64;
-
-            if (Math.Abs(Math.Abs(y) - Math.Abs(x)) <= 2)
-            {
-                TexOutput[index] = Line;
-                return;
-            }
-            if (y > x && y > -x)
-            {
-                TexOutput[index] = Top;
-                return;
-            }
-            if (y < x && y < -x)
-            {
-                TexOutput[index] = Bottom;
-                return;
-            }
-            if (y > x && y < -x)
-            {
-                TexOutput[index] = Left;
-                return;
-            }
-            if (y < x && y > -x)
-            {
-                TexOutput[index] = Right;
-            }
-        }
-    }
-
-    /// <summary>
-    /// A container struct for all SkinDef parameters.
-    /// Use this to set skinDef values, then call CreateNewSkinDef().
-    /// </summary>
+    [Obsolete($"Utilize the SkinDefInfo in the R2API namespace instead of this nested type.s")]
     public struct SkinDefInfo
     {
         public SkinDef?[]? BaseSkins;
@@ -242,168 +130,43 @@ public static partial class LoadoutAPI
         public SkinDef.ProjectileGhostReplacement[]? ProjectileGhostReplacements;
         public SkinDef.MinionSkinReplacement[]? MinionSkinReplacements;
         public string? Name;
+
+        //For backwards compat
+        public static implicit operator SkinDefInfoNew(SkinDefInfo orig)
+        {
+            return new SkinDefInfoNew
+            {
+                BaseSkins = orig.BaseSkins,
+                Icon = orig.Icon,
+                NameToken = orig.NameToken,
+                UnlockableDef = orig.UnlockableDef,
+                RootObject = orig.RootObject,
+                RendererInfos = orig.RendererInfos,
+                MeshReplacements = orig.MeshReplacements,
+                GameObjectActivations = orig.GameObjectActivations,
+                ProjectileGhostReplacements = orig.ProjectileGhostReplacements,
+                MinionSkinReplacements = orig.MinionSkinReplacements,
+                Name = orig.Name,
+            };
+        }
     }
 
-    /// <summary>
-    /// Creates a new SkinDef from a SkinDefInfo.
-    /// Note that this prevents null-refs by disabling SkinDef awake while the SkinDef is being created.
-    /// The things that occur during awake are performed when first applied to a character instead.
-    /// </summary>
-    /// <param name="skin"></param>
-    /// <returns></returns>
+    [Obsolete("Create SkinDefs using R2API.Skins.CreateNewSkinDef(SkinDefInfo)")]
     public static SkinDef CreateNewSkinDef(SkinDefInfo skin)
     {
-        On.RoR2.SkinDef.Awake += DoNothing;
-
-        var newSkin = ScriptableObject.CreateInstance<SkinDef>();
-
-        newSkin.baseSkins = skin.BaseSkins ?? Array.Empty<SkinDef>();
-        newSkin.icon = skin.Icon;
-        newSkin.unlockableDef = skin.UnlockableDef;
-        newSkin.rootObject = skin.RootObject;
-        newSkin.rendererInfos = skin.RendererInfos ?? Array.Empty<CharacterModel.RendererInfo>();
-        newSkin.gameObjectActivations = skin.GameObjectActivations ?? Array.Empty<SkinDef.GameObjectActivation>();
-        newSkin.meshReplacements = skin.MeshReplacements ?? Array.Empty<SkinDef.MeshReplacement>();
-        newSkin.projectileGhostReplacements = skin.ProjectileGhostReplacements ?? Array.Empty<SkinDef.ProjectileGhostReplacement>();
-        newSkin.minionSkinReplacements = skin.MinionSkinReplacements ?? Array.Empty<SkinDef.MinionSkinReplacement>();
-        newSkin.nameToken = skin.NameToken;
-        newSkin.name = skin.Name;
-
-        On.RoR2.SkinDef.Awake -= DoNothing;
-
-        AddedSkins.Add(newSkin);
-        return newSkin;
+        return Skins.CreateNewSkinDef(skin);
     }
 
-    /// <summary>
-    /// Adds a skin to the body prefab for a character.
-    /// Will attempt to create a default skin if one is not present.
-    /// Must be called during plugin Awake or OnEnable. If called afterwards the new skins must be added to bodycatalog manually.
-    /// </summary>
-    /// <param name="bodyPrefab">The body to add the skin to</param>
-    /// <param name="skin">The SkinDefInfo for the skin to add</param>
-    /// <returns>True if successful</returns>
+    [Obsolete($"Add Skins to Characters using R2API.Skins.AddSkinToCharacter(GameObject, SkinDefInfo)")]
     public static bool AddSkinToCharacter(GameObject? bodyPrefab, SkinDefInfo skin)
     {
-        var skinDef = CreateNewSkinDef(skin);
-        return AddSkinToCharacter(bodyPrefab, skinDef);
+        return Skins.AddSkinToCharacter(bodyPrefab, skin);
     }
 
-    /// <summary>
-    /// Adds a skin to the body prefab for a character.
-    /// Will attempt to create a default skin if one is not present.
-    /// Must be called during plugin Awake or OnEnable. If called afterwards the new skins must be added to bodycatalog manually.
-    /// </summary>
-    /// <param name="bodyPrefab">The body to add the skin to</param>
-    /// <param name="skin">The SkinDef to add</param>
-    /// <returns>True if successful</returns>
+    [Obsolete($"Add Skins to Characters using R2API.Skins.AddSkinToCharacter(GameObject, SkinDef)")]
     public static bool AddSkinToCharacter(GameObject? bodyPrefab, SkinDef? skin)
     {
-        if (bodyPrefab == null)
-        {
-            LoadoutPlugin.Logger.LogError("Tried to add skin to null body prefab.");
-            return false;
-        }
-
-        if (skin == null)
-        {
-            LoadoutPlugin.Logger.LogError("Tried to add invalid skin.");
-            return false;
-        }
-        AddedSkins.Add(skin);
-
-        var modelLocator = bodyPrefab.GetComponent<ModelLocator>();
-        if (modelLocator == null)
-        {
-            LoadoutPlugin.Logger.LogError("Tried to add skin to invalid body prefab (No ModelLocator).");
-            return false;
-        }
-
-        var model = modelLocator.modelTransform;
-        if (model == null)
-        {
-            LoadoutPlugin.Logger.LogError("Tried to add skin to body prefab with no modelTransform.");
-            return false;
-        }
-
-        if (skin.rootObject != model.gameObject)
-        {
-            LoadoutPlugin.Logger.LogError("Tried to add skin with improper root object set.");
-            return false;
-        }
-
-        var modelSkins = model.GetComponent<ModelSkinController>();
-        if (modelSkins == null)
-        {
-            LoadoutPlugin.Logger.LogWarning(bodyPrefab.name + " does not have a modelSkinController.\nAdding a new one and attempting to populate the default skin.\nHighly recommended you set the controller up manually.");
-            var charModel = model.GetComponent<CharacterModel>();
-            if (charModel == null)
-            {
-                LoadoutPlugin.Logger.LogError("Unable to locate CharacterModel, default skin creation aborted.");
-                return false;
-            }
-
-            var skinnedRenderer = charModel.mainSkinnedMeshRenderer;
-            if (skinnedRenderer == null)
-            {
-                LoadoutPlugin.Logger.LogError("CharacterModel did not contain a main SkinnedMeshRenderer, default skin creation aborted.");
-                return false;
-            }
-
-            var baseRenderInfos = charModel.baseRendererInfos;
-            if (baseRenderInfos == null || baseRenderInfos.Length == 0)
-            {
-                LoadoutPlugin.Logger.LogError("CharacterModel rendererInfos are invalid, default skin creation aborted.");
-                return false;
-            }
-
-            modelSkins = model.gameObject.AddComponent<ModelSkinController>();
-
-            var skinDefInfo = new SkinDefInfo
-            {
-                BaseSkins = Array.Empty<SkinDef>(),
-                GameObjectActivations = Array.Empty<SkinDef.GameObjectActivation>(),
-                Icon = CreateDefaultSkinIcon(),
-                Name = "skin" + bodyPrefab.name + "Default",
-                NameToken = bodyPrefab.name.ToUpper() + "_DEFAULT_SKIN_NAME",
-                RootObject = model.gameObject,
-                UnlockableDef = null,
-                MeshReplacements = new[]
-                {
-                    new SkinDef.MeshReplacement {
-                        renderer = skinnedRenderer,
-                        mesh = skinnedRenderer.sharedMesh
-                    }
-                },
-                RendererInfos = charModel.baseRendererInfos,
-                ProjectileGhostReplacements = Array.Empty<SkinDef.ProjectileGhostReplacement>(),
-                MinionSkinReplacements = Array.Empty<SkinDef.MinionSkinReplacement>()
-            };
-
-            var defaultSkinDef = CreateNewSkinDef(skinDefInfo);
-
-            modelSkins.skins = new[] {
-                defaultSkinDef
-            };
-        }
-
-        var skinsArray = modelSkins.skins;
-        var index = skinsArray.Length;
-        Array.Resize(ref skinsArray, index + 1);
-        skinsArray[index] = skin;
-        modelSkins.skins = skinsArray;
-        return true;
+        return Skins.AddSkinToCharacter(bodyPrefab, skin);
     }
-
-    private static Sprite CreateDefaultSkinIcon()
-    {
-        return CreateSkinIcon(Color.red, Color.green, Color.blue, Color.black);
-    }
-
-    private static void DoNothing(On.RoR2.SkinDef.orig_Awake orig, SkinDef self)
-    {
-        //Intentionally do nothing
-    }
-
     #endregion Adding Skins
 }

--- a/R2API.Loadout/R2API.Loadout.csproj
+++ b/R2API.Loadout/R2API.Loadout.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
     <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
     <ProjectReference Include="../R2API.ContentManagement/R2API.ContentManagement.csproj" Private="false"/>
+    <ProjectReference Include="..\R2API.Skins\R2API.Skins.csproj" Private ="false"/>
   </ItemGroup>
 </Project>

--- a/R2API.Skins/IconTexJob.cs
+++ b/R2API.Skins/IconTexJob.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace R2API;
+
+internal struct IconTexJob : IJobParallelFor
+{
+
+    [ReadOnly]
+    public Color32 Top;
+
+    [ReadOnly]
+    public Color32 Right;
+
+    [ReadOnly]
+    public Color32 Bottom;
+
+    [ReadOnly]
+    public Color32 Left;
+
+    [ReadOnly]
+    public Color32 Line;
+
+    public NativeArray<Color32> TexOutput;
+
+    public void Execute(int index)
+    {
+        int x = index % 128 - 64;
+        int y = index / 128 - 64;
+
+        if (Math.Abs(Math.Abs(y) - Math.Abs(x)) <= 2)
+        {
+            TexOutput[index] = Line;
+            return;
+        }
+        if (y > x && y > -x)
+        {
+            TexOutput[index] = Top;
+            return;
+        }
+        if (y < x && y < -x)
+        {
+            TexOutput[index] = Bottom;
+            return;
+        }
+        if (y > x && y < -x)
+        {
+            TexOutput[index] = Left;
+            return;
+        }
+        if (y < x && y > -x)
+        {
+            TexOutput[index] = Right;
+        }
+    }
+}

--- a/R2API.Skins/OverrideData.cs
+++ b/R2API.Skins/OverrideData.cs
@@ -1,0 +1,5 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace R2API;

--- a/R2API.Skins/OverrideData.cs
+++ b/R2API.Skins/OverrideData.cs
@@ -1,5 +1,0 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace R2API;

--- a/R2API.Skins/R2API.Skins.csproj
+++ b/R2API.Skins/R2API.Skins.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
     <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>

--- a/R2API.Skins/README.md
+++ b/R2API.Skins/README.md
@@ -1,0 +1,13 @@
+# R2API.Skins - Adding new Skins and Skin-Specific IDRS
+
+## About
+
+R2API.Skins is a submodule for R2API that takes the Skin related methods and utilities from ``R2API.Loadout`` and implements them in this new submodule
+
+Alongside the old skin creation methods from ``R2API.Loadout``, R2API.Skins also contains utilities for improving the skin experience, such as having Skin-Specific ItemDisplayRuleSets.
+
+## Changelog
+
+### '1.0.0'
+
+* Initial Release

--- a/R2API.Skins/SkinDefInfo.cs
+++ b/R2API.Skins/SkinDefInfo.cs
@@ -1,0 +1,26 @@
+﻿using RoR2;
+using UnityEngine;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace R2API;
+
+/// <summary>
+/// A container struct for all SkinDef parameters.
+/// Use this to set skinDef values, then call CreateNewSkinDef().
+/// </summary>
+public struct SkinDefInfo
+{
+    public SkinDef?[]? BaseSkins;
+    public Sprite? Icon;
+    public string? NameToken;
+    public UnlockableDef? UnlockableDef;
+    public GameObject? RootObject;
+    public CharacterModel.RendererInfo[]? RendererInfos;
+    public SkinDef.MeshReplacement[]? MeshReplacements;
+    public SkinDef.GameObjectActivation[]? GameObjectActivations;
+    public SkinDef.ProjectileGhostReplacement[]? ProjectileGhostReplacements;
+    public SkinDef.MinionSkinReplacement[]? MinionSkinReplacements;
+    public string? Name;
+}

--- a/R2API.Skins/SkinIDRS.cs
+++ b/R2API.Skins/SkinIDRS.cs
@@ -1,0 +1,87 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace R2API;
+
+/// <summary>
+/// Class for adding Skin Specific ItemDisplayRuleSets for skin defs.
+/// </summary>
+public static class SkinIDRS
+{
+    private static List<(SkinDef, ItemDisplayRuleSet)> tuples = new List<(SkinDef, ItemDisplayRuleSet)>();
+    private static Dictionary<SkinIndex, ItemDisplayRuleSet> skinIndexToCustomIDRS = new Dictionary<SkinIndex, ItemDisplayRuleSet>();
+
+    private static bool hooksSet = false;
+    private static bool catalogInitialized = false;
+    /// <summary>
+    /// Adds a pair of SkinDef and ItemDisplayRuleSet
+    /// <para>Ingame, once the Skin is applied to the model, the default IDRS will be swapped for the one specified in <paramref name="ruleSet"/></para>
+    /// </summary>
+    /// <param name="skinDef"></param>
+    /// <param name="ruleSet"></param>
+    /// <returns>True if added succesfully, false otherwise</returns>
+    public static bool AddPair(SkinDef skinDef, ItemDisplayRuleSet ruleSet)
+    {
+        SetHooks();
+
+        if (catalogInitialized)
+        {
+            SkinsPlugin.Logger.LogInfo($"Cannot add pair {skinDef} && {ruleSet} as the SkinCatalog has already initialized.");
+            return false;
+        }
+
+        if (tuples.Any(t => t.Item1 == skinDef))
+        {
+            SkinsPlugin.Logger.LogInfo($"Cannot add pair {skinDef} && {ruleSet}, the skin {skinDef} already has an entry associated to it.");
+            return false;
+        }
+
+        tuples.Add((skinDef, ruleSet));
+        return true;
+    }
+
+    [SystemInitializer(typeof(SkinCatalog))]
+    private static void SystemInit()
+    {
+        catalogInitialized = true;
+        foreach(var (skinDef, idrs) in tuples)
+        {
+            skinIndexToCustomIDRS.Add(skinDef.skinIndex, idrs);
+        }
+        tuples.Clear();
+    }
+
+    internal static void SetHooks()
+    {
+        if (hooksSet)
+            return;
+        hooksSet = true;
+
+        On.RoR2.ModelSkinController.ApplySkin += SetCustomIDRS;
+    }
+
+    private static void SetCustomIDRS(On.RoR2.ModelSkinController.orig_ApplySkin orig, ModelSkinController self, int skinIndex)
+    {
+        orig(self, skinIndex);
+        if (!self.characterModel)
+            return;
+
+        SkinDef skin = HG.ArrayUtils.GetSafe(self.skins, skinIndex);
+        if (!skin)
+            return;
+
+        if(skinIndexToCustomIDRS.TryGetValue(skin.skinIndex, out var idrs))
+        {
+            self.characterModel.itemDisplayRuleSet = idrs;
+        }
+    }
+
+    internal static void UnsetHooks()
+    {
+        hooksSet = false;
+        On.RoR2.ModelSkinController.ApplySkin -= SetCustomIDRS;
+    }
+}

--- a/R2API.Skins/Skins.cs
+++ b/R2API.Skins/Skins.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EntityStates;
+using R2API.AutoVersionGen;
+using R2API.Utils;
+using RoR2;
+using RoR2.Skills;
+using Unity.Jobs;
+using UnityEngine;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace R2API;
+#pragma warning disable CS0436 // Type conflicts with imported type
+[AutoVersion]
+#pragma warning restore CS0436 // Type conflicts with imported type
+public static partial class Skins
+{
+    public const string PluginGUID = R2API.PluginGUID + ".skins";
+    public const string PluginName = R2API.PluginName + ".Skins";
+
+    private static readonly HashSet<SkinDef> AddedSkins = new HashSet<SkinDef>();
+
+    /// <summary>
+    /// Creates a skin icon sprite styled after the ones already in the game.
+    /// </summary>
+    /// <param name="top">The color of the top portion</param>
+    /// <param name="right">The color of the right portion</param>
+    /// <param name="bottom">The color of the bottom portion</param>
+    /// <param name="left">The color of the left portion</param>
+    /// <returns>The icon sprite</returns>
+    public static Sprite CreateSkinIcon(Color top, Color right, Color bottom, Color left)
+    {
+        return CreateSkinIcon(top, right, bottom, left, new Color(0.6f, 0.6f, 0.6f));
+    }
+
+    /// <summary>
+    /// Creates a skin icon sprite styled after the ones already in the game.
+    /// </summary>
+    /// <param name="top">The color of the top portion</param>
+    /// <param name="right">The color of the right portion</param>
+    /// <param name="bottom">The color of the bottom portion</param>
+    /// <param name="left">The color of the left portion</param>
+    /// <param name="line">The color of the dividing lines</param>
+    /// <returns></returns>
+    public static Sprite CreateSkinIcon(Color top, Color right, Color bottom, Color left, Color line)
+    {
+        var tex = new Texture2D(128, 128, TextureFormat.RGBA32, false);
+        new IconTexJob
+        {
+            Top = top,
+            Bottom = bottom,
+            Right = right,
+            Left = left,
+            Line = line,
+            TexOutput = tex.GetRawTextureData<Color32>()
+        }.Schedule(16384, 1).Complete();
+        tex.wrapMode = TextureWrapMode.Clamp;
+        tex.Apply();
+        return Sprite.Create(tex, new Rect(0, 0, 128, 128), new Vector2(0.5f, 0.5f));
+    }
+
+    /// <summary>
+    /// Creates a new SkinDef from a SkinDefInfo.
+    /// Note that this prevents null-refs by disabling SkinDef awake while the SkinDef is being created.
+    /// The things that occur during awake are performed when first applied to a character instead.
+    /// </summary>
+    /// <param name="skin"></param>
+    /// <returns></returns>
+    public static SkinDef CreateNewSkinDef(SkinDefInfo skin)
+    {
+        On.RoR2.SkinDef.Awake += DoNothing;
+
+        var newSkin = ScriptableObject.CreateInstance<SkinDef>();
+
+        newSkin.baseSkins = skin.BaseSkins ?? Array.Empty<SkinDef>();
+        newSkin.icon = skin.Icon;
+        newSkin.unlockableDef = skin.UnlockableDef;
+        newSkin.rootObject = skin.RootObject;
+        newSkin.rendererInfos = skin.RendererInfos ?? Array.Empty<CharacterModel.RendererInfo>();
+        newSkin.gameObjectActivations = skin.GameObjectActivations ?? Array.Empty<SkinDef.GameObjectActivation>();
+        newSkin.meshReplacements = skin.MeshReplacements ?? Array.Empty<SkinDef.MeshReplacement>();
+        newSkin.projectileGhostReplacements = skin.ProjectileGhostReplacements ?? Array.Empty<SkinDef.ProjectileGhostReplacement>();
+        newSkin.minionSkinReplacements = skin.MinionSkinReplacements ?? Array.Empty<SkinDef.MinionSkinReplacement>();
+        newSkin.nameToken = skin.NameToken;
+        newSkin.name = skin.Name;
+
+        On.RoR2.SkinDef.Awake -= DoNothing;
+
+        AddedSkins.Add(newSkin);
+        return newSkin;
+    }
+
+    /// <summary>
+    /// Adds a skin to the body prefab for a character.
+    /// Will attempt to create a default skin if one is not present.
+    /// Must be called during plugin Awake or OnEnable. If called afterwards the new skins must be added to bodycatalog manually.
+    /// </summary>
+    /// <param name="bodyPrefab">The body to add the skin to</param>
+    /// <param name="skin">The SkinDefInfo for the skin to add</param>
+    /// <returns>True if successful</returns>
+    public static bool AddSkinToCharacter(GameObject? bodyPrefab, SkinDefInfo skin)
+    {
+        var skinDef = CreateNewSkinDef(skin);
+        return AddSkinToCharacter(bodyPrefab, skinDef);
+    }
+
+    /// <summary>
+    /// Adds a skin to the body prefab for a character.
+    /// Will attempt to create a default skin if one is not present.
+    /// Must be called during plugin Awake or OnEnable. If called afterwards the new skins must be added to bodycatalog manually.
+    /// </summary>
+    /// <param name="bodyPrefab">The body to add the skin to</param>
+    /// <param name="skin">The SkinDef to add</param>
+    /// <returns>True if successful</returns>
+    public static bool AddSkinToCharacter(GameObject? bodyPrefab, SkinDef? skin)
+    {
+        if (bodyPrefab == null)
+        {
+            SkinsPlugin.Logger.LogError("Tried to add skin to null body prefab.");
+            return false;
+        }
+
+        if (skin == null)
+        {
+            SkinsPlugin.Logger.LogError("Tried to add invalid skin.");
+            return false;
+        }
+        AddedSkins.Add(skin);
+
+        var modelLocator = bodyPrefab.GetComponent<ModelLocator>();
+        if (modelLocator == null)
+        {
+            SkinsPlugin.Logger.LogError("Tried to add skin to invalid body prefab (No ModelLocator).");
+            return false;
+        }
+
+        var model = modelLocator.modelTransform;
+        if (model == null)
+        {
+            SkinsPlugin.Logger.LogError("Tried to add skin to body prefab with no modelTransform.");
+            return false;
+        }
+
+        if (skin.rootObject != model.gameObject)
+        {
+            SkinsPlugin.Logger.LogError("Tried to add skin with improper root object set.");
+            return false;
+        }
+
+        var modelSkins = model.GetComponent<ModelSkinController>();
+        if (modelSkins == null)
+        {
+            SkinsPlugin.Logger.LogWarning(bodyPrefab.name + " does not have a modelSkinController.\nAdding a new one and attempting to populate the default skin.\nHighly recommended you set the controller up manually.");
+            var charModel = model.GetComponent<CharacterModel>();
+            if (charModel == null)
+            {
+                SkinsPlugin.Logger.LogError("Unable to locate CharacterModel, default skin creation aborted.");
+                return false;
+            }
+
+            var skinnedRenderer = charModel.mainSkinnedMeshRenderer;
+            if (skinnedRenderer == null)
+            {
+                SkinsPlugin.Logger.LogError("CharacterModel did not contain a main SkinnedMeshRenderer, default skin creation aborted.");
+                return false;
+            }
+
+            var baseRenderInfos = charModel.baseRendererInfos;
+            if (baseRenderInfos == null || baseRenderInfos.Length == 0)
+            {
+                SkinsPlugin.Logger.LogError("CharacterModel rendererInfos are invalid, default skin creation aborted.");
+                return false;
+            }
+
+            modelSkins = model.gameObject.AddComponent<ModelSkinController>();
+
+            var skinDefInfo = new SkinDefInfo
+            {
+                BaseSkins = Array.Empty<SkinDef>(),
+                GameObjectActivations = Array.Empty<SkinDef.GameObjectActivation>(),
+                Icon = CreateDefaultSkinIcon(),
+                Name = "skin" + bodyPrefab.name + "Default",
+                NameToken = bodyPrefab.name.ToUpper() + "_DEFAULT_SKIN_NAME",
+                RootObject = model.gameObject,
+                UnlockableDef = null,
+                MeshReplacements = new[]
+                {
+                    new SkinDef.MeshReplacement {
+                        renderer = skinnedRenderer,
+                        mesh = skinnedRenderer.sharedMesh
+                    }
+                },
+                RendererInfos = charModel.baseRendererInfos,
+                ProjectileGhostReplacements = Array.Empty<SkinDef.ProjectileGhostReplacement>(),
+                MinionSkinReplacements = Array.Empty<SkinDef.MinionSkinReplacement>()
+            };
+
+            var defaultSkinDef = CreateNewSkinDef(skinDefInfo);
+
+            modelSkins.skins = new[] {
+                defaultSkinDef
+            };
+        }
+
+        var skinsArray = modelSkins.skins;
+        var index = skinsArray.Length;
+        Array.Resize(ref skinsArray, index + 1);
+        skinsArray[index] = skin;
+        modelSkins.skins = skinsArray;
+        return true;
+    }
+
+    private static Sprite CreateDefaultSkinIcon()
+    {
+        return CreateSkinIcon(Color.red, Color.green, Color.blue, Color.black);
+    }
+
+    private static void DoNothing(On.RoR2.SkinDef.orig_Awake orig, SkinDef self)
+    {
+        //Intentionally do nothing
+    }
+}

--- a/R2API.Skins/SkinsPlugin.cs
+++ b/R2API.Skins/SkinsPlugin.cs
@@ -1,0 +1,28 @@
+using BepInEx;
+using BepInEx.Logging;
+using System;
+
+[assembly: HG.Reflection.SearchableAttribute.OptIn]
+
+namespace R2API;
+
+[BepInPlugin(Skins.PluginGUID, Skins.PluginName, Skins.PluginVersion)]
+public sealed class SkinsPlugin : BaseUnityPlugin
+{
+    internal static new ManualLogSource Logger { get; set; }
+
+    private void Awake()
+    {
+        Logger = base.Logger;
+    }
+
+    private void OnEnable()
+    {
+        SkinIDRS.SetHooks();
+    }
+
+    private void OnDisable()
+    {
+        SkinIDRS.UnsetHooks();
+    }
+}

--- a/R2API.Skins/thunderstore.toml
+++ b/R2API.Skins/thunderstore.toml
@@ -4,9 +4,9 @@ schemaVersion = "0.0.1"
 
 [package]
 namespace = "RiskofThunder"
-name = "R2API_Loadout"
-versionNumber = "1.0.1"
-description = "API for registering skills, skins and entity states"
+name = "R2API_Skins"
+versionNumber = "1.0.0"
+description = "R2API Submodule for adding custom Skins and Skin-related utilities to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 
@@ -14,8 +14,6 @@ containsNsfwContent = false
 bbepis-BepInExPack = "5.4.2103"
 RiskofThunder-HookGenPatcher = "1.2.3"
 RiskofThunder-R2API_Core = "1.0.0"
-RiskofThunder-R2API_ContentManagement = "1.0.0"
-RiskofThunder-R2API_Skins = "1.0.0"
 
 [build]
 icon = "../icon.png"
@@ -24,7 +22,7 @@ outdir = "./build"
 
 [[build.copy]]
 source = "./ReleaseOutput"
-target = "./plugins/R2API.Loadout"
+target = "./plugins/R2API.Skins"
 
 [publish]
 repository = "https://thunderstore.io"

--- a/R2API.sln
+++ b/R2API.sln
@@ -85,6 +85,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildCI", "BuildCI\BuildCI.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Rules", "R2API.Rules\R2API.Rules.csproj", "{EE0946D0-2181-49BD-AF1E-75DBA3DA89AF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Skins", "R2API.Skins\R2API.Skins.csproj", "{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,10 @@ Global
 		{EE0946D0-2181-49BD-AF1E-75DBA3DA89AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE0946D0-2181-49BD-AF1E-75DBA3DA89AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE0946D0-2181-49BD-AF1E-75DBA3DA89AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This Pull request changes 2 Submodules.

The main new change is the Skins submodule, which is basically an "extraction" of LoadoutAPI's Skin features, including the Sprite creation job, the SkinDefInfo struct, ETC.

The other change is completely deprecating LoadoutAPI, LoadoutAPI's methods now mostly just use either ContenttManagement's ContentAddition class, and it's Skin related systems have been salvaged to the new Submodule, Skins.
LoadoutAPI's SkinDefInfo struct now has an implicit operator for Skins submodule's SkinDefInfo, which with my tests have proved that this new submodule change wont break mods, as I've also added the Skins submodule to LoadoutAPI's dependencies.

Apart from using LoadoutAPI's skin systems, the Skin submodule also now comes with Skin Specific IDRS replacements. which allows users to create IDRS for specific skins.

Example shown here, of the Skin specific IDRS system.
![](https://media.discordapp.net/attachments/567832879879553037/1096209210376720494/image.png?width=1202&height=676) ![](https://media.discordapp.net/attachments/567832879879553037/1096209210829701210/image.png?width=1202&height=676)