### PR TITLE
[AnimationsAPI] fix auto build

### DIFF
--- a/R2API.Animations/R2API.Animations.csproj
+++ b/R2API.Animations/R2API.Animations.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\R2API.Animations.Runtime\R2API.Animations.Runtime.csproj" />
     <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+    <ProjectReference Include="..\R2API.Animations.Editor\R2API.Animations.Editor.csproj" Private="false" PrivateAssets="all" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <None Update="animator_api_dummy_bundle">


### PR DESCRIPTION
Forgot that for pipeline to build not referenced project you need to add project reference but without referencing assembly