### PR TITLE
Fix R2API.Core NuGet Package

### DIFF
--- a/R2API.Core/R2API.Core.csproj
+++ b/R2API.Core/R2API.Core.csproj
@@ -1,14 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
-  <ItemGroup>
-    <PackageReference Include="bbepis-BepInExPack" Version="5.4.2109" GeneratePathProperty="true" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="RoR2BepInExPack">
-      <HintPath>$(Pkgbbepis-BepInExPack)\lib\$(TargetFramework)\RoR2BepInExPack.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-  
 </Project>

--- a/R2API.props
+++ b/R2API.props
@@ -18,11 +18,17 @@
         <ProjectReference Include="../R2API.AutoVersionGen/R2API.AutoVersionGen.csproj" OutputItemType="analyzer" ReferenceOutputAssembly="false" />
 
         <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-        <PackageReference Include="BepInEx.Core" Version="5.4.19" />
-        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+		
+		<PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
+		
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" NoWarn="NU5104" />
+		
+		<PackageReference Include="BepInEx.Core" Version="5.4.19" />
+		<PackageReference Include="RoR2BepInExPack" Version="*" />
+		
         <PackageReference Include="MMHOOK.RoR2" Version="2022.4.19" NoWarn="NU1701" />
+		
         <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-        <PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" NoWarn="NU5104" />
-        <PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
     </ItemGroup>
 </Project>

--- a/R2API.props
+++ b/R2API.props
@@ -18,17 +18,17 @@
         <ProjectReference Include="../R2API.AutoVersionGen/R2API.AutoVersionGen.csproj" OutputItemType="analyzer" ReferenceOutputAssembly="false" />
 
         <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-		
-		<PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
-		
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" NoWarn="NU5104" />
-		
-		<PackageReference Include="BepInEx.Core" Version="5.4.19" />
-		<PackageReference Include="RoR2BepInExPack" Version="*" />
-		
+        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+        
+        <PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
+        
+        <PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" NoWarn="NU5104" />
+        
+        <PackageReference Include="BepInEx.Core" Version="5.4.19" />
+        <PackageReference Include="RoR2BepInExPack" Version="*" />
+        
         <PackageReference Include="MMHOOK.RoR2" Version="2022.4.19" NoWarn="NU1701" />
-		
+        
         <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
-    <add key="Thunderstore" value="https://nuget.windows10ce.com/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Don't use thunderstore nuget package mirror, as people who depends on R2API may not have that nuget package registry setup, the dependency on it wasnt justified anyway as it was just a bandaid fix until we had proper nuget package releases

The fix is to have a proper RoR2BepInExPack dll nuget release, reducing the dependency load.

Closes https://github.com/risk-of-thunder/R2API/issues/478