### PR TITLE
Fix SystemInitializerInjector

### DIFF
--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -18,6 +18,10 @@ Do not hesitate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ## Changelog
 
+### '5.0.11'
+
+- Fix SystemInitializerInjector.
+
 ### '5.0.10'
 * Make R2API Reflection methods return / take into account inherited members.
 

--- a/R2API.Core/Utils/SystemInitializerInjector.cs
+++ b/R2API.Core/Utils/SystemInitializerInjector.cs
@@ -34,6 +34,8 @@ public static class SystemInitializerInjector
                     if (instance.target is MethodInfo initializerMethod && _dependenciesToInject.TryGetValue(initializerMethod, out HashSet<Type> newDependencies))
                     {
                         newDependencies.RemoveWhere(t => instance.dependencies.Contains(t));
+                        if (newDependencies.Count == 0)
+                            return;
 
                         int originalDependenciesLength = instance.dependencies.Length;
                         Array.Resize(ref instance.dependencies, originalDependenciesLength + newDependencies.Count);

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.0.10"
+versionNumber = "5.0.11"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Fixes #502

This implementation also accounts for there being multiple SystemInitializer methods in the same class (not the case anywhere in game code, but thought it wouldn't hurt to handle that anyway).