### PR TITLE
Add support for skin-specific VFX replacements to the R2API.Skins submodule.

### DIFF
--- a/R2API.Skins/README.md
+++ b/R2API.Skins/README.md
@@ -8,6 +8,10 @@ Alongside the old skin creation methods from ``R2API.Loadout``, R2API.Skins also
 
 ## Changelog
 
+### '1.1.0'
+
+* Added the SkinVFX class for adding skin-specific effect replacements.
+
 ### '1.0.0'
 
 * Initial Release

--- a/R2API.Skins/SkinVFX.cs
+++ b/R2API.Skins/SkinVFX.cs
@@ -81,7 +81,7 @@ public static partial class SkinVFX {
     }
 
     private static SkinVFXInfo FindSkinVFXInfo(uint identifier) {
-        return skinVFXInfos.FirstOrDefault(skinVFXInfo => skinVFXInfo.Identifier == identifier);
+        return skinVFXInfos[(int)(identifier - BaseIdentifier)];
     }
 
     private static SkinVFXInfo FindSkinVFXInfo(GameObject attacker, GameObject effectPrefab) {

--- a/R2API.Skins/SkinVFX.cs
+++ b/R2API.Skins/SkinVFX.cs
@@ -46,6 +46,7 @@ public static partial class SkinVFX {
         hooksSet = false;
         On.RoR2.EffectComponent.Start -= ApplyModifier;
         On.RoR2.EffectManager.SpawnEffect_GameObject_EffectData_bool -= ApplyReplacement;
+        IL.RoR2.BulletAttack.FireSingle -= ModifyBulletAttack;
 
         IL.RoR2.Orbs.GenericDamageOrb.Begin -= ModifyGenericOrb;
     }

--- a/R2API.Skins/SkinVFX.cs
+++ b/R2API.Skins/SkinVFX.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using RoR2;
+using UnityEngine;
+using RoR2.Orbs;
+
+namespace R2API;
+
+/// <summary>
+/// Class for adding skin-specific effect replacements for SkinDefs.
+/// </summary>
+public static class SkinVFX {
+    private static List<SkinVFXInfo> skinVFXInfos = new List<SkinVFXInfo>();
+    private static bool hooksSet = false;
+    private const uint BaseIdentifier = 24000; // arbitrary, but we shouldn't hit 24,000 unique items for a substantial amount of time.
+    private static uint currentIdentifier = BaseIdentifier; 
+    private static uint nextIdentifier => currentIdentifier++;
+
+    /// <summary>
+    /// Called when a skin-specific effect is ready to be modified.
+    /// </summary>
+    /// <param name="spawnedEffect">The effect that was spawned.</param>
+    public delegate void OnEffectSpawnedDelegate(GameObject spawnedEffect);
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The EffectIndex of the effect that should be replaced.</param>
+    /// <param name="replacementPrefab">A replacement prefab to spawn instead of the effect. To modify the normal prefab, see the overload with OnEffectSpawnedDelegate.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, EffectIndex targetEffect, GameObject replacementPrefab) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            TargetEffect = targetEffect,
+            ReplacementEffectPrefab = replacementPrefab,
+        };
+
+        AddSkinVFX(ref skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The EffectIndex of the effect that should be replaced.</param>
+    /// <param name="onEffectSpawned">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, EffectIndex targetEffect, OnEffectSpawnedDelegate onEffectSpawned) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            TargetEffect = targetEffect,
+            OnEffectSpawned = onEffectSpawned,
+        };
+
+        AddSkinVFX(ref skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinVFXInfo">The SkinVFXInfo to register. Its Identifier field will be automatically assigned by this method.</param>
+    /// <returns>True on success, false otherwise.</returns>
+    public static bool AddSkinVFX(ref SkinVFXInfo skinVFXInfo) {
+        SetHooks();
+
+        if (skinVFXInfo.RequiredSkin == null) {
+            SkinsPlugin.Logger.LogError($"Cannot add a SkinVFXInfo with no assigned SkinDef.");
+            return false;
+        }
+
+        if (skinVFXInfo.TargetEffect == EffectIndex.Invalid) {
+            SkinsPlugin.Logger.LogError($"SkinVFXInfo may not have a TargetEffect of EffectIndex.Invalid");
+            return false;
+        }
+
+        if (skinVFXInfo.ReplacementEffectPrefab == null && skinVFXInfo.OnEffectSpawned == null) {
+            SkinsPlugin.Logger.LogError($"SkinVFXInfo must have either a ReplacementEffectPrefab or an OnEffectSpawnedDelegate assigned.");
+            return false;
+        }
+
+        skinVFXInfo.Identifier = nextIdentifier;
+        skinVFXInfos.Add(skinVFXInfo);
+
+        return true;
+    }
+
+    internal static void SetHooks() {
+        if (hooksSet) {
+            return;
+        }
+
+        hooksSet = true;
+
+        On.RoR2.EffectComponent.Start += ApplyModifier;
+        On.RoR2.EffectManager.SpawnEffect_GameObject_EffectData_bool += ApplyReplacement;
+        IL.RoR2.BulletAttack.FireSingle += ModifyBulletAttack;
+
+        IL.RoR2.Orbs.GenericDamageOrb.Begin += ModifyGenericOrb;
+    }
+
+    internal static void UnsetHooks() {
+        hooksSet = false;
+        On.RoR2.EffectComponent.Start -= ApplyModifier;
+        On.RoR2.EffectManager.SpawnEffect_GameObject_EffectData_bool -= ApplyReplacement;
+
+        IL.RoR2.Orbs.GenericDamageOrb.Begin -= ModifyGenericOrb;
+    }
+
+    private static SkinVFXInfo FindSkinVFXInfo(uint identifier) {
+        return skinVFXInfos.FirstOrDefault(skinVFXInfo => skinVFXInfo.Identifier == identifier);
+    }
+
+    private static SkinVFXInfo FindSkinVFXInfo(GameObject attacker, GameObject effectPrefab) {
+        if (!attacker || !effectPrefab) {
+            return default(SkinVFXInfo);
+        }
+
+        SkinDef skinDef = SkinCatalog.FindCurrentSkinDefForBodyInstance(attacker);
+        EffectIndex index = EffectCatalog.FindEffectIndexFromPrefab(effectPrefab);
+
+        return skinVFXInfos.FirstOrDefault(skinVFXInfo => skinVFXInfo.RequiredSkin == skinDef && skinVFXInfo.TargetEffect == index);
+    }
+
+    private static void ApplyReplacement(On.RoR2.EffectManager.orig_SpawnEffect_GameObject_EffectData_bool orig, GameObject effectPrefab, EffectData effectData, bool transmit)
+    {
+        if (effectData == null) {
+            orig(effectPrefab, effectData, transmit);
+            return;
+        }
+
+        if (effectData.genericUInt < BaseIdentifier) {
+            orig(effectPrefab, effectData, transmit);
+            return;
+        }
+
+        SkinVFXInfo skinVFXInfo = FindSkinVFXInfo(effectData.genericUInt);
+
+        if (skinVFXInfo.Identifier == uint.MaxValue) {
+            orig(effectPrefab, effectData, transmit);
+            return;
+        }
+
+        if (skinVFXInfo.ReplacementEffectPrefab != null) {
+            orig(skinVFXInfo.ReplacementEffectPrefab, effectData, transmit);
+            return;
+        }
+
+        orig(effectPrefab, effectData, transmit);
+    }
+
+    private static void ApplyModifier(On.RoR2.EffectComponent.orig_Start orig, EffectComponent self) {
+        orig(self);
+
+        if (self.effectData == null) return;
+        if (self.effectData.genericUInt < BaseIdentifier) return;
+
+        SkinVFXInfo skinVFXInfo = FindSkinVFXInfo(self.effectData.genericUInt);
+
+        if (skinVFXInfo.Identifier == uint.MaxValue) return;
+
+        skinVFXInfo.OnEffectSpawned?.Invoke(self.gameObject);
+    }
+
+    private static void ModifyGenericOrb(ILContext il) {
+        ILCursor c = new ILCursor(il);
+
+        bool found = c.TryGotoNext(MoveType.After,
+            x => x.MatchCallOrCallvirt<EffectData>(nameof(EffectData.SetHurtBoxReference))
+        );
+
+        if (!found) {
+            SkinsPlugin.Logger.LogError($"Failed to apply SkinVFX IL hook on {il.Method.DeclaringType}.{il.Method.Name}");
+            return;
+        }
+
+        c.Emit(OpCodes.Ldloc_0);
+        c.Emit(OpCodes.Ldarg_0);
+
+        c.EmitDelegate<Action<EffectData, GenericDamageOrb>>((data, orb) => {
+            if (data == null) return;
+            if (!orb.attacker) return;
+
+            SkinVFXInfo info = FindSkinVFXInfo(orb.attacker, orb.GetOrbEffect());
+
+            if (info.Identifier == uint.MaxValue) return;
+
+            data.genericUInt = info.Identifier;
+        });
+    }
+
+    private static void ModifyBulletAttack(ILContext il) {
+        ILCursor c = new ILCursor(il);
+
+        bool found = c.TryGotoNext(MoveType.After,
+            x => x.MatchCallOrCallvirt<EffectData>(nameof(EffectData.SetChildLocatorTransformReference))
+        );
+
+        if (!found) {
+            SkinsPlugin.Logger.LogError($"Failed to apply SkinVFX IL hook on BulletAttack.FireSingle");
+            return;
+        }
+
+        c.Emit(OpCodes.Ldloc_S, (byte)14);
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate<Action<EffectData, BulletAttack>>((effectData, bulletAttack) => {
+            SkinVFXInfo skinVFXInfo = FindSkinVFXInfo(bulletAttack.owner, bulletAttack.tracerEffectPrefab);
+
+            if (skinVFXInfo.Identifier == uint.MaxValue) return;
+
+            effectData.genericUInt = skinVFXInfo.Identifier;
+        });
+    }
+}

--- a/R2API.Skins/SkinVFX.cs
+++ b/R2API.Skins/SkinVFX.cs
@@ -81,6 +81,9 @@ public static partial class SkinVFX {
     }
 
     private static SkinVFXInfo FindSkinVFXInfo(uint identifier) {
+        if (identifier < BaseIdentifier || identifier >= (skinVFXInfos.Count + BaseIdentifier)) {
+            return null;
+        }
         return skinVFXInfos[(int)(identifier - BaseIdentifier)];
     }
 

--- a/R2API.Skins/SkinVFXHelpers.cs
+++ b/R2API.Skins/SkinVFXHelpers.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using RoR2;
+using UnityEngine;
+using RoR2.Orbs;
+
+
+namespace R2API;
+
+// this is partial to avoid cluttering with the multiple overloads of AddSkinVFX
+public static partial class SkinVFX {
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The EffectIndex of the effect that should be replaced.</param>
+    /// <param name="replacementPrefab">A replacement prefab to spawn instead of the effect. To modify the normal prefab, see the overload with OnEffectSpawnedDelegate.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, EffectIndex targetEffect, GameObject replacementPrefab) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            TargetEffect = targetEffect,
+            ReplacementEffectPrefab = replacementPrefab,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The name of the effect that should be replaced.</param>
+    /// <param name="replacementPrefab">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, string targetEffect, GameObject replacementPrefab) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            EffectString = targetEffect,
+            ReplacementEffectPrefab = replacementPrefab,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The the effect that should be replaced.</param>
+    /// <param name="replacementPrefab">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, GameObject targetEffect, GameObject replacementPrefab) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            EffectPrefab = targetEffect,
+            ReplacementEffectPrefab = replacementPrefab,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The EffectIndex of the effect that should be replaced.</param>
+    /// <param name="onEffectSpawned">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, EffectIndex targetEffect, OnEffectSpawnedDelegate onEffectSpawned) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            TargetEffect = targetEffect,
+            OnEffectSpawned = onEffectSpawned,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">Name of the effect that should be replaced.</param>
+    /// <param name="onEffectSpawned">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, string targetEffect, OnEffectSpawnedDelegate onEffectSpawned) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            EffectString = targetEffect,
+            OnEffectSpawned = onEffectSpawned,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinDef">The SkinDef that should be required for the replacement to occur.</param>
+    /// <param name="targetEffect">The effect prefab that should be replaced.</param>
+    /// <param name="onEffectSpawned">A delegate that will be called when the effect is spawned by a character with a matching SkinDef.</param>
+    /// <returns>The SkinVFXInfo created from the input.</returns>
+    public static SkinVFXInfo AddSkinVFX(SkinDef skinDef, GameObject targetEffect, OnEffectSpawnedDelegate onEffectSpawned) {
+        SetHooks();
+
+        SkinVFXInfo skinVFXInfo = new SkinVFXInfo {
+            RequiredSkin = skinDef,
+            EffectPrefab = targetEffect,
+            OnEffectSpawned = onEffectSpawned,
+        };
+
+        AddSkinVFX(skinVFXInfo);
+
+        return skinVFXInfo;
+    }
+
+    /// <summary>
+    /// Adds a skin-specific effect replacement.
+    /// </summary>
+    /// <param name="skinVFXInfo">The SkinVFXInfo to register. Its Identifier field will be automatically assigned by this method.</param>
+    /// <returns>True on success, false otherwise.</returns>
+    public static bool AddSkinVFX(SkinVFXInfo skinVFXInfo) {
+        SetHooks();
+
+        if (hasCatalogInitOccured && skinVFXInfo.EffectPrefab != null) {
+            skinVFXInfo.TargetEffect = EffectCatalog.FindEffectIndexFromPrefab(skinVFXInfo.EffectPrefab);
+
+            EffectDef def = EffectCatalog.entries.FirstOrDefault(effectDef => effectDef.prefabName == skinVFXInfo.EffectString);
+
+            if (def == null) {
+                SkinsPlugin.Logger.LogError($"Failed to find effect {skinVFXInfo.EffectString} for SkinVFXInfo!");
+                return false;
+            }
+
+            skinVFXInfo.TargetEffect = def.index;
+        }
+
+        if (skinVFXInfo.RequiredSkin == null) {
+            SkinsPlugin.Logger.LogError($"Cannot add a SkinVFXInfo with no assigned SkinDef.");
+            return false;
+        }
+
+        if (skinVFXInfo.TargetEffect == EffectIndex.Invalid && skinVFXInfo.EffectPrefab == null && skinVFXInfo.EffectString == null) {
+            SkinsPlugin.Logger.LogError($"SkinVFXInfo may not have a TargetEffect of EffectIndex.Invalid, or must also specify an EffectPrefab or EffectString.");
+            return false;
+        }
+
+        if (skinVFXInfo.ReplacementEffectPrefab == null && skinVFXInfo.OnEffectSpawned == null) {
+            SkinsPlugin.Logger.LogError($"SkinVFXInfo must have either a ReplacementEffectPrefab or an OnEffectSpawnedDelegate assigned.");
+            return false;
+        }
+
+        skinVFXInfo.Identifier = nextIdentifier;
+        skinVFXInfos.Add(skinVFXInfo);
+
+        return true;
+    }
+}

--- a/R2API.Skins/SkinVFXInfo.cs
+++ b/R2API.Skins/SkinVFXInfo.cs
@@ -8,7 +8,7 @@ namespace R2API;
 /// When the specified VFX would be spawned and the spawner's SkinDef matches, it will be modified by the values here.
 /// Call AddSkinVFX() to register this. 
 /// </summary>
-public struct SkinVFXInfo {
+public class SkinVFXInfo {
     /// <summary>
     /// SkinDef required before this replacement is applied.
     /// </summary>
@@ -30,7 +30,12 @@ public struct SkinVFXInfo {
     /// </summary>
     public uint Identifier = uint.MaxValue;
 
-    public SkinVFXInfo() {
-
-    }
+    /// <summary>
+    /// The prefab of the effect that should be replaced. This will automatically fill out TargetEffect on EffectCatalog.Init
+    /// </summary>
+    public GameObject EffectPrefab;
+    /// <summary>
+    /// The name of the effect that should be replaced. This will automatically fill out TargetEffect on EffectCatalog.Init
+    /// </summary>
+    public string EffectString;
 }

--- a/R2API.Skins/SkinVFXInfo.cs
+++ b/R2API.Skins/SkinVFXInfo.cs
@@ -1,0 +1,36 @@
+using RoR2;
+using UnityEngine;
+
+namespace R2API;
+
+/// <summary>
+/// A container struct for a skin-specific VFX.
+/// When the specified VFX would be spawned and the spawner's SkinDef matches, it will be modified by the values here.
+/// Call AddSkinVFX() to register this. 
+/// </summary>
+public struct SkinVFXInfo {
+    /// <summary>
+    /// SkinDef required before this replacement is applied.
+    /// </summary>
+    public SkinDef RequiredSkin;
+    /// <summary>
+    /// EffectIndex of the effect that should be replaced.
+    /// </summary>
+    public EffectIndex TargetEffect = EffectIndex.Invalid;
+    /// <summary>
+    /// A replacement prefab to spawn instead of the effect. This will be used instead of OnEffectSpawn if assigned.
+    /// </summary>
+    public GameObject? ReplacementEffectPrefab;
+    /// <summary>
+    /// A delegate that will be called when the effect is spawned by a character with a matching SkinDef.
+    /// </summary>
+    public SkinVFX.OnEffectSpawnedDelegate? OnEffectSpawned;
+    /// <summary>
+    /// An identifier used to track whether or not this effect met the skin condition. This will be automatically assigned, and shouldn't be modified.
+    /// </summary>
+    public uint Identifier = uint.MaxValue;
+
+    public SkinVFXInfo() {
+
+    }
+}

--- a/R2API.Skins/SkinsPlugin.cs
+++ b/R2API.Skins/SkinsPlugin.cs
@@ -19,10 +19,12 @@ public sealed class SkinsPlugin : BaseUnityPlugin
     private void OnEnable()
     {
         SkinIDRS.SetHooks();
+        SkinVFX.SetHooks();
     }
 
     private void OnDisable()
     {
         SkinIDRS.UnsetHooks();
+        SkinVFX.UnsetHooks();
     }
 }

--- a/R2API.Skins/thunderstore.toml
+++ b/R2API.Skins/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Skins"
-versionNumber = "1.0.0"
+versionNumber = "1.1.0"
 description = "R2API Submodule for adding custom Skins and Skin-related utilities to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Adds the SkinVFX class to R2API.Skins. Provides an easy helper method for automatically replacing VFX depending on the equipped skin.

Supports replacing VFX for:
- EffectManager.SimpleMuzzleFlash
- BasicMeleeAttack swingEffectPrefab
- BulletAttack tracerEffectPrefab
- GenericDamageOrb's orb effect
- Any other spawned VFX if the source passes in the Identifier manually.

Provides the AddSkinVFX method, which takes in a SkinDef to require, any of (EffectIndex | string | GameObject), and either a replacement gameobject or a delegate to call upon the effect being spawned.