### PR TITLE
CrocoDamageTypeController Support For DamageAPI

### DIFF
--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -18,6 +18,9 @@ Do not hesitate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ## Changelog
 
+### '5.1.0'
+* Add Array to Array operations to CompressedFlagArrayUtilities
+
 ### '5.0.11'
 
 - Fix SystemInitializerInjector.

--- a/R2API.Core/Utils/CompressedFlagArrayUtilities.cs
+++ b/R2API.Core/Utils/CompressedFlagArrayUtilities.cs
@@ -59,6 +59,13 @@ internal static class CompressedFlagArrayUtilities
         values[valueIndex] = (byte)(values[valueIndex] | highestBitInByte >> flagIndex);
     }
 
+    public static void Add(ref byte[] values, byte[] operand){
+        ResizeIfNeeded(ref values,operand.Length);
+        for(int i = 0 ; i < operand.Length ; i++){
+          values[i] |= operand[i];
+        }
+    }
+
     public static bool Remove(ref byte[] values, int index)
     {
         if (index < 0)
@@ -77,6 +84,17 @@ internal static class CompressedFlagArrayUtilities
         DownsizeIfNeeded(ref values);
 
         return true;
+    }
+
+    public static bool Remove(ref byte[] values, byte[] operand){
+        bool result = false;
+        int length = Math.Min(values.Length,operand.Length);
+        for(int i = 0 ; i < length ; i++){
+           result |= ((values[i] & operand[i]) != Byte.MinValue);
+           values[i] &= (byte)(~operand[i]);
+        }
+        DownsizeIfNeeded(ref values);
+        return result;
     }
 
     public static bool Has(byte[] values, int index)

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.0.11"
+versionNumber = "5.1.0"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -17,10 +17,14 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 * BlastAttack
 * OverlapAttack
 * DotController.DotStack
+* CrocoDamageTypeController
 
 ## Related Pages
 
 ## Changelog
+
+### '1.1.0'
+* CrocoDamageTypeController support added,allowing better implementations of alt passives for Acrid.
 
 ### '1.0.4'
 * Memory optimization

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.0.4"
+versionNumber = "1.1.0"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Not being able to support modded damage types made CrocoDamageTypeController almost entirely useless for mods and made compatibility between mods adding new passives to Acrid difficult.
However it's conceptually really useful,so here is an effort to make it work like we'd want it to.Includes additions to CompressedFlagArrayUtilities to facilitate non-destructive copying of ModdedDamageTypeHolders
Draft PR currently only implements support for projectiles,putting it up to gather feedback on changes to API surface and on the following:
The transfer of modded damage types from the holder assigned to the CrocoDamageTypeController needs to be deferred due to the way the vanilla component is setup (which is why it was such a pain),signalling for this is available through the remaining unused vanilla damage type.While projectiles have a very convenient place to do this in (ProjectileManager.InitProjectile),there is no direct equivalent to handle non-projectile attacks.
One option to keep the implementation simple is to delay this operation until TakeDamage/OnHitAll,this seems ideal but makes it so that the damage type coming from the CrocoDamageTypeController is not visible to checks before that point (HasModdedDamageType on a BulletAttack,for example).
The opposite approach would be to check for the signal and perform it in every current hook,this guarantees total visiblity for the moddeddamagetypes in question but will complicate the implementation. (Might cause performance/maintenance burden)