### PR TITLE
[ContentManagement] Added Rejection cases and null check fields

### DIFF
--- a/R2API.ContentManagement/ContentAddition.cs
+++ b/R2API.ContentManagement/ContentAddition.cs
@@ -284,10 +284,19 @@ public static class ContentAddition
     /// <returns>True if valid and added, false if one of the requirements is not met</returns>
     public static bool AddItemRelationshipProvider(ItemRelationshipProvider itemRelationshipProvider)
     {
-        //Todo: Find what makes an ItemRelationshipProvider invalid
         var asm = GetNonAPICaller();
         if (CatalogBlockers.GetAvailability<ItemRelationshipProvider>())
         {
+            if (!itemRelationshipProvider.relationshipType)
+            {
+                RejectContent(itemRelationshipProvider, asm, "ItemRelationshipProvider", "but the RelationshipType is null!");
+                return false;
+            }
+            if (itemRelationshipProvider.relationships == null)
+            {
+                RejectContent(itemRelationshipProvider, asm, "ItemRelationshipProvider", "but the Relationships array is null!");
+                return false;
+            }
             R2APIContentManager.HandleContentAddition(asm, itemRelationshipProvider);
             return true;
         }

--- a/R2API.ContentManagement/R2APISerializableContentPack.cs
+++ b/R2API.ContentManagement/R2APISerializableContentPack.cs
@@ -115,6 +115,7 @@ public class R2APISerializableContentPack : ScriptableObject
         cp.itemDefs.Add(itemDefs);
         cp.itemTierDefs.Add(itemTierDefs);
         cp.itemRelationshipTypes.Add(itemRelationshipTypes);
+        cp.itemRelationshipProviders.Add(itemRelationshipProviders);
         cp.equipmentDefs.Add(equipmentDefs);
         cp.buffDefs.Add(buffDefs);
         cp.eliteDefs.Add(eliteDefs);

--- a/R2API.ContentManagement/R2APISerializableContentPack.cs
+++ b/R2API.ContentManagement/R2APISerializableContentPack.cs
@@ -115,7 +115,6 @@ public class R2APISerializableContentPack : ScriptableObject
         cp.itemDefs.Add(itemDefs);
         cp.itemTierDefs.Add(itemTierDefs);
         cp.itemRelationshipTypes.Add(itemRelationshipTypes);
-        cp.itemRelationshipProviders.Add(itemRelationshipProviders);
         cp.equipmentDefs.Add(equipmentDefs);
         cp.buffDefs.Add(buffDefs);
         cp.eliteDefs.Add(eliteDefs);
@@ -128,6 +127,8 @@ public class R2APISerializableContentPack : ScriptableObject
         cp.gameEndingDefs.Add(gameEndingDefs);
         cp.miscPickupDefs.Add(miscPickupDefs);
         cp.entityStateConfigurations.Add(entityStateConfigurations);
+        cp.expansionDefs.Add(expansionDefs);
+        cp.entitlementDefs.Add(entitlementDefs);
 
         List<Type> list = new List<Type>();
         for (int i = 0; i < entityStateTypes.Length; i++)
@@ -142,8 +143,26 @@ public class R2APISerializableContentPack : ScriptableObject
         }
         cp.entityStateTypes.Add(list.ToArray());
 
-        cp.expansionDefs.Add(expansionDefs);
-        cp.entitlementDefs.Add(entitlementDefs);
+        for (int i = 0; i < itemRelationshipProviders.Length; i++)
+        {
+            ItemRelationshipProvider provider = itemRelationshipProviders[i];
+            List<ItemDef.Pair> validPairs = new List<ItemDef.Pair>();
+
+            for (int j = 0; j < provider.relationships.Length; j++)
+            {
+                ItemDef.Pair pair = provider.relationships[j];
+                if (pair.itemDef1 && pair.itemDef2)
+                {
+                    validPairs.Add(pair);
+                    continue;
+                }
+                Debug.LogWarning("SerializableContentPack \"" + base.name + "\" is trying to define a " + provider.relationshipType.name +
+                    " relationship between the invalid pair \"" + pair.itemDef1?.name + "\" and \"" + pair.itemDef2?.name + "\".");
+            }
+
+            provider.relationships = validPairs.ToArray();
+        }
+        cp.itemRelationshipProviders.Add(itemRelationshipProviders);
 
         return cp;
     }

--- a/R2API.ContentManagement/README.md
+++ b/R2API.ContentManagement/README.md
@@ -23,6 +23,9 @@ R2API.ContentManaged is used for mods that would like to have R2API handle the c
 
 ## Changelog
 
+### '1.0.8'
+* Adds additional null checks to the ItemRelationshipProvider content.
+
 ### '1.0.7'
 * Adds ItemRelationshipProviders to the ContentPack as intended.
 

--- a/R2API.ContentManagement/README.md
+++ b/R2API.ContentManagement/README.md
@@ -23,6 +23,9 @@ R2API.ContentManaged is used for mods that would like to have R2API handle the c
 
 ## Changelog
 
+### '1.0.7'
+* Adds ItemRelationshipProviders to the ContentPack as intended.
+
 ### '1.0.6'
 * Fix SystemInitializer infinite loop.
 

--- a/R2API.ContentManagement/thunderstore.toml
+++ b/R2API.ContentManagement/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_ContentManagement"
-versionNumber = "1.0.7"
+versionNumber = "1.0.8"
 description = "API for adding content to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.ContentManagement/thunderstore.toml
+++ b/R2API.ContentManagement/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_ContentManagement"
-versionNumber = "1.0.6"
+versionNumber = "1.0.7"
 description = "API for adding content to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
ItemDef.Pair cant contain null itemdefs because GetHashCode explodes

- ContentAddition rejects providers that have a null relationshipType or relationship fields
- R2APISerializableContentPack sanitizes the relationship array before adding to the contentpack

![image](https://github.com/user-attachments/assets/a217c106-29b4-42d9-abab-aee1c6625f7f)
