### PR TITLE
[DamageAPI] Changed bounds check and minimum damage type value

### DIFF
--- a/R2API.DamageType/DamageAPI.cs
+++ b/R2API.DamageType/DamageAPI.cs
@@ -266,7 +266,9 @@ public static partial class DamageAPI
             throw new IndexOutOfRangeException($"Reached the limit of {CompressedFlagArrayUtilities.sectionsCount * CompressedFlagArrayUtilities.flagsPerSection} ModdedDamageTypes. Please contact R2API developers to increase the limit");
         }
 
-        return (ModdedDamageType)ModdedDamageTypeCount++;
+        ModdedDamageTypeCount++;
+
+        return (ModdedDamageType)ModdedDamageTypeCount;
     }
 
     #region AddModdedDamageType
@@ -342,13 +344,13 @@ public static partial class DamageAPI
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
-        CompressedFlagArrayUtilities.AddImmutable(ref damageTypes, (int)moddedDamageType);
+        CompressedFlagArrayUtilities.AddImmutable(ref damageTypes, (int)moddedDamageType - 1);
         CrocoDamageTypeControllerInterop.SetModdedDamageTypes(croco, damageTypes);
     }
 
@@ -356,13 +358,13 @@ public static partial class DamageAPI
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);
-        CompressedFlagArrayUtilities.AddImmutable(ref damageTypes, (int)moddedDamageType);
+        CompressedFlagArrayUtilities.AddImmutable(ref damageTypes, (int)moddedDamageType - 1);
         DamageTypeComboInterop.SetModdedDamageTypes(ref damageType, damageTypes);
     }
     #endregion
@@ -440,13 +442,13 @@ public static partial class DamageAPI
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
-        var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref damageTypes, (int)moddedDamageType);
+        var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref damageTypes, (int)moddedDamageType - 1);
         CrocoDamageTypeControllerInterop.SetModdedDamageTypes(croco, damageTypes);
 
         return removed;
@@ -456,13 +458,13 @@ public static partial class DamageAPI
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);
-        var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref damageTypes, (int)moddedDamageType);
+        var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref damageTypes, (int)moddedDamageType - 1);
         DamageTypeComboInterop.SetModdedDamageTypes(ref damageType, damageTypes);
 
         return removed;
@@ -565,26 +567,26 @@ public static partial class DamageAPI
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
-        return CompressedFlagArrayUtilities.Has(damageTypes, (int)moddedDamageType);
+        return CompressedFlagArrayUtilities.Has(damageTypes, (int)moddedDamageType - 1);
     }
 
     private static bool HasModdedDamageTypeInternal(ref DamageTypeCombo damageType, ModdedDamageType moddedDamageType)
     {
         SetHooks();
 
-        if ((int)moddedDamageType >= ModdedDamageTypeCount || (int)moddedDamageType < 0)
+        if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (0-{ModdedDamageTypeCount - 1})");
+            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);
-        return CompressedFlagArrayUtilities.Has(damageTypes, (int)moddedDamageType);
+        return CompressedFlagArrayUtilities.Has(damageTypes, (int)moddedDamageType - 1);
     }
     #endregion
 
@@ -635,7 +637,7 @@ public static partial class DamageAPI
                 projectileDamage.damageType.AddModdedDamageType(moddedDamageType);
             }
 
-            CompressedFlagArrayUtilities.AddImmutable(ref values, (int)moddedDamageType);
+            CompressedFlagArrayUtilities.AddImmutable(ref values, (int)moddedDamageType - 1);
         }
 
         /// <summary>
@@ -658,7 +660,7 @@ public static partial class DamageAPI
                 return projectileDamage.damageType.RemoveModdedDamageType(moddedDamageType);
             }
 
-            return CompressedFlagArrayUtilities.RemoveImmutable(ref values, (int)moddedDamageType);
+            return CompressedFlagArrayUtilities.RemoveImmutable(ref values, (int)moddedDamageType - 1);
         }
 
         /// <summary>
@@ -681,7 +683,7 @@ public static partial class DamageAPI
                 return projectileDamage.damageType.HasModdedDamageType(moddedDamageType);
             }
 
-            return CompressedFlagArrayUtilities.Has(values, (int)moddedDamageType);
+            return CompressedFlagArrayUtilities.Has(values, (int)moddedDamageType - 1);
         }
 
         #region CopyTo

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -23,6 +23,9 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 
 ## Changelog
 
+### '1.1.6'
+* Changed bounds check and minimum damage type value to make it easier to notice when using unregistered damage type.
+
 ### '1.1.5'
 * Fixed an issue where `FireProjectileInfo.damageTypeOverride` wasn't applied to a projectile if it only had ModdedDamageType set.
 

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.1.5"
+versionNumber = "1.1.6"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Before first registered damage type had value 0, which meant that if someone forgot to register a damage type it will cause unexpected behaviour that is hard to pin point. Now the first damage type has value 1 and bounds checks adjusted, so there will be exceptions with a stack trace in the logs.