### PR TITLE
EliteAPI: Update conditional cost to match latest game version

### DIFF
--- a/R2API.Elites/EliteAPI.cs
+++ b/R2API.Elites/EliteAPI.cs
@@ -118,7 +118,7 @@ public static partial class EliteAPI
                 Addressables.LoadAssetAsync<EliteDef>("RoR2/Base/EliteFire/edFire.asset").WaitForCompletion(),
                 Addressables.LoadAssetAsync<EliteDef>("RoR2/DLC1/EliteEarth/edEarth.asset").WaitForCompletion(),
             },
-            isAvailable = (SpawnCard.EliteRules rules) => CombatDirector.NotEliteOnlyArtifactActive() && rules == SpawnCard.EliteRules.Default,
+            isAvailable = (SpawnCard.EliteRules rules) => CombatDirector.NotEliteOnlyArtifactActive() && rules == SpawnCard.EliteRules.Default && Run.instance.stageClearCount < 2,
             canSelectWithoutAvailableEliteDef = false
         };
         eliteTiersDef.Add(eliteTierDef);
@@ -139,7 +139,7 @@ public static partial class EliteAPI
 
         eliteTierDef = new CombatDirector.EliteTierDef
         {
-            costMultiplier = Mathf.LerpUnclamped(1f, CombatDirector.baseEliteCostMultiplier, 0.5f),
+            costMultiplier = CombatDirector.baseEliteCostMultiplier,
             eliteTypes = new EliteDef[] {
                 Addressables.LoadAssetAsync<EliteDef>("RoR2/Base/EliteLightning/edLightning.asset").WaitForCompletion(),
                 Addressables.LoadAssetAsync<EliteDef>("RoR2/Base/EliteIce/edIce.asset").WaitForCompletion(),


### PR DESCRIPTION
https://store.steampowered.com/news/app/632360/view/4478359995220492415
https://github.com/xiaoxiao921/RoR2_diff_20_05_2024/blame/2b1da2d/DecompilationOutput/RoR2/CombatDirector.cs#L516
https://github.com/xiaoxiao921/RoR2_diff_20_05_2024/blame/2b1da2d/DecompilationOutput/RoR2/CombatDirector.cs#L498

Past stage two, elite cost uses the old reduced *Honor* value otherwise (with this **API** installed). They also added an extra check that, while unnecessary, is included.