### PR TITLE
fix ci breaking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         set -x
         cd BuildCI
 
-        for line in $(dotnet run Program.cs); do
+        for line in $(dotnet run --configuration Release Program.cs); do
           IFS='|' read -ra parts <<< "$line"
           namespace=${parts[0]}
           name_underscore_separator=${parts[1]}

--- a/locally_verify_release_ci.sh
+++ b/locally_verify_release_ci.sh
@@ -1,6 +1,6 @@
 cd BuildCI
 
-for line in $(dotnet run Program.cs); do
+for line in $(dotnet run --configuration Release Program.cs); do
   IFS='|' read -ra parts <<< "$line"
   namespace=${parts[0]}
   name_underscore_separator=${parts[1]}


### PR DESCRIPTION
fix ci breaking due to https://github.com/risk-of-thunder/R2API/commit/d55e9064676aeb296dc6a17198f4fe4a4182553a#diff-6695f846f6d9db6b084e118db68d388645a92cd133bdf1651454121f93bc2123R17 

and not running as Release config