### PR TITLE
Fixes `RemoveExistingMonsterFromStage`, which by default removed the given monster from family DCCSs, potentially affecting other scenes unintentionally since those are shared between stages.

### DIFF
--- a/R2API.Director/DirectorAPIhelpers.cs
+++ b/R2API.Director/DirectorAPIhelpers.cs
@@ -754,7 +754,7 @@ public static partial class DirectorAPI
         {
             DirectorAPI.SetHooks();
 
-            RemoveExistingMonsterFromStage(monsterName, true, null, stage, customStageName);
+            RemoveExistingMonsterFromStage(monsterName, false, null, stage, customStageName);
         }
 
         /// <summary>
@@ -763,7 +763,7 @@ public static partial class DirectorAPI
         /// If a valid (non null) predicate is provided the monster will only be removed from the given DirectorCardCategorySelection if the predicate return true.
         /// </summary>
         /// <param name="monsterName">The name of the monster card to remove</param>
-        /// <param name="removeFromFamilies">Whether or not it the monster should be removed from familiy DCCSs</param>
+        /// <param name="removeFromFamilies">Whether or not it the monster should be removed from family DCCSs</param>
         /// <param name="predicate">If a valid (non null) predicate is provided the monster will only be removed from the given DirectorCardCategorySelection if the predicate return true.</param>
         /// <param name="stage">The stage to remove on</param>
         /// <param name="customStageName">The name of the custom stage</param>

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,10 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.3.2'
+
+* Fixed `RemoveExistingMonsterFromStage`, which by default removed the given monster from family DCCSs, potentially affecting other scenes unintentionally since those are shared between stages.
+
 ### '2.3.1'
 
 * Fixed the AddressableDCCSPool's ConditionalPool class not upgrading properly when it was using the new FamilyDCCSOption

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.1"
+versionNumber = "2.3.2"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Fix https://github.com/risk-of-thunder/R2API/issues/562