### PR TITLE
[DamageTypeAPI] Rewrite to use patcher field, instead of il hooks and ConditionalWeakTable

### DIFF
--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -18,6 +18,9 @@ Do not hesitate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ## Changelog
 
+### '5.1.3'
+* Added methods for immutable Array operation to CompressedFlagArrayUtilities
+
 ### '5.1.2'
 * Fix SystemInitializerInjector
 

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.1.2"
+versionNumber = "5.1.3"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.DamageType.Interop/CrocoDamageTypeControllerInterop.cs
+++ b/R2API.DamageType.Interop/CrocoDamageTypeControllerInterop.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RoR2;
+
+namespace R2API;
+internal class CrocoDamageTypeControllerInterop
+{
+    public static byte[] GetModdedDamageTypes(CrocoDamageTypeController damageTypeController) => damageTypeController.r2api_moddedDamageTypes;
+
+    public static void SetModdedDamageTypes(CrocoDamageTypeController damageTypeController, byte[] value) => damageTypeController.r2api_moddedDamageTypes = value;
+}

--- a/R2API.DamageType.Interop/DamageTypeComboInterop.cs
+++ b/R2API.DamageType.Interop/DamageTypeComboInterop.cs
@@ -1,0 +1,13 @@
+using RoR2;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("R2API.DamageType")]
+
+namespace R2API;
+
+internal static class DamageTypeComboInterop
+{
+    public static byte[] GetModdedDamageTypes(DamageTypeCombo damageType) => damageType.r2api_moddedDamageTypes;
+
+    public static void SetModdedDamageTypes(ref DamageTypeCombo damageType, byte[] value) => damageType.r2api_moddedDamageTypes = value;
+}

--- a/R2API.DamageType.Interop/R2API.DamageType.Interop.csproj
+++ b/R2API.DamageType.Interop/R2API.DamageType.Interop.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RoR2.Patched\RoR2.Patched.csproj" Privete="false" PrivateAssets="all"/>
+  </ItemGroup>
+</Project>

--- a/R2API.DamageType.Patcher/DamageTypePatcher.cs
+++ b/R2API.DamageType.Patcher/DamageTypePatcher.cs
@@ -1,0 +1,38 @@
+using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace R2API;
+
+internal static class DamageTypePatcher
+{
+    public static IEnumerable<string> TargetDLLs
+    {
+        get
+        {
+            yield return "RoR2.dll";
+        }
+    }
+
+    public static void Patch(AssemblyDefinition assembly)
+    {
+        PatchDamageTypeCombo(assembly);
+        PatchCrocoDamageTypeController(assembly);
+    }
+
+    private static void PatchCrocoDamageTypeController(AssemblyDefinition assembly)
+    {
+        var crocoDamageTypeController = assembly.MainModule.GetType("RoR2", "CrocoDamageTypeController");
+        var newField = new FieldDefinition("r2api_moddedDamageTypes", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[])));
+        crocoDamageTypeController?.Fields.Add(newField);
+    }
+
+    private static void PatchDamageTypeCombo(AssemblyDefinition assembly)
+    {
+        var damageTypeCombo = assembly.MainModule.GetType("RoR2", "DamageTypeCombo");
+        var newField = new FieldDefinition("r2api_moddedDamageTypes", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[])));
+        newField.Offset = 16;
+        damageTypeCombo?.Fields.Add(newField);
+    }
+}

--- a/R2API.DamageType.Patcher/R2API.DamageType.Patcher.csproj
+++ b/R2API.DamageType.Patcher/R2API.DamageType.Patcher.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="5.4.19" />
+  </ItemGroup>
+</Project>

--- a/R2API.DamageType/R2API.DamageType.csproj
+++ b/R2API.DamageType/R2API.DamageType.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
-    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+    <ProjectReference Include="..\R2API.DamageType.Interop\R2API.DamageType.Interop.csproj" Private="false" PrivateAssets="all"/>
+    <ProjectReference Include="..\R2API.DamageType.Patcher\R2API.DamageType.Patcher.csproj" Private="false" PrivateAssets="all" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -23,6 +23,9 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 
 ## Changelog
 
+### '1.1.3'
+* Internal rewrite for easier support in the future.
+
 ### '1.1.2'
 * More fixes for SOTS DLC2 Release.
 

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.1.2"
+versionNumber = "1.1.3"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
@@ -21,8 +21,20 @@ readme = "./README.md"
 outdir = "./build"
 
 [[build.copy]]
