### PR TITLE
Fix R2API.Skins being shipped with the legacy package for some reason

### DIFF
--- a/R2API.Legacy/R2API.Legacy.csproj
+++ b/R2API.Legacy/R2API.Legacy.csproj
@@ -20,6 +20,7 @@
       <ProjectReference Include="../R2API.SceneAsset/R2API.SceneAsset.csproj" Private="false"/>
       <ProjectReference Include="../R2API.Orb/R2API.Orb.csproj" Private="false"/>
       <ProjectReference Include="../R2API.Loadout/R2API.Loadout.csproj" Private="false"/>
+      <ProjectReference Include="../R2API.Skins/R2API.Skins.csproj" Private="false"/>
       <ProjectReference Include="../R2API.DamageType/R2API.DamageType.csproj" Private="false"/>
       <ProjectReference Include="../R2API.Deployable/R2API.Deployable.csproj" Private="false"/>
       <ProjectReference Include="../R2API.Dot/R2API.Dot.csproj" Private="false"/>

--- a/R2API.Legacy/thunderstore.toml
+++ b/R2API.Legacy/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "tristanmcpherson"
 name = "R2API"
-versionNumber = "5.0.4"
+versionNumber = "5.0.5"
 description = "A modding API for Risk of Rain 2"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
R2API.Legacy has a projectref to R2API.Loadout, R2API.Loadout has a Private=false reference to R2API.Skins, but that somehow make R2API.Skins getting outputted to output build folder even though it's not referenced anywhere???