### PR TITLE
Fixed custom monsters and interactables being added to stage pool multiple times as a result of SoTS Phase 2 changes

### DIFF
--- a/R2API.Director/DirectorAPIhelpers.cs
+++ b/R2API.Director/DirectorAPIhelpers.cs
@@ -407,7 +407,7 @@ public static partial class DirectorAPI
                     var isAFamilyCategoryAndShouldAddToIt = addToFamilies && isAFamilyCategory;
                     if (isNotAFamilyCategory || isAFamilyCategoryAndShouldAddToIt)
                     {
-                        ForEachPoolEntryInDccsPoolCategory(poolCategory, (poolEntry) =>
+                        ForEachElementInPoolEntryArray(SelectPoolEntryArrayGearboxStyle(poolCategory), (poolEntry) =>
                         {
                             AddMonsterToPoolEntry(monsterCardHolder, poolEntry, predicate);
                         });
@@ -428,6 +428,24 @@ public static partial class DirectorAPI
             }
 
             return true;
+        }
+
+        private static DccsPool.PoolEntry[] SelectPoolEntryArrayGearboxStyle(DccsPool.Category poolCategory)
+        {
+            // With SoTS Phase 2 update (1.3.7) DCCSBlender has been added, so we want to add cards primarily to alwaysIncluded to avoid card duplication.
+            // If alwaysIncluded doesn't have any pool entries then we add cards to includedIfNoConditionsMet, since some Simulacrum DccsPools are like that.
+            // And if includedIfNoConditionsMet doesn't have any pool entries then this is most likely a modded stage made before 1.3.7
+            // and we just add to includedIfConditionsMet for backwards compatibility.
+            if (poolCategory.alwaysIncluded.Length > 0)
+            {
+                return poolCategory.alwaysIncluded;
+            } else if(poolCategory.includedIfNoConditionsMet.Length > 0)
+            {
+                return poolCategory.includedIfNoConditionsMet;
+            } else
+            {
+                return poolCategory.includedIfConditionsMet;
+            }
         }
 
         private static void AddMonsterToPoolEntry(DirectorCardHolder monsterCardHolder, DccsPool.PoolEntry poolEntry, Predicate<DirectorCardCategorySelection> predicate)
@@ -659,9 +677,12 @@ public static partial class DirectorAPI
         {
             if (interactablesDccsPool)
             {
-                ForEachPoolEntryInDccsPool(interactablesDccsPool, (poolEntry) =>
+                ForEachPoolCategoryInDccsPool(interactablesDccsPool, (poolCategory) =>
                 {
-                    AddInteractableToPoolEntry(interactableCardHolder, poolEntry, predicate);
+                    ForEachElementInPoolEntryArray(SelectPoolEntryArrayGearboxStyle(poolCategory), (poolEntry) =>
+                    {
+                        AddInteractableToPoolEntry(interactableCardHolder, poolEntry, predicate);
+                    });
                 });
             }
         }
@@ -1061,30 +1082,23 @@ public static partial class DirectorAPI
         {
             DirectorAPI.SetHooks();
 
-            void CallAction(DccsPool.PoolEntry[] poolEntries)
-            {
-                foreach (var poolEntry in poolEntries)
-                {
-                    try
-                    {
-                        action(poolEntry);
-                    }
-                    catch (Exception e)
-                    {
-                        DirectorPlugin.Logger.LogError(e);
-                    }
-                }
-            }
+            ForEachElementInPoolEntryArray(dccsPoolCategory.alwaysIncluded, action);
+            ForEachElementInPoolEntryArray(dccsPoolCategory.includedIfNoConditionsMet, action);
+            ForEachElementInPoolEntryArray(dccsPoolCategory.includedIfConditionsMet, action);
+        }
 
-            if (dccsPoolCategory.alwaysIncluded.Length > 0)
+        private static void ForEachElementInPoolEntryArray(DccsPool.PoolEntry[] poolEntries, Action<DccsPool.PoolEntry> action)
+        {
+            foreach (var poolEntry in poolEntries)
             {
-                CallAction(dccsPoolCategory.alwaysIncluded);
-            } else if(dccsPoolCategory.includedIfNoConditionsMet.Length > 0)
-            {
-                CallAction(dccsPoolCategory.includedIfNoConditionsMet);
-            } else
-            {
-                CallAction(dccsPoolCategory.includedIfConditionsMet);
+                try
+                {
+                    action(poolEntry);
+                }
+                catch (Exception e)
+                {
+                    DirectorPlugin.Logger.LogError(e);
+                }
             }
         }
 

--- a/R2API.Director/DirectorAPIhelpers.cs
+++ b/R2API.Director/DirectorAPIhelpers.cs
@@ -1076,9 +1076,13 @@ public static partial class DirectorAPI
                 }
             }
 
-            CallAction(dccsPoolCategory.alwaysIncluded);
-            CallAction(dccsPoolCategory.includedIfConditionsMet);
-            CallAction(dccsPoolCategory.includedIfNoConditionsMet);
+            if (dccsPoolCategory.alwaysIncluded.Length > 0)
+            {
+                CallAction(dccsPoolCategory.alwaysIncluded);
+            } else
+            {
+                CallAction(dccsPoolCategory.includedIfNoConditionsMet);
+            }
         }
 
         /// <summary>

--- a/R2API.Director/DirectorAPIhelpers.cs
+++ b/R2API.Director/DirectorAPIhelpers.cs
@@ -1079,9 +1079,12 @@ public static partial class DirectorAPI
             if (dccsPoolCategory.alwaysIncluded.Length > 0)
             {
                 CallAction(dccsPoolCategory.alwaysIncluded);
-            } else
+            } else if(dccsPoolCategory.includedIfNoConditionsMet.Length > 0)
             {
                 CallAction(dccsPoolCategory.includedIfNoConditionsMet);
+            } else
+            {
+                CallAction(dccsPoolCategory.includedIfConditionsMet);
             }
         }
 

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,10 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.3.3'
+
+* Fixed custom monsters and interactables being added to stage pool multiple times as a result of SoTS Phase 2 changes.
+
 ### '2.3.2'
 
 * Fixed `RemoveExistingMonsterFromStage`, which by default removed the given monster from family DCCSs, potentially affecting other scenes unintentionally since those are shared between stages.

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.2"
+versionNumber = "2.3.3"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
With `DccsBlender` in play, adding monsters and interactables to every `DirectorCardCategorySelection` would result in cards being added to the spawn pools up to 3 times (since by default the system mixes `Always Included` DCCS plus two from `Included If Conditions Met`). Ideally we should only add new cards to DCCS under `Always Included`, however Gearbox break their own rule and some Simulacrum stages only have `Included if No Conditions Met` DCCS.