### PR TITLE
Addressables submodule and DirectorAPI additions

### DIFF
--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
@@ -1,0 +1,283 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UObject = UnityEngine.Object;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// A <see cref="AddressReferencedAsset"/> is a class that's used for referencing assets ingame.
+/// <br></br>
+/// <br>The asset referenced can either be a direct reference, or a reference via an address</br>
+/// <br>Some <see cref="AddressReferencedAsset{T}"/> can load their assets via catalog, such as <see cref="AddressReferencedItemDef"/></br>
+/// <br>An <see cref="AddressReferencedAsset{T}"/> has implicit operators for casting to it's <typeparamref name="T"/> Type, and for casting into a boolean. It also has implicit operators for encapsulating a <see cref="string"/> and <typeparamref name="T"/> inside an <see cref="AddressReferencedAsset{T}"/></br>
+/// </summary>
+/// <typeparam name="T"></typeparam>
+[Serializable]
+public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObject
+{
+    /// <summary>
+    /// The Asset of type <typeparamref name="T"/> contained by this <see cref="AddressReferencedAsset"/>
+    /// <para><b>Get behaviour</b></para>
+    /// <br>If the asset has not been loaded or is null, the asset is loaded synchronously via addressables.</br>
+    /// <br>In the scenario where <see cref="CanLoadFromCatalog"/> is set to true, the asset itself is null, and <see cref="AddressReferencedAsset.Initialized"/> is false, a warning message is displayed, this is because the AddressReferencedAsset instance can use an asset name directly by loading it via the game's catalogues.</br>
+    /// <para><b>Set Behaviour</b></para>
+    /// <br>Setting this property sets the address to null if the provided value is not null.</br>
+    /// </summary>
+    public T Asset
+    {
+        get
+        {
+            /*
+             * For future maintainers, some AddressReferencedAssets like AddressReferencedItem can load directly from the catalog.
+             * As such, if the Asset is trying to be fetched, it doesnt use a direct reference, the system it not initalized, and it can load from catalog, we should warn the user they should wait until the system loads the asset. We will still try to load the asset synchronously regardless in case it loads from an address.
+             * 
+             * In other cases, we'll just load the asset immediatly.
+             */
+            if(!_asset && !Initialized && CanLoadFromCatalog)
+            {
+                string typeName = GetType().Name;
+                var stackTrace = new StackTrace();
+                var method = stackTrace.GetFrame(1).GetMethod();
+                AddressablesPlugin.Logger.LogWarning($"Assembly {Assembly.GetCallingAssembly()} is trying to access an {typeName} before AddressReferencedAssets have initialized! This can cause issues as {typeName} can load the asset from Catalogs within the game." +
+                    $"\n Consider using AddressReferencedAssets.OnAddressReferencedAssetsLoaded for running code that depends on AddressableAssets! (Method: {method.DeclaringType.FullName}.{method.Name}()");
+                Load();
+            }
+            else if(!_asset)
+            {
+                LoadFromAddress();
+            }
+
+            return _asset;
+        }
+        set
+        {
+            _asset = value;
+            _address = _asset ? string.Empty : _address;
+            _useDirectReference = _asset;
+        }
+    }
+    [SerializeField] private T _asset;
+
+    /// <summary>
+    /// The string to use for loading the <see cref="Asset"/>
+    /// <br>Setting this value sets the current <see cref="Asset"/> to null and <see cref="UseDirectReference"/> to false. if the game has already finished loading, the new Asset is loaded.</br>
+    /// </summary>
+    public string Address
+    {
+        get => _address;
+        set
+        {
+            _address = value;
+            _asset = null;
+            _useDirectReference = false;
+            if(RoR2Application.loadFinished)
+            {
+                Load();
+            }
+        }
+    }
+    [SerializeField] private string _address;
+
+    /// <summary>
+    /// Wether this AddressReferencedAsset is using a DirectReference (<see cref="Asset"/> is not null) or an Address Reference (<see cref="Asset"/> is null)
+    /// <br>Mainly used for Editor related scripts</br>
+    /// </summary>
+    public bool UseDirectReference => _useDirectReference;
+    [SerializeField] private bool _useDirectReference;
+
+    /// <summary>
+    /// Wether this AddressReferencedAsset can load an Asset using the game's catalogues.
+    /// <br>If this is true, you're encouraged to wait for AddressReferencedAsset to initialize fully using <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/></br>
+    /// </summary>
+    public virtual bool CanLoadFromCatalog { get; } = false;
+
+    /// <summary>
+    /// Loads the asset asynchronously if <see cref="Asset"/> is not null and <see cref="Address"/> is not null or empty.
+    /// <br>This is automatically called by the AddressReferencedAsset system and should not be called manually.</br>
+    /// </summary>
+    protected sealed override async Task LoadAssetAsync()
+    {
+        if(!_asset && string.IsNullOrEmpty(_address))
+        {
+            await LoadAsync();
+        }
+    }
+
+    /// <summary>
+    /// Implement how the Asset of type <typeparamref name="T"/> is loaded synchronously when <see cref="Asset"/> is null
+    /// </summary>
+    protected virtual void Load()
+    {
+        LoadFromAddress();
+    }
+
+    /// <summary>
+    /// Implement how the Asset of type <typeparamref name="T"/> is loaded asynchronously when <see cref="Asset"/> is null
+    /// </summary>
+    protected virtual async Task LoadAsync()
+    {
+        await LoadFromAddressAsync();
+    }
+
+    /// <summary>
+    /// Loads the Asset asynchronously via <see cref="Addressables"/>
+    /// </summary>
+    protected async Task LoadFromAddressAsync()
+    {
+        var task = Addressables.LoadAssetAsync<T>(_address).Task;
+        _asset = await task;
+    }
+
+    /// <summary>
+    /// Loads the Asset synchronously via <see cref="Addressables"/>
+    /// </summary>
+    protected void LoadFromAddress()
+    {
+        _asset = Addressables.LoadAssetAsync<T>(_address).WaitForCompletion();
+    }
+
+    /// <summary>
+    /// Operator for casting <see cref="AddressReferencedAsset{T}"/> to a boolean value
+    /// <br>Allows you to keep using the unity Syntax for checking if an object exists.</br>
+    /// </summary>
+    public static implicit operator bool(AddressReferencedAsset<T> addressReferencedAsset)
+    {
+        return addressReferencedAsset?.Asset;
+    }
+
+    /// <summary>
+    /// Operator for casting <see cref="AddressReferencedAsset{T}"/> to it's currently loaded <see cref="Asset"/> value
+    /// </summary>
+    public static implicit operator T(AddressReferencedAsset<T> addressReferencedAsset)
+    {
+        return addressReferencedAsset?.Asset;
+    }
+
+    /// <summary>
+    /// Operator for encapsulating a <see cref="string"/> inside an <see cref="AddressReferencedAsset{T}"/>
+    /// </summary>
+    public static implicit operator AddressReferencedAsset<T>(string address)
+    {
+        return new AddressReferencedAsset<T>(address);
+    }
+
+    /// <summary>
+    /// Operator for encapsulating an asset of type <typeparamref name="T"/> inside an <see cref="AddressReferencedAsset{T}"/>
+    /// </summary>
+    public static implicit operator AddressReferencedAsset<T>(T asset)
+    {
+        return new AddressReferencedAsset<T>(asset);
+    }
+
+    /// <summary>
+    /// Constructor for <see cref="AddressReferencedAsset{T}"/>
+    /// <br><see cref="Asset"/> will be set to <paramref name="asset"/> and <see cref="UseDirectReference"/> to true</br>
+    /// </summary>
+    public AddressReferencedAsset(T asset)
+    {
+        SetHooks();
+        _asset = asset;
+        _useDirectReference = false;
+        instances.Add(this);
+    }
+
+    /// <summary>
+    /// Constructor for <see cref="AddressReferencedAsset{T}"/>
+    /// <br><see cref="Address"/> will be set to <paramref name="address"/> and <see cref="UseDirectReference"/> to false</br>
+    /// </summary>
+    public AddressReferencedAsset(string address)
+    {
+        SetHooks();
+        this._address = address;
+        _useDirectReference = false;
+        instances.Add(this);
+    }
+
+    /// <summary>
+    /// Parameterless Constructor for <see cref="AddressReferencedAsset{T}"/>
+    /// </summary>
+    public AddressReferencedAsset()
+    {
+        SetHooks();
+        instances.Add(this);
+    }
+
+    /// <summary>
+    /// <see cref="AddressReferencedAsset{T}"/> Deconstructor
+    /// </summary>
+    ~AddressReferencedAsset()
+    {
+        instances.Remove(this);
+        if (instances.Count == 0)
+            UnsetHooks();
+    }
+}
+
+/// <summary>
+/// A <see cref="AddressReferencedAsset"/> is a class that's used for referencing assets ingame.
+/// <br>You're strongly adviced to use <see cref="AddressReferencedAsset{T}"/> instead.</br> 
+/// </summary>
+public abstract class AddressReferencedAsset
+{
+    protected static readonly HashSet<AddressReferencedAsset> instances = new();
+
+    /// <summary>
+    /// Wether or not the <see cref="AddressReferencedAsset"/> system has initialized.
+    /// <br>Particularly useful for interacting with <see cref="AddressReferencedAsset{T}"/> who's <see cref="AddressReferencedAsset{T}.CanLoadFromCatalog"/> is true, such as <see cref="AddressReferencedItemDef"/></br>
+    /// </summary>
+    public static bool Initialized { get => _initialized; }
+    private static bool _initialized;
+
+    /// <summary>
+    /// An event that gets invoked when all the AddressReferencedAssets have been loaded.
+    /// </summary>
+
+    public static event Action OnAddressReferencedAssetsLoaded;
+
+    /// <summary>
+    /// Sets hooks for the AddressReferencedSystem, any constructor from classes inheriting <see cref="AddressReferencedAsset"/> must call it.
+    /// </summary>
+    protected void SetHooks()
+    {
+        if(RoR2Application.loadFinished)
+        {
+            LoadReferencesAsync();
+            return;
+        }
+        RoR2Application.onLoad += LoadReferencesAsync;
+    }
+
+    /// <summary>
+    /// Unsets hooks for the AddressReferencedSystem, any deconstructor from classes inheriting <see cref="AddressReferencedAsset"/> must call it IF <see cref="instances"/>'s count is 0
+    /// </summary>
+    protected void UnsetHooks()
+    {
+        if (!RoR2Application.loadFinished)
+            RoR2Application.onLoad -= LoadReferencesAsync;
+    }
+
+    private static async void LoadReferencesAsync()
+    {
+        foreach(AddressReferencedAsset instance in instances)
+        {
+            try
+            {
+                await instance.LoadAssetAsync();
+            }
+            catch(Exception e)
+            {
+                AddressablesPlugin.Logger.LogError(e);
+            }
+        }
+        _initialized = true;
+        OnAddressReferencedAssetsLoaded?.Invoke();
+    }
+    protected abstract Task LoadAssetAsync();
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
@@ -49,7 +49,7 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
                     $"\n Consider using AddressReferencedAssets.OnAddressReferencedAssetsLoaded for running code that depends on AddressableAssets! (Method: {method.DeclaringType.FullName}.{method.Name}()");
                 Load();
             }
