### PR TITLE
[DamageAPI] Changed bounds exception to just log error to not completely break mods that already try to use not registered damage types.

### DIFF
--- a/R2API.DamageType/DamageAPI.cs
+++ b/R2API.DamageType/DamageAPI.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour.HookGen;
@@ -346,7 +347,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return;
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
@@ -360,7 +362,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return;
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);
@@ -444,7 +447,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return false;
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
@@ -460,7 +464,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return false;
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);
@@ -569,7 +574,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return false;
         }
 
         var damageTypes = CrocoDamageTypeControllerInterop.GetModdedDamageTypes(croco);
@@ -582,7 +588,8 @@ public static partial class DamageAPI
 
         if ((int)moddedDamageType > ModdedDamageTypeCount || (int)moddedDamageType < 1)
         {
-            throw new ArgumentOutOfRangeException($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})");
+            DamageTypePlugin.Logger.LogError($"Parameter '{nameof(moddedDamageType)}' with value {moddedDamageType} is out of range of registered types (1-{ModdedDamageTypeCount})\n{new StackTrace(true)}");
+            return false;
         }
 
         var damageTypes = DamageTypeComboInterop.GetModdedDamageTypes(damageType);

--- a/R2API.DamageType/README.md
+++ b/R2API.DamageType/README.md
@@ -23,6 +23,9 @@ This is done via the DamageAPI class, which is used for reserving DamageTypes an
 
 ## Changelog
 
+### '1.1.7'
+* Changed bounds exception to just log error to not completely break mods that already try to use not registered damage types.
+
 ### '1.1.6'
 * Changed bounds check and minimum damage type value to make it easier to notice when using unregistered damage type.
 

--- a/R2API.DamageType/thunderstore.toml
+++ b/R2API.DamageType/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_DamageType"
-versionNumber = "1.1.6"
+versionNumber = "1.1.7"
 description = "API for registering damage types"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Surprise, surprise, even mods like StarStorm forget to register damage types. I would still prefer the exception but completely breaking existing mods is not good.