### PR TITLE
[ContentManagement] Fix for ItemRelationshipProviders

### DIFF
--- a/R2API.ContentManagement/R2APISerializableContentPack.cs
+++ b/R2API.ContentManagement/R2APISerializableContentPack.cs
@@ -115,6 +115,7 @@ public class R2APISerializableContentPack : ScriptableObject
         cp.itemDefs.Add(itemDefs);
         cp.itemTierDefs.Add(itemTierDefs);
         cp.itemRelationshipTypes.Add(itemRelationshipTypes);
+        cp.itemRelationshipProviders.Add(itemRelationshipProviders);
         cp.equipmentDefs.Add(equipmentDefs);
         cp.buffDefs.Add(buffDefs);
         cp.eliteDefs.Add(eliteDefs);

--- a/R2API.ContentManagement/README.md
+++ b/R2API.ContentManagement/README.md
@@ -23,6 +23,9 @@ R2API.ContentManaged is used for mods that would like to have R2API handle the c
 
 ## Changelog
 
+### '1.0.7'
+* Adds ItemRelationshipProviders to the ContentPack as intended.
+
 ### '1.0.6'
 * Fix SystemInitializer infinite loop.
 

--- a/R2API.ContentManagement/thunderstore.toml
+++ b/R2API.ContentManagement/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_ContentManagement"
-versionNumber = "1.0.6"
+versionNumber = "1.0.7"
 description = "API for adding content to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
`ContentAddition.AddItemRelationshipProvider` isn't functional because it never adds the object to the `ContentPack.itemRelationshipProviders` from the `R2APISerializableContentPack.itemRelationshipProviders`