### PR TITLE
[R2API.Skils] Fix mod incompatibility

### DIFF
--- a/R2API.Skills/README.md
+++ b/R2API.Skills/README.md
@@ -10,5 +10,8 @@ Adds extra fields (can be accessed with extension methods) to GenericSkill that 
 
 ## Changelog
 
+### '1.0.1'
+* Fix an incompatibility with another mod
+
 ### '1.0.0'
 * Initial Release

--- a/R2API.Skills/SkillsAPI.cs
+++ b/R2API.Skills/SkillsAPI.cs
@@ -162,10 +162,8 @@ public static partial class SkillsAPI
     {
         var c = new ILCursor(il);
         if (c.TryGotoNext(MoveType.Before,
-            x => x.MatchLdloc(out _),
             x => x.MatchNewobj<LoadoutPanelController.Row>()))
         {
-            c.Index++;
             c.Emit(OpCodes.Ldarg_3);
             c.EmitDelegate(LoadoutPanelControllerReplaceTitleToken);
         }

--- a/R2API.Skills/thunderstore.toml
+++ b/R2API.Skills/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Skills"
-versionNumber = "1.0.0"
+versionNumber = "1.0.1"
 description = "API for skills"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
ConcentricContent was hooking the same place breaking our goto. Made it less specific.