### PR TITLE
CostAPI

### DIFF
--- a/R2API.CostType/CostAPI.cs
+++ b/R2API.CostType/CostAPI.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using EntityStates.FalseSonBoss;
+using MonoMod.Cil;
+using Mono.Cecil.Cil;
+using R2API.AutoVersionGen;
+using RoR2;
+
+namespace R2API;
+
+///<summary>
+/// API for registering custom CostTypeDefs
+///</summary>
+[AutoVersion]
+public static partial class CostAPI {
+    public const string PluginGUID = R2API.PluginGUID + ".costtype";
+    public const string PluginName = R2API.PluginName + ".CostType";
+    private static bool catalogAvailable = false;
+    private static List<CostTypeHolder> pendingHolders = new();
+    private static bool _hooksEnabled = false;
+
+    internal static void SetHooks() {
+        if (_hooksEnabled) return;
+        _hooksEnabled = true;
+        IL.RoR2.CostTypeCatalog.Init += Init;
+    }
+
+    internal static void UnsetHooks() {
+        _hooksEnabled = false;
+        IL.RoR2.CostTypeCatalog.Init -= Init;
+    }
+
+    // we do this to process as early as we can
+    private static void Init(ILContext il)
+    {
+        ILCursor c = new(il);
+        
+        while (c.TryGotoNext(MoveType.After, x => x.MatchRet())) {
+            // progress to the ending return
+        }
+
+        c.Index--;
+        c.Emit(OpCodes.Call, typeof(CostAPI).GetMethod(nameof(ProcessHolders), BindingFlags.Static | BindingFlags.NonPublic));
+    }
+
+    private static void ProcessHolders()
+    {
+        catalogAvailable = true;
+
+        foreach (CostTypeHolder holder in pendingHolders) {
+            CostTypeIndex index = RegisterCostType(holder.CostTypeDef);
+            holder._costTypeIndex = index;
+            holder.OnReserved(index);
+        }
+
+        pendingHolders.Clear();
+    }
+
+    /// <summary>
+    /// Registers a CostTypeDef to the catalog. CostTypeCatalog must be initialized when calling this.
+    /// </summary>
+    /// <param name="costTypeDef">The CostTypeDef to register.</param>
+    /// <returns>The CostTypeIndex corresponding to your CostTypeDef, or -1 upon failure.</returns>
+    public static CostTypeIndex RegisterCostType(CostTypeDef costTypeDef) {
+        SetHooks();
+
+        if (!catalogAvailable) {
+            CostTypePlugin.Logger.LogError("Attempted to register CostTypeIndex before the CostTypeCatalog has initialized!");
+            return (CostTypeIndex)(-1f);
+        }
+
+        CostTypeIndex index = (CostTypeIndex)CostTypeCatalog.costTypeDefs.Length;
+        Array.Resize(ref CostTypeCatalog.costTypeDefs, (int)index + 1);
+        CostTypeCatalog.Register(index, costTypeDef);
+
+        return index;
+    }
+    
+    /// <summary>
+    /// Reserves a CostTypeIndex if the catalog has not yet been initialized.
+    /// </summary>
+    /// <param name="costTypeDef">The CostTypeDef to register.</param>
+    /// <param name="onRegistered">A callback to run once the CostTypeCatalog initializes.</param>
+    /// <returns>A CostTypeHolder, which will be registered once the CostTypeCatalog has initialized.</returns>
+    public static CostTypeHolder ReserveCostType(CostTypeDef costTypeDef, Action<CostTypeIndex> onRegistered) {
+        SetHooks();
+
+        CostTypeHolder holder = new() {
+            OnReserved = onRegistered,
+            CostTypeDef = costTypeDef
+        };
+
+        if (catalogAvailable) {
+            CostTypeIndex index = RegisterCostType(costTypeDef);
+            holder._costTypeIndex = index;
+            holder.OnReserved(index);
+            return holder;
+        }
+
+        pendingHolders.Add(holder);
+        return holder;
+    }
+}