-            else if(!_asset)
+            else if(IsValidForLoadingWithAddress())
             {
                 LoadFromAddress();
             }
@@ -90,7 +90,7 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// <br>Mainly used for Editor related scripts</br>
     /// </summary>
     public bool UseDirectReference => _useDirectReference;
-    [SerializeField] private bool _useDirectReference;
+    [SerializeField,HideInInspector] private bool _useDirectReference;
 
     /// <summary>
     /// Wether this AddressReferencedAsset can load an Asset using the game's catalogues.
@@ -98,13 +98,17 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// </summary>
     public virtual bool CanLoadFromCatalog { get; } = false;
 
+    private bool IsValidForLoadingWithAddress()
+    {
+        return !_asset && !string.IsNullOrEmpty(_address);
+    }
     /// <summary>
     /// Loads the asset asynchronously if <see cref="Asset"/> is not null and <see cref="Address"/> is not null or empty.
     /// <br>This is automatically called by the AddressReferencedAsset system and should not be called manually.</br>
     /// </summary>
     protected sealed override async Task LoadAssetAsync()
     {
-        if(!_asset && string.IsNullOrEmpty(_address))
+        if(IsValidForLoadingWithAddress())
         {
             await LoadAsync();
         }
@@ -251,6 +255,7 @@ public abstract class AddressReferencedAsset
             LoadReferencesAsync();
             return;
         }
