### PR TITLE
Add bleed chance to stats API

### DIFF
--- a/R2API.RecalculateStats/README.md
+++ b/R2API.RecalculateStats/README.md
@@ -29,6 +29,9 @@ These stat changes are represented in the StatHookEventArgs, which includes argu
 
 ## Changelog
 
+### '1.5.0'
+* Added `bleedChanceAdd`.
+
 ### '1.4.0'
 * Initial fixes for SOTS DLC2 Release.
 

--- a/R2API.RecalculateStats/thunderstore.toml
+++ b/R2API.RecalculateStats/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_RecalculateStats"
-versionNumber = "1.4.0"
+versionNumber = "1.5.0"
 description = "API for manipulating Character Stats"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Allows modders to add bleed chance on top of that granted by daggers and thorn. I've tested it with my own mod and it is able to handle multiple different modded items adding bleed chance at once, as well as bleed chance past 100.