### PR TITLE
fix(TempVisualEffect): recompile needed cause RoR2.FixedSizeArrayPool.Return signature changed when sots dlc2 released

### DIFF
--- a/R2API.TempVisualEffect/README.md
+++ b/R2API.TempVisualEffect/README.md
@@ -18,6 +18,9 @@ A separate overload for AddTemporaryVisualEffect takes an EffectRadius delegate,
 
 ## Changelog
 
+### '1.0.3'
+* Initial fixes for SOTS DLC2 Release.
+
 ### '1.0.2'
 * Add missing `BepInDependency` to `R2API.ContentManagement`
 

--- a/R2API.TempVisualEffect/thunderstore.toml
+++ b/R2API.TempVisualEffect/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_TempVisualEffect"
-versionNumber = "1.0.2"
+versionNumber = "1.0.3"
 description = "API for adding custom temporary visual effects for characters."
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Closes https://github.com/risk-of-thunder/R2API/issues/538