--- a/R2API.CostType/CostTypeHolder.cs
+++ b/R2API.CostType/CostTypeHolder.cs
@@ -1,0 +1,35 @@
+using System;
+using RoR2;
+
+namespace R2API;
+
+/// <summary>
+/// A holder for reserving a CostTypeIndex before the catalog has initialized.
+/// </summary>
+public class CostTypeHolder {
+    /// <summary>A callback that will be ran once the CostTypeDef gets registered.</summary>
+    public Action<CostTypeIndex> OnReserved;
+    /// <summary>The CostTypeDef that will be registered</summary>
+    public CostTypeDef CostTypeDef;
+    /// <summary>The reserved CostTypeIndex. This will be -1 if it has not yet been reserved.</summary>
+    public CostTypeIndex CostTypeIndex { 
+        get {
+            if (!Available) {
+                CostTypePlugin.Logger.LogError("Attempted to access to CostTypeIndex of a CostTypeHolder that was reserved before catalog initialization!");
+            }
+
+            return _costTypeIndex;
+        }
+    }
+    /// <summary>Whether or not this CostTypeHolder has registered its CostTypeDef yet.</summary>
+    public bool Available => _costTypeIndex != (CostTypeIndex)(-1);
+    internal CostTypeIndex _costTypeIndex = (CostTypeIndex)(-1);
+
+    /// <summary>
+    /// Get the CostTypeIndex stored in this CostTypeHolder
+    /// </summary>
+    /// <returns>The CostTypeIndex, or -1 if CostTypeHolder.Available is false</returns>
+    public static implicit operator CostTypeIndex(CostTypeHolder self) {
+        return self.CostTypeIndex;
+    }
+}

--- a/R2API.CostType/CostTypePlugin.cs
+++ b/R2API.CostType/CostTypePlugin.cs
@@ -1,0 +1,19 @@
+using BepInEx;
+using BepInEx.Logging;
+
+namespace R2API;
+
+[BepInPlugin(CostAPI.PluginGUID, CostAPI.PluginName, CostAPI.PluginVersion)]
+public sealed class CostTypePlugin : BaseUnityPlugin {
+    internal static new ManualLogSource Logger { get; set; }
+
+    private void Awake() {
+        Logger = base.Logger;
+
+        CostAPI.SetHooks();
+    }
+
+    private void OnDestroy() {
+        CostAPI.UnsetHooks();
+    }
+}

--- a/R2API.CostType/R2API.CostType.csproj
+++ b/R2API.CostType/R2API.CostType.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../R2API.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+  </ItemGroup>
+</Project>

--- a/R2API.CostType/README.md
+++ b/R2API.CostType/README.md
@@ -1,0 +1,20 @@
+# R2API.CostType - Custom Cost Type Handling
+
+## About
+
+R2API.CostType is a submodule assembly for R2API that simplifies the process of adding custom CostTypeDefs to avoid mod conflicts.
+
+## Use Cases / Features
+
+R2API.CostType provides two handlers for registering custom CostTypeDefs, both located in the CostAPI class.
+
+`ReserveCostType` can be used to reserve a CostTypeIndex before the catalog has initialized, via a `CostTypeHolder` which can store a callback to run on reservation.
+
+`RegisterCostType` will register a CostTypeDef immediately. This method may only be used after the catalog has initialized.
+
+## Related Pages
+
+## Changelog
+
+### '1.0.0'
+* Released.

--- a/R2API.CostType/thunderstore.toml
+++ b/R2API.CostType/thunderstore.toml
@@ -1,0 +1,34 @@
+
+[config]
+schemaVersion = "0.0.1"
+
+[package]
+namespace = "RiskofThunder"
+name = "R2API_CostType"
+versionNumber = "1.0.0"
+description = "API for creating custom cost types."
+websiteUrl = "https://github.com/risk-of-thunder/R2API"
+containsNsfwContent = false
+
+[package.dependencies]
+bbepis-BepInExPack = "5.4.2109"
+RiskofThunder-HookGenPatcher = "1.2.3"
+RiskofThunder-R2API_Core = "1.0.0"
+
+[build]
+icon = "../icon.png"
+readme = "./README.md"
+outdir = "./build"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.CostType.dll"
+target = "./plugins/R2API.CostType/R2API.CostType.dll"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.CostType.xml"
+target = "./plugins/R2API.CostType/R2API.CostType.xml"
+
+[publish]
+repository = "https://thunderstore.io"
+communities = ["riskofrain2"]
+categories = ["libraries"]

--- a/R2API.Test/R2API.Test.csproj
+++ b/R2API.Test/R2API.Test.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="../R2API.Elites/R2API.Elites.csproj" />
     <ProjectReference Include="../R2API.SceneAsset/R2API.SceneAsset.csproj" />
     <ProjectReference Include="../R2API.Deployable/R2API.Deployable.csproj" />
