### PR TITLE
Remove extra spaces in DirectMessage's documentation comments

### DIFF
--- a/R2API.Core/Utils/DirectMessage.cs
+++ b/R2API.Core/Utils/DirectMessage.cs
@@ -10,10 +10,10 @@ public static class DirectMessage
 {
 
     /// <summary>
-    /// returns NetworkUsers associated  to a NetworkConnection
+    /// returns NetworkUsers associated to a NetworkConnection
     /// </summary>
     /// <param name="conn"></param>
-    /// <returns>returns NetworkUsers associated  to a NetworkConnection</returns>
+    /// <returns>returns NetworkUsers associated to a NetworkConnection</returns>
     private static RoR2.NetworkUser[] GetConnectionNetworkUsers(UnityEngine.Networking.NetworkConnection conn)
     {
         System.Collections.Generic.List<UnityEngine.Networking.PlayerController> playerControllers = conn.playerControllers;


### PR DESCRIPTION
-  Removed extra space on lines 13 and 16

Just a small thing I noticed while looking through the code. 