### PR TITLE
Fix ColorsAPI

### DIFF
--- a/R2API.Colors/ColorsAPI.cs
+++ b/R2API.Colors/ColorsAPI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using R2API.AutoVersionGen;
@@ -37,8 +38,8 @@ public static partial class ColorsAPI
         }
 
         //Color Catalog
-        IL.RoR2.ColorCatalog.GetColor += GetColorIL;
-        IL.RoR2.ColorCatalog.GetColorHexString += GetColorIL;
+        On.RoR2.ColorCatalog.GetColor += OnColorCatalogGetColor;
+        On.RoR2.ColorCatalog.GetColorHexString += OnColorCatalogGetColorHexString;
 
         //DamageColor
         IL.RoR2.DamageColor.FindColor += GetColorIL;
@@ -49,8 +50,8 @@ public static partial class ColorsAPI
     internal static void UnsetHooks()
     {
         //Color Catalog
-        IL.RoR2.ColorCatalog.GetColor -= GetColorIL;
-        IL.RoR2.ColorCatalog.GetColorHexString -= GetColorIL;
+        On.RoR2.ColorCatalog.GetColor -= OnColorCatalogGetColor;
+        On.RoR2.ColorCatalog.GetColorHexString -= OnColorCatalogGetColorHexString;
 
         //DamageColor
         IL.RoR2.DamageColor.FindColor -= GetColorIL;
@@ -76,6 +77,29 @@ public static partial class ColorsAPI
         c.Index++;
         c.Emit(OpCodes.Pop);
     }
+
+    private static Color32 OnColorCatalogGetColor(On.RoR2.ColorCatalog.orig_GetColor orig, ColorCatalog.ColorIndex colorIndex)
+    {
+        var index = (int)colorIndex;
+        if (index < 0 || index > GetLength(ref ColorCatalog.indexToColor32))
+        {
+            index = (int)ColorCatalog.ColorIndex.Error;
+        }
+
+        return GetItem(ref ColorCatalog.indexToColor32, index);
+    }
+
+    private static string OnColorCatalogGetColorHexString(On.RoR2.ColorCatalog.orig_GetColorHexString orig, ColorCatalog.ColorIndex colorIndex)
+    {
+        var index = (int)colorIndex;
+        if (index < 0 || index > GetLength(ref ColorCatalog.indexToHexString))
+        {
+            index = (int)ColorCatalog.ColorIndex.Error;
+        }
+
+        return GetItem(ref ColorCatalog.indexToHexString, index);
+    }
+
     #endregion
 
     #region Damage Color Public Methods
@@ -122,7 +146,10 @@ public static partial class ColorsAPI
     public static ColorCatalog.ColorIndex RegisterColor(Color color)
     {
         ColorsAPI.SetHooks();
-        int nextColorIndex = ColorCatalog.indexToColor32.Length;
+        //Just doing ColorCatalog.indexToColor.Length always returns 28
+        //Most likely some kind of JIT optimization because it's a static readonly array
+        //resulting in using old array(that's why we use ref)/length even though it actually changed
+        int nextColorIndex = GetLength(ref ColorCatalog.indexToColor32);
         ColorCatalog.ColorIndex newIndex = (ColorCatalog.ColorIndex)nextColorIndex;
         HG.ArrayUtils.ArrayAppend(ref ColorCatalog.indexToColor32, color);
         HG.ArrayUtils.ArrayAppend(ref ColorCatalog.indexToHexString, Util.RGBToHex(color));
@@ -145,5 +172,12 @@ public static partial class ColorsAPI
 
         serializableColor.ColorIndex = RegisterColor(serializableColor.color32);
     }
+
     #endregion
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetLength<T>(ref T[] array) => array.Length;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T GetItem<T>(ref T[] array, int i) => array[i];
 }

--- a/R2API.Colors/README.md
+++ b/R2API.Colors/README.md
@@ -22,6 +22,9 @@ These scriptable objects can later be used for example, in EntityStateConfigurat
 
 ## Changelog
 
+### '1.0.2'
+* Fix for `SOTS` update.
+
 ### '1.0.1'
 * Fix the NuGet package which had a dependency on a non-existent version of `R2API.Core`.
 

--- a/R2API.Colors/thunderstore.toml
+++ b/R2API.Colors/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Colors"
-versionNumber = "1.0.1"
+versionNumber = "1.0.2"
 description = "API for registering Colors to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
I can only assume the real issue is JIT in Unity 2021 being very agressive with optimizations for dynamically generated methods (hooks in our case) when accessing static readonly arrays.

From debugging and logging it seems to me that a hook refers to a specific object ptr instead of a field. Adding new color creates new array and the hook still using old array which eventually gets deallocated and the hook returns random data.
Only making a hook, works fine. Only adding new colors to an array works fine. But doing both results in wrong results. A happy accident that it doesn't cause a crash, just because these methods don't use actual array length and instead uses enum value.

Probably propper solution would be making a patcher that would remove readonly modificator from these fields to ensure there is no more JIT shenanigans, but for this case it should be fine the way I did it.