-
+    <ProjectReference Include="../R2API.CostType/R2API.CostType.csproj" />
   </ItemGroup>
 
 </Project>

--- a/R2API.Test/R2APITest.cs
+++ b/R2API.Test/R2APITest.cs
@@ -12,6 +12,7 @@ namespace R2API.Test;
 [BepInDependency(DirectorAPI.PluginGUID)]
 [BepInDependency(EliteAPI.PluginGUID)]
 [BepInDependency(SceneAssetAPI.PluginGUID)]
+[BepInDependency(CostAPI.PluginGUID)]
 [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
 public class R2APITest : BaseUnityPlugin
 {

--- a/R2API.Test/Tests/AwakeTests/CostAPITests.cs
+++ b/R2API.Test/Tests/AwakeTests/CostAPITests.cs
@@ -1,0 +1,70 @@
+using System;
+using R2API;
+using R2API.TestingLibrary;
+using RoR2;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace R2API.Test;
+
+public class CostAPITests {
+    // tests reservation and registration
+    [Fact]
+    public static void Test() {
+        // reserve a cost type
+        AegisCostType = CostAPI.ReserveCostType(new CostTypeDef() {
+            buildCostString = delegate (CostTypeDef def, CostTypeDef.BuildCostStringContext context) {
+                context.stringBuilder.Append($"{context.cost} {(context.cost > 1 ? "Aegises" : "Aegis")}");
+            },
+
+            isAffordable = delegate (CostTypeDef def, CostTypeDef.IsAffordableContext context) {
+                if (!context.activator || !context.activator.TryGetComponent<CharacterBody>(out CharacterBody body)) {
+                    return false;
+                }
+
+                return body.master && body.master.inventory.GetItemCount(RoR2Content.Items.BarrierOnOverHeal) >= context.cost;
+            },
+            payCost = delegate (CostTypeDef def, CostTypeDef.PayCostContext context) {
+                Inventory inv = context.activatorMaster.inventory;
+                inv.RemoveItem(RoR2Content.Items.BarrierOnOverHeal, context.cost);
+                context.results.itemsTaken.Add(RoR2Content.Items.BarrierOnOverHeal.itemIndex);
+            },
+            colorIndex = ColorCatalog.ColorIndex.Tier3Item
+        }, (index) => { // use our new costtypeindex to change small chests to cost 25 aegises
+            Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Chest1/Chest1.prefab").WaitForCompletion().GetComponent<PurchaseInteraction>().costType = index;
+        });
+    }
+
+    [SystemInitializer(typeof(CostTypeCatalog))]
+    public static void OnInit() {
+        // register a cost type after catalog init
+        YourSoulIndex = CostAPI.RegisterCostType( new() {
+            buildCostString = delegate (CostTypeDef def, CostTypeDef.BuildCostStringContext context) {
+                context.stringBuilder.Append($"Your life.");
+            },
+
+            isAffordable = delegate (CostTypeDef def, CostTypeDef.IsAffordableContext context) {
+                if (!context.activator || !context.activator.TryGetComponent<CharacterBody>(out CharacterBody body)) {
+                    return false;
+                }
+
+                return true;
+            },
+            payCost = delegate (CostTypeDef def, CostTypeDef.PayCostContext context) {
+                context.activatorBody.healthComponent.Suicide();
+            },
+            colorIndex = ColorCatalog.ColorIndex.Blood
+        });
+
+        Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Chest2/Chest2.prefab").WaitForCompletion().GetComponent<PurchaseInteraction>().costType = YourSoulIndex;
+
+        Assert.True(YourSoulIndex != (CostTypeIndex)(-1));
+        Debug.Log("asserting available");
+        Assert.True(AegisCostType.Available);
+        Debug.Log("asserting ageis cost type");
+        Assert.True(AegisCostType.CostTypeIndex != (CostTypeIndex)(-1));
+    }
+
+    public static CostTypeHolder AegisCostType;
+    public static CostTypeIndex YourSoulIndex;
+}


### PR DESCRIPTION
Adds CostAPI submodule to make it easier for mods to register custom CostTypeDefs and avoid conflicts. Provides methods for both immediate registration and pre-init reservation.