### PR TITLE
Fix VoidLocus & ThePlanetarium accidental swap

### DIFF
--- a/R2API.Director/DirectorAPIexternal.cs
+++ b/R2API.Director/DirectorAPIexternal.cs
@@ -400,8 +400,8 @@ public static partial class DirectorAPI
         "itskymeadow" => Stage.SkyMeadowSimulacrum,
         "snowyforest" => Stage.SiphonedForest,
         "sulfurpools" => Stage.SulfurPools,
-        "voidraid" => Stage.VoidLocus,
-        "voidstage" => Stage.ThePlanetarium,
+        "voidraid" => Stage.ThePlanetarium,
+        "voidstage" => Stage.VoidLocus,
         _ => Stage.Custom,
     };
 
@@ -448,8 +448,8 @@ public static partial class DirectorAPI
         Stage.SkyMeadowSimulacrum => "itskymeadow",
         Stage.SiphonedForest => "snowyforest",
         Stage.SulfurPools => "sulfurpools",
-        Stage.VoidLocus => "voidraid",
-        Stage.ThePlanetarium => "voidstage",
+        Stage.VoidLocus => "voidstage",
+        Stage.ThePlanetarium => "voidraid",
         _ => "", // Stage.Custom
     };
 

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,9 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '1.1.1'
+* Fix issue where the ``Stage ParseToInternalStageName(string)`` and ``string ToInternalStageName(Stage stage)`` would return invalid values for The Planetarium and Void Locus respectively.
+
 ### '1.1.0'
 * Tentative fix a bug where family events could occur unannounced, and earlier than expected (for the Void & Lunar family). Usually, this would only become apparent if multiple runs are completed in a single game session. Thanks to 6thmoon for helping finding the root cause of the bug. If the bug is still not fixed do not hesitate to tell us in the modding discord!
 * Add to most `DirectorAPI.Helpers` methods an optional predicate parameter for more granular control on whether or not a monster / interactable should be added / removed to / from a stage. The predicate have a `DirectorCardCategorySelection` parameter that you can inspect (you don't have to, you can do other checks instead, like if a specific `ExpansionDef` is active) to decide whether or not the monster / interactable should be added / removed.

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "1.1.0"
+versionNumber = "1.1.1"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
The original code for DirectorAPI has this set to their methods that parse a Stage's name to a Stage Enum, and for StageEnum to StageName.

```
Stage.VoidLocus => "voidraid",
Stage.ThePlanetarium => "voidstage",
```

```
"voidraid" => Stage.VoidLocus,
"voidstage" => Stage.ThePlanetarium,
```

This of course is wrong, as the enum and names point to the wrong values, VoidLocus should point to voidstage and ThePlanetarium should point to voidraid`

i'm doing this change as this was an upstream issue on teammoonstorm/starstorm2#271