### PR TITLE
ColorsAPI IL instead of On hook

### DIFF
--- a/R2API.Colors/ColorsAPI.cs
+++ b/R2API.Colors/ColorsAPI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -38,8 +39,8 @@ public static partial class ColorsAPI
         }
 
         //Color Catalog
-        On.RoR2.ColorCatalog.GetColor += OnColorCatalogGetColor;
-        On.RoR2.ColorCatalog.GetColorHexString += OnColorCatalogGetColorHexString;
+        IL.RoR2.ColorCatalog.GetColor += ColorCatalogGetColorIL;
+        IL.RoR2.ColorCatalog.GetColorHexString += ColorCatalogGetColorHexStringIL;
 
         //DamageColor
         IL.RoR2.DamageColor.FindColor += GetColorIL;
@@ -50,8 +51,8 @@ public static partial class ColorsAPI
     internal static void UnsetHooks()
     {
         //Color Catalog
-        On.RoR2.ColorCatalog.GetColor -= OnColorCatalogGetColor;
-        On.RoR2.ColorCatalog.GetColorHexString -= OnColorCatalogGetColorHexString;
+        IL.RoR2.ColorCatalog.GetColor -= ColorCatalogGetColorIL;
+        IL.RoR2.ColorCatalog.GetColorHexString -= ColorCatalogGetColorHexStringIL;
 
         //DamageColor
         IL.RoR2.DamageColor.FindColor -= GetColorIL;
@@ -78,7 +79,15 @@ public static partial class ColorsAPI
         c.Emit(OpCodes.Pop);
     }
 
-    private static Color32 OnColorCatalogGetColor(On.RoR2.ColorCatalog.orig_GetColor orig, ColorCatalog.ColorIndex colorIndex)
+    private static void ColorCatalogGetColorIL(ILContext il)
+    {
+        var c = new ILCursor(il);
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(ColorCatalogGetColor);
+        c.Emit(OpCodes.Ret);
+    }
+
+    private static Color32 ColorCatalogGetColor(ColorCatalog.ColorIndex colorIndex)
     {
         var index = (int)colorIndex;
         if (index < 0 || index > GetLength(ref ColorCatalog.indexToColor32))
@@ -89,7 +98,15 @@ public static partial class ColorsAPI
         return GetItem(ref ColorCatalog.indexToColor32, index);
     }
 
-    private static string OnColorCatalogGetColorHexString(On.RoR2.ColorCatalog.orig_GetColorHexString orig, ColorCatalog.ColorIndex colorIndex)
+    private static void ColorCatalogGetColorHexStringIL(ILContext il)
+    {
+        var c = new ILCursor(il);
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(ColorCatalogGetColorHexString);
+        c.Emit(OpCodes.Ret);
+    }
+
+    private static string ColorCatalogGetColorHexString(ColorCatalog.ColorIndex colorIndex)
     {
         var index = (int)colorIndex;
         if (index < 0 || index > GetLength(ref ColorCatalog.indexToHexString))

--- a/R2API.Colors/README.md
+++ b/R2API.Colors/README.md
@@ -22,6 +22,9 @@ These scriptable objects can later be used for example, in EntityStateConfigurat
 
 ## Changelog
 
+### '1.0.3'
+* Fix compatibility with other mods that modify ColorCatalog.
+
 ### '1.0.2'
 * Fix for `SOTS` update.
 

--- a/R2API.Colors/thunderstore.toml
+++ b/R2API.Colors/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Colors"
-versionNumber = "1.0.2"
+versionNumber = "1.0.3"
 description = "API for registering Colors to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Not calling orig bit me, as it does. Some mods also hook into GetColors and some (namely Augmentum) don't modify indexToColor array but do their own stuff. To get back previous behaviour we just call static method in IL hook and return.