-source = "./ReleaseOutput"
-target = "./plugins/R2API.DamageType"
+source = "./ReleaseOutput/R2API.DamageType.dll"
+target = "./plugins/R2API.DamageType/R2API.DamageType.dll"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.DamageType.xml"
+target = "./plugins/R2API.DamageType/R2API.DamageType.xml"
+
+[[build.copy]]
+source = "../R2API.DamageType.Interop/ReleaseOutput/R2API.DamageType.Interop.dll"
+target = "./plugins/R2API.DamageType/R2API.DamageType.Interop.dll"
+
+[[build.copy]]
+source = "../R2API.DamageType.Patcher/ReleaseOutput/R2API.DamageType.Patcher.dll"
+target = "./patchers/R2API.DamageType/R2API.DamageType.Patcher.dll"
 
 [publish]
 repository = "https://thunderstore.io"

--- a/R2API.props
+++ b/R2API.props
@@ -22,12 +22,12 @@
 
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.1.275-r.0" NoWarn="NU5104" />
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.6-r.0" NoWarn="NU5104" />
 
 		<PackageReference Include="BepInEx.Core" Version="5.4.19" />
 		<PackageReference Include="RoR2BepInExPack" Version="*" />
 
-		<PackageReference Include="MMHOOK.RoR2" Version="2024.8.28" NoWarn="NU1701" />
+		<PackageReference Include="MMHOOK.RoR2" Version="2024.12.10" NoWarn="NU1701" />
 
 		<PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
 	</ItemGroup>

--- a/R2API.sln
+++ b/R2API.sln
@@ -103,6 +103,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.ProcType.Interop", "R
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoR2.Patched", "RoR2.Patched\RoR2.Patched.csproj", "{77CAE85A-E1FA-44C4-9E78-404A12DF2CCE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.DamageType.Patcher", "R2API.DamageType.Patcher\R2API.DamageType.Patcher.csproj", "{929EEC5C-61AA-4B96-97BC-8A95DA7DB036}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.DamageType.Interop", "R2API.DamageType.Interop\R2API.DamageType.Interop.csproj", "{51B64907-065C-49D8-900F-26E9B54DD04F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -265,6 +269,14 @@ Global
 		{77CAE85A-E1FA-44C4-9E78-404A12DF2CCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77CAE85A-E1FA-44C4-9E78-404A12DF2CCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77CAE85A-E1FA-44C4-9E78-404A12DF2CCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{929EEC5C-61AA-4B96-97BC-8A95DA7DB036}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{929EEC5C-61AA-4B96-97BC-8A95DA7DB036}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{929EEC5C-61AA-4B96-97BC-8A95DA7DB036}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{929EEC5C-61AA-4B96-97BC-8A95DA7DB036}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51B64907-065C-49D8-900F-26E9B54DD04F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51B64907-065C-49D8-900F-26E9B54DD04F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51B64907-065C-49D8-900F-26E9B54DD04F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51B64907-065C-49D8-900F-26E9B54DD04F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RoR2.Patched/CrocoDamageTypeController.cs
+++ b/RoR2.Patched/CrocoDamageTypeController.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RoR2;
+public class CrocoDamageTypeController
+{
+    public byte[] r2api_moddedDamageTypes;
+}

--- a/RoR2.Patched/DamageTypeCombo.cs
+++ b/RoR2.Patched/DamageTypeCombo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RoR2;
+
+public struct DamageTypeCombo
+{
+    public byte[] r2api_moddedDamageTypes;
+}


### PR DESCRIPTION
This feels like a good time to do this, since with DamageTypeSource addition people would be likely to update their mods and check that new changes to the api work fine.
I liked the way ProcTypeAPI was done and I think it would be great to do same thing to DamageTypeAPI since with SOTS we also have a struct for all damage type needs. This allows us to remove all the IL hooks leaving only a few necessary On hooks which is always great.

This update should not be a breaking change, despite removing a ModdedTypeDamageHolder class. I checked all non-deprecated mods and none of them reference this class or methods that return this class or have it as a parameter. ModdedTypeDamageHolderComponent is no longer necessary but it is used by mods so it was marked as obsolete and redirected to use new field.