### PR TITLE
Fix custom DOTs not counting as active upon infliction

### DIFF
--- a/R2API.Dot/DotAPI.cs
+++ b/R2API.Dot/DotAPI.cs
@@ -341,6 +341,7 @@ public static partial class DotAPI
                     {
                         var customDotIndex = (int)dotStack.dotIndex - VanillaDotCount;
                         _customDotBehaviours[customDotIndex]?.Invoke(self, dotStack);
+                        ActiveCustomDots[self][customDotIndex] = true;
                     }
                 });
             }

--- a/R2API.Dot/README.md
+++ b/R2API.Dot/README.md
@@ -17,6 +17,9 @@ Alongside adding new DotIndices and DotDefs, One can also provide CustomDotBehav
 
 ## Changelog
 
+### '1.0.2'
+* Fix custom DOTs counting as active upon infliction and not only after having ticked once.
+
 ### '1.0.1'
 * Fix the NuGet package which had a dependency on a non-existent version of `R2API.Core`.
 

--- a/R2API.Dot/thunderstore.toml
+++ b/R2API.Dot/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Dot"
-versionNumber = "1.0.1"
+versionNumber = "1.0.2"
 description = "API for adding custom damage over time effects"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Update the active custom dots the moment one is inflicted, else it doesn't count for Death Mark until it has ticked once and its active state is refreshed in the FixedUpdate hook.