+        RoR2Application.onLoad -= LoadReferencesAsync;
         RoR2Application.onLoad += LoadReferencesAsync;
     }
 

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
@@ -1,0 +1,39 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="BuffDef"/></br>
+/// <br>The <see cref="BuffDef"/> can also be loaded via the <see cref="BuffCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+[Serializable]
+public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
+{
+    public override bool CanLoadFromCatalog => true;
+    protected override async Task LoadAsync()
+    {
+        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+        if(index != BuffIndex.None)
+        {
+            Asset = BuffCatalog.GetBuffDef(index);
+            return;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+        if (index != BuffIndex.None)
+        {
+            Asset = BuffCatalog.GetBuffDef(index);
+            return;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
@@ -1,0 +1,41 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="EliteDef"/></br>
+/// <br>The <see cref="EliteDef"/> can also be loaded via the <see cref="EliteCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+[Serializable]
+public class AddressReferencedEliteDef : AddressReferencedAsset<EliteDef>
+{
+    public override bool CanLoadFromCatalog => true;
+    protected override async Task LoadAsync()
+    {
+        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+        if (def != null)
+        {
+            Asset = def;
+            return;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+        if (def != null)
+        {
+            Asset = def;
+            return;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
@@ -1,0 +1,39 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="EquipmentDef"/></br>
+/// <br>The <see cref="EquipmentDef"/> can also be loaded via the <see cref="EquipmentCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+public class AddressReferencedEquipmentDef : AddressReferencedAsset<EquipmentDef>
+{
+    public override bool CanLoadFromCatalog => true;
+    protected override async Task LoadAsync()
+    {
+        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+        if (index != EquipmentIndex.None)
+        {
+            Asset = EquipmentCatalog.GetEquipmentDef(index);
+            return;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+        if (index != EquipmentIndex.None)
+        {
+            Asset = EquipmentCatalog.GetEquipmentDef(index);
+            return;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -1,0 +1,38 @@
+﻿using RoR2.ExpansionManagement;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="ExpansionDef"/></br>
+/// <br>The <see cref="ExpansionDef"/> can also be loaded via the <see cref="ExpansionCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef>
+{
+    public override bool CanLoadFromCatalog => true;
+
+    protected override async Task LoadAsync()
+    {
+        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+        if (expansionDef != null)
+        {
+            Asset = expansionDef;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+        if (expansionDef != null)
+        {
+            Asset = expansionDef;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -12,6 +12,7 @@ namespace R2API.AddressReferencedAssets;
 /// <br>T is <see cref="ExpansionDef"/></br>
 /// <br>The <see cref="ExpansionDef"/> can also be loaded via the <see cref="ExpansionCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
 /// </summary>
+[Serializable]
 public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef>
 {
     public override bool CanLoadFromCatalog => true;

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
@@ -1,0 +1,39 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="ItemDef"/></br>
+/// <br>The <see cref="ItemDef"/> can also be loaded via the <see cref="ItemCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+[Serializable]
+public class AddressReferencedItemDef : AddressReferencedAsset<ItemDef>
+{
+    public override bool CanLoadFromCatalog => true;
+    protected override async Task LoadAsync()
+    {
+        ItemIndex index = ItemCatalog.FindItemIndex(Address);
+        if (index != ItemIndex.None)
+        {
+            Asset = ItemCatalog.GetItemDef(index);
+            return;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        ItemIndex index = ItemCatalog.FindItemIndex(Address);
+        if (index != ItemIndex.None)
+        {
+            Asset = ItemCatalog.GetItemDef(index);
+            return;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedPrefab.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedPrefab.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="GameObject"/></br>
+/// </summary>
+[Serializable]
+public class AddressReferencedPrefab : AddressReferencedAsset<GameObject>
+{
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedSpawnCard.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedSpawnCard.cs
@@ -1,0 +1,16 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="GameObject"/></br>
+/// </summary>
+[Serializable]
+public class AddressReferencedSpawnCard : AddressReferencedAsset<SpawnCard>
+{
+
+}

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedSpawnCard.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedSpawnCard.cs
@@ -7,7 +7,7 @@ namespace R2API.AddressReferencedAssets;
 
 /// <summary>
 /// <inheritdoc cref="AddressReferencedAsset{T}"/>
-/// <br>T is <see cref="GameObject"/></br>
+/// <br>T is <see cref="SpawnCard"/></br>
 /// </summary>
 [Serializable]
 public class AddressReferencedSpawnCard : AddressReferencedAsset<SpawnCard>

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
@@ -1,0 +1,39 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace R2API.AddressReferencedAssets;
+
+/// <summary>
+/// <inheritdoc cref="AddressReferencedAsset{T}"/>
+/// <br>T is <see cref="UnlockableDef"/></br>
+/// <br>The <see cref="UnlockableDef"/> can also be loaded via the <see cref="UnlockableCatalog"/>, as such, you should wait until <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/> gets raised.</br>
+/// </summary>
+[Serializable]
+public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableDef>
+{
+    protected override async Task LoadAsync()
+    {
+        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+        if (unlockable)
+        {
+            Asset = unlockable;
+            return;
+        }
+        await LoadFromAddressAsync();
+    }
+
+    protected override void Load()
+    {
+        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+        if (unlockable)
+        {
+            Asset = unlockable;
+            return;
+        }
+        LoadFromAddress();
+    }
+}

--- a/R2API.Addressables/AddressablesPlugin.cs
+++ b/R2API.Addressables/AddressablesPlugin.cs
@@ -1,0 +1,22 @@
+using BepInEx;
+using BepInEx.Logging;
+using R2API.AutoVersionGen;
+using System;
+
+[assembly: HG.Reflection.SearchableAttribute.OptIn]
+
+namespace R2API;
+
+[AutoVersion]
+[BepInPlugin(PluginGUID, PluginName, PluginVersion)]
+public sealed partial class AddressablesPlugin : BaseUnityPlugin
+{
+    public const string PluginGUID = R2API.PluginGUID + ".addressables";
+    public const string PluginName = R2API.PluginName + ".Addressables";
+    internal static new ManualLogSource Logger { get; set; }
+
+    private void Awake()
+    {
+        Logger = base.Logger;
+    }
+}

--- a/R2API.Addressables/R2API.Addressables.csproj
+++ b/R2API.Addressables/R2API.Addressables.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
     <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
-    <ProjectReference Include="..\R2API.Addressables\R2API.Addressables.csproj" Private="false"/>
   </ItemGroup>
 </Project>

--- a/R2API.Addressables/README.md
+++ b/R2API.Addressables/README.md
@@ -1,0 +1,13 @@
+# R2API.Skins - Adding new Skins and Skin-Specific IDRS
+
+## About
+
+R2API.Skins is a submodule for R2API that takes the Skin related methods and utilities from ``R2API.Loadout`` and implements them in this new submodule
+
+Alongside the old skin creation methods from ``R2API.Loadout``, R2API.Skins also contains utilities for improving the skin experience, such as having Skin-Specific ItemDisplayRuleSets.
+
+## Changelog
+
+### '1.0.0'
+
+* Initial Release

--- a/R2API.Addressables/README.md
+++ b/R2API.Addressables/README.md
@@ -1,10 +1,10 @@
-# R2API.Skins - Adding new Skins and Skin-Specific IDRS
+# R2API.Addressables - Addressable related utility for modding
 
 ## About
 
-R2API.Skins is a submodule for R2API that takes the Skin related methods and utilities from ``R2API.Loadout`` and implements them in this new submodule
+R2API.Addressables is a submodule for R2API that implements systems for working with the AddressablesAPI from Unity.
 
-Alongside the old skin creation methods from ``R2API.Loadout``, R2API.Skins also contains utilities for improving the skin experience, such as having Skin-Specific ItemDisplayRuleSets.
+Currently it adds the AddressReferencedAsset system, which allows you on the Editor or on Code to easily refer to either an explicit Asset, or an Address to said asset.
 
 ## Changelog
 

--- a/R2API.Addressables/thunderstore.toml
+++ b/R2API.Addressables/thunderstore.toml
@@ -4,9 +4,9 @@ schemaVersion = "0.0.1"
 
 [package]
 namespace = "RiskofThunder"
-name = "R2API_Director"
-versionNumber = "2.0.0"
-description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
+name = "R2API_Addressables"
+versionNumber = "1.0.0"
+description = "R2API Submodule for implementing Addressables functionality"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 
@@ -14,7 +14,6 @@ containsNsfwContent = false
 bbepis-BepInExPack = "5.4.2109"
 RiskofThunder-HookGenPatcher = "1.2.3"
 RiskofThunder-R2API_Core = "1.0.0"
-RiskofThunder-R2API_Addressables = "1.0.0"
 
 [build]
 icon = "../icon.png"
@@ -23,7 +22,7 @@ outdir = "./build"
 
 [[build.copy]]
 source = "./ReleaseOutput"
-target = "./plugins/R2API.Director"
+target = "./plugins/R2API.Addressables"
 
 [publish]
 repository = "https://thunderstore.io"

--- a/R2API.Director/AddressableDCCSPool.cs
+++ b/R2API.Director/AddressableDCCSPool.cs
@@ -12,6 +12,7 @@ namespace R2API;
 /// A <see cref="AddressableDCCSPool"/> is a version of a <see cref="DccsPool"/> that can be created from the editor itself, it allows you to create complex DccsPools using R2API's <see cref="AddressReferencedAsset"/> system and your own existing spawn cards
 /// <br>You should also see <see cref="AddressableDirectorCardCategorySelection"/></br>
 /// </summary>
+[CreateAssetMenu(fileName = "New AddressableDCCSPool", menuName = "R2API/DirectorAPI/AddressableDCCSPool")]
 public class AddressableDCCSPool : ScriptableObject
 {
     private static HashSet<AddressableDCCSPool> instances = new HashSet<AddressableDCCSPool>();

--- a/R2API.Director/AddressableDCCSPool.cs
+++ b/R2API.Director/AddressableDCCSPool.cs
@@ -1,0 +1,119 @@
+﻿using R2API.AddressReferencedAssets;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace R2API;
+
+/// <summary>
+/// A <see cref="AddressableDCCSPool"/> is a version of a <see cref="DccsPool"/> that can be created from the editor itself, it allows you to create complex DccsPools using R2API's <see cref="AddressReferencedAsset"/> system and your own existing spawn cards
+/// <br>You should also see <see cref="AddressableDirectorCardCategorySelection"/></br>
+/// </summary>
+public class AddressableDCCSPool : ScriptableObject
+{
+    private static HashSet<AddressableDCCSPool> instances = new HashSet<AddressableDCCSPool>();
+
+    [Tooltip("The DccsPool that will be overwritten with the values stored in this AddressableDCCSPool")]
+    public DccsPool targetPool;
+
+    [Tooltip("The categories for this pool")]
+    public Category[] poolCategories = Array.Empty<Category>();
+
+    [SystemInitializer]
+    private static void SystemInitializer()
+    {
+        AddressReferencedAsset.OnAddressReferencedAssetsLoaded += () =>
+        {
+            foreach (var instance in instances)
+            {
+                instance.Upgrade();
+            }
+        };
+    }
+
+    private void Upgrade()
+    {
+        DccsPool.Category[] categories = poolCategories.Select(x => x.Upgrade()).ToArray();
+        targetPool.poolCategories = categories;
+        poolCategories = null;
+    }
+
+    private void Awake() => instances.Add(this);
+
+    private void OnDestroy() => instances.Remove(this);
+
+    /// <summary>
+    /// Represents a version of <see cref="DccsPool.PoolEntry"/> that uses <see cref="AddressableDirectorCardCategorySelection"/> for representing a pool entry
+    /// </summary>
+    [Serializable]
+    public class PoolEntry
+    {
+        [Tooltip("The DCCS for this pool entry")]
+        public AddressableDirectorCardCategorySelection dccs;
+        [Tooltip("The weight of this pool entry relative to the others")]
+        public float weight;
+
+        internal virtual DccsPool.PoolEntry Upgrade()
+        {
+            return new DccsPool.PoolEntry
+            {
+                dccs = dccs.targetCardCategorySelection,
+                weight = weight
+            };
+        }
+    }
+
+    /// <summary>
+    /// Represents a conditional version of a <see cref="PoolEntry"/>
+    /// <br>Contains a <see cref="requiredExpansions"/> array that's populated using <see cref="AddressReferencedExpansionDef"/></br>
+    /// </summary>
+    [Serializable]
+    public class ConditionalPoolEntry : PoolEntry
+    {
+        [Tooltip("ALL expansions in this list must be enabled for this run for this entry to be considered")]
+        public AddressReferencedExpansionDef[] requiredExpansions = Array.Empty<AddressReferencedExpansionDef>();
+
+        internal override DccsPool.PoolEntry Upgrade()
+        {
+            return new DccsPool.ConditionalPoolEntry
+            {
+                dccs = dccs.targetCardCategorySelection,
+                requiredExpansions = requiredExpansions.Select(x => x.Asset).ToArray(),
+                weight = weight
+            };
+        }
+    }
+
+    /// <summary>
+    /// Represents a category of DirectorCardCategorySelections for this pool
+    /// </summary>
+    [Serializable]
+    public class Category
+    {
+        [Tooltip("A name to help identify this category")]
+        public string name;
+        [Tooltip("The weight of all entries in this category relative to the sibling categories")]
+        public float categoryWeight;
+        [Tooltip("These entries are always considered")]
+        public PoolEntry[] alwaysIncluded = Array.Empty<PoolEntry>();
+        [Tooltip("These entries are only considered if their individual conditions are met")]
+        public ConditionalPoolEntry[] includedIfConditionsMet = Array.Empty<ConditionalPoolEntry>();
+        [Tooltip("These entries are considered only if no entries from 'includedIfConditionsMet' have been includedd")]
+        public PoolEntry[] includedIfNoConditionsMet = Array.Empty<PoolEntry>();
+
+        internal DccsPool.Category Upgrade()
+        {
+            return new DccsPool.Category
+            {
+                name = name,
+                categoryWeight = categoryWeight,
+                alwaysIncluded = alwaysIncluded.Select(x => x.Upgrade()).ToArray(),
+                includedIfConditionsMet = includedIfConditionsMet.Select(x => x.Upgrade()).Cast<DccsPool.ConditionalPoolEntry>().ToArray(),
+                includedIfNoConditionsMet = includedIfNoConditionsMet.Select(x => x.Upgrade()).ToArray()
+            };
+        }
+    }
+}

--- a/R2API.Director/AddressableDirectorCard.cs
+++ b/R2API.Director/AddressableDirectorCard.cs
@@ -1,0 +1,41 @@
+﻿using R2API.AddressReferencedAssets;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API;
+
+/// <summary>
+/// Represents a <see cref="DirectorCard"/> that can be created from using <see cref=""/>
+/// </summary>
+[Serializable]
+public class AddressableDirectorCard
+{
+    [Tooltip("The spawn card for this DirectorCard")]
+    public AddressReferencedSpawnCard spawnCard;
+    [Tooltip("The weight of this director card relative to other cards")]
+    public int selectionWeight;
+    [Tooltip("The distance used for spawning this card, used for monsters")]
+    public DirectorCore.MonsterSpawnDistance spawnDistance;
+    public bool preventOverhead;
+    [Tooltip("The minimum amount of stages that need to be completed before this Card can be spawned")]
+    public int minimumStageCompletions;
+    [Tooltip("This unlockableDef must be unlocked for this Card to spawn")]
+    public AddressReferencedUnlockableDef requiredUnlockableDef;
+    [Tooltip("This unlockableDef cannot be unlocked for this Card to spawn")]
+    public AddressReferencedUnlockableDef forbiddenUnlockableDef;
+    internal DirectorCard Upgrade()
+    {
+        DirectorCard returnVal = new DirectorCard();
+        returnVal.spawnCard = spawnCard;
+        returnVal.selectionWeight = selectionWeight;
+        returnVal.spawnDistance = spawnDistance;
+        returnVal.preventOverhead = preventOverhead;
+        returnVal.minimumStageCompletions = minimumStageCompletions;
+        returnVal.requiredUnlockableDef = requiredUnlockableDef;
+        returnVal.forbiddenUnlockableDef = forbiddenUnlockableDef;
+        return returnVal;
+    }
+}

--- a/R2API.Director/AddressableDirectorCardCategorySelection.cs
+++ b/R2API.Director/AddressableDirectorCardCategorySelection.cs
@@ -13,6 +13,8 @@ namespace R2API;
 /// <para>All the values from this category selection will be added to the <see cref="DirectorCardCategorySelection"/> specified in <see cref="targetCardCategorySelection"/></para>
 /// <br>You should also see <see cref="AddressableDCCSPool"/></br>
 /// </summary>
+
+[CreateAssetMenu(fileName = "New AddressableDirectorCardCategorySelection", menuName = "R2API/DirectorAPI/AddressableDirectorCardCategorySelection")]
 public class AddressableDirectorCardCategorySelection : ScriptableObject
 {
     private static HashSet<AddressableDirectorCardCategorySelection> instances;

--- a/R2API.Director/AddressableDirectorCardCategorySelection.cs
+++ b/R2API.Director/AddressableDirectorCardCategorySelection.cs
@@ -17,7 +17,7 @@ namespace R2API;
 [CreateAssetMenu(fileName = "New AddressableDirectorCardCategorySelection", menuName = "R2API/DirectorAPI/AddressableDirectorCardCategorySelection")]
 public class AddressableDirectorCardCategorySelection : ScriptableObject
 {
-    private static HashSet<AddressableDirectorCardCategorySelection> instances;
+    private static HashSet<AddressableDirectorCardCategorySelection> instances = new();
 
     [Tooltip("The DirectorCardCategorySelection that will be overridedn with the values stored in this AddressableDirectorCardCategorySelection")]
     public DirectorCardCategorySelection targetCardCategorySelection;
@@ -50,6 +50,7 @@ public class AddressableDirectorCardCategorySelection : ScriptableObject
     /// <summary>
     /// Represents a category of spawn cards
     /// </summary>
+    [Serializable]
     public struct Category
     {
         [Tooltip("The name of this category")]

--- a/R2API.Director/AddressableDirectorCardCategorySelection.cs
+++ b/R2API.Director/AddressableDirectorCardCategorySelection.cs
@@ -1,0 +1,70 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using R2API.AddressReferencedAssets;
+
+namespace R2API;
+
+/// <summary>
+/// A <see cref="AddressableDirectorCardCategorySelection"/> is a version of a <see cref="DirectorCardCategorySelection"/> that can be used for creating a custom and complex <see cref="DirectorCardCategorySelection"/> for stages, using R2API's <see cref="AddressReferencedAsset"/> system and your own existing spawn cards
+/// <para>All the values from this category selection will be added to the <see cref="DirectorCardCategorySelection"/> specified in <see cref="targetCardCategorySelection"/></para>
+/// <br>You should also see <see cref="AddressableDCCSPool"/></br>
+/// </summary>
+public class AddressableDirectorCardCategorySelection : ScriptableObject
+{
+    private static HashSet<AddressableDirectorCardCategorySelection> instances;
+
+    [Tooltip("The DirectorCardCategorySelection that will be overridedn with the values stored in this AddressableDirectorCardCategorySelection")]
+    public DirectorCardCategorySelection targetCardCategorySelection;
+
+    [Tooltip("The categories for this AddressableDirectorCardCategorySelection")]
+    public Category[] categories = Array.Empty<Category>();
+
+    private void Upgrade()
+    {
+        targetCardCategorySelection.categories = categories.Select(x => x.Upgrade()).ToArray();
+        categories = null;
+    }
+
+    private void Awake() => instances.Add(this);
+
+    private void OnDestroy() => instances.Remove(this);
+
+    [SystemInitializer]
+    private static void SystemInitializer()
+    {
+        AddressReferencedAsset.OnAddressReferencedAssetsLoaded += () =>
+        {
+            foreach (var instance in instances)
+            {
+                instance.Upgrade();
+            }
+        };
+    }
+
+    /// <summary>
+    /// Represents a category of spawn cards
+    /// </summary>
+    public struct Category
+    {
+        [Tooltip("The name of this category")]
+        public string name;
+        [Tooltip("The DirectorCards for this category")]
+        public AddressableDirectorCard[] cards;
+        [Tooltip("The weight of this category relative to the other categories")]
+        public float selectionWeight;
+
+        internal DirectorCardCategorySelection.Category Upgrade()
+        {
+            return new DirectorCardCategorySelection.Category
+            {
+                name = name,
+                cards = cards.Select(x => x.Upgrade()).ToArray(),
+                selectionWeight = selectionWeight
+            };
+        }
+    }
+}

--- a/R2API.Director/DirectorAPIexternal.cs
+++ b/R2API.Director/DirectorAPIexternal.cs
@@ -571,7 +571,7 @@ public static partial class DirectorAPI
         /// <summary>
         /// This is only used in case the category didnt exist in the first place in the targeted DCCS.
         /// </summary>
-        public int MonsterCategorySelectionWeight = 1;
+        public float MonsterCategorySelectionWeight = 1;
 
         /// <summary>
         /// The interactable category the card belongs to. Will be set to <see cref="InteractableCategory.Invalid"/> for monsters,
@@ -587,7 +587,7 @@ public static partial class DirectorAPI
         /// <summary>
         /// This is only used in case the category didnt exist in the first place in the targeted DCCS.
         /// </summary>
-        public int InteractableCategorySelectionWeight = 1;
+        public float InteractableCategorySelectionWeight = 1;
 
         public bool IsMonster => MonsterCategory != MonsterCategory.Invalid;
 

--- a/R2API.Director/DirectorPlugin.cs
+++ b/R2API.Director/DirectorPlugin.cs
@@ -1,6 +1,8 @@
 using BepInEx;
 using BepInEx.Logging;
 
+[assembly: HG.Reflection.SearchableAttribute.OptIn]
+
 namespace R2API;
 
 [BepInPlugin(DirectorAPI.PluginGUID, DirectorAPI.PluginName, DirectorAPI.PluginVersion)]

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,7 +18,7 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
-### '1.1.3'
+### '2.0.0'
 * Fixed issue where DirectorCardHolder's custom category selection weights where integers instead of floats.
 
 ### '1.1.2'

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,10 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.1.0'
+* Added Dependency for the Addressables Submodule
+* Added AddressableDCCSPool and AddressableDirectorCardCategorySelection, both intended for usage in the Unity Editor.
+
 ### '2.0.0'
 * Fixed issue where DirectorCardHolder's custom category selection weights where integers instead of floats.
 

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,9 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '1.1.3'
+* Fixed issue where DirectorCardHolder's custom category selection weights where integers instead of floats.
+
 ### '1.1.2'
 * Make the API safer.
 

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "1.1.3"
+versionNumber = "2.0.0"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "1.1.2"
+versionNumber = "1.1.3"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.0.0"
+versionNumber = "2.1.0"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.sln
+++ b/R2API.sln
@@ -88,6 +88,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Rules", "R2API.Rules\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Skins", "R2API.Skins\R2API.Skins.csproj", "{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Addressables", "R2API.Addressables\R2API.Addressables.csproj", "{3AB66A0A-4905-41B2-A397-7C7D92CDDA8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -218,6 +220,10 @@ Global
 		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C712F6B5-1E08-4FB5-90EE-2D2C7F2DFF55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AB66A0A-4905-41B2-A397-7C7D92CDDA8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AB66A0A-4905-41B2-A397-7C7D92CDDA8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AB66A0A-4905-41B2-A397-7C7D92CDDA8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AB66A0A-4905-41B2-A397-7C7D92CDDA8D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Addressables Submodule
The addressables submodule should ideally contain all the addressables utility, this addressable utility is usually miscelaneous, but currently pertrains Editor and Runtime functionality.

Currently it contains the [AddressableAsset](https://github.com/TeamMoonstorm/MoonstormSharedUtils/blob/main/Runtime/Code/Classes/AddressableAsset/AddressableAsset.cs) system from MoonstormSharedUtils. but rebranded as "AddressReferencedAsset"

The AddressReferencedAsset is a wrapper for an Asset that can be either specified explicitly (set in the editor or at runtime manually), or specified implicitly via an address (set in the editor or at runtime). including different utilities such as implicit operators and constructors. Some of these classes have the ability to load the asset using Catalogs, the system itself implements a warning message whenever an asset is trying to be accessed, the asset isnt explicit  and the system hasnt initialized fully. as such, there's an event that the end user can use to wait untill all the AddressReferencedAssets finished loading.

Note: I am aware this works best with editor scripts such as drawers, i plan on adding such capabilities to RoR2EK using a special assembly for R2API scripts.

# DirectorAPI Additions
To prepare for the Stage submodule specified #492, i've proceeded to add custom versions of the game's DirectorCardCategorySelection and DCCSPools, these two scriptable objects are meant mainly for editor use and allows the end user to create DCCS and DCCSPools respectively entirely in the unity editor while using the AddressReferencedAssets to specify ExpansionDefs for conditional pool entries and SpawnCards for the DirectorCards.