### PR TITLE
[Animations] NuGet fix

### DIFF
--- a/R2API.Animations/R2API.Animations.csproj
+++ b/R2API.Animations/R2API.Animations.csproj
@@ -1,14 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferenceDlls</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AssetsTools.NET" Version="3.0.0" GeneratePathProperty="true" />
     <None Include="$(PkgAssetsTools_NET)\lib\netstandard2.0\AssetsTools.NET.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\R2API.Animations.Runtime\R2API.Animations.Runtime.csproj" />
+    <ProjectReference Include="..\R2API.Animations.Runtime\R2API.Animations.Runtime.csproj" Private="true" PrivateAssets="all"/>
     <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
     <ProjectReference Include="..\R2API.Animations.Editor\R2API.Animations.Editor.csproj" Private="false" PrivateAssets="all" ReferenceOutputAssembly="false" />
   </ItemGroup>
+  <Target Name="IncludeProjectReferenceDlls" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage
+        Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all'))"
+        TargetPath="%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <None Update="animator_api_dummy_bundle">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/R2API.Animations/README.md
+++ b/R2API.Animations/README.md
@@ -14,6 +14,8 @@ and `Modified Controller` which should have all things that `Source Controller` 
 After that you add the `AnimatorDiff` to an `AssetBundle` and in code you can create an instance of `AnimatorModifications` with `AnimatorModifications.CreateFromDiff()`.
 
 ## Changelog
+### '1.1.1'
+* Fix NuGet package
 
 ### '1.1.0'
 * Added support for `BlendTree`s.

--- a/R2API.Animations/thunderstore.toml
+++ b/R2API.Animations/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Animations"
-versionNumber = "1.1.0"
+versionNumber = "1.1.1"
 description = "API for modifying RuntimeAnimatorController"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Turns out nuget package was broken.
Fixed main package trying to reference non-existing Animations.Runtime package.
Now Animations.Runtime.dll is also included in the main package, had to use some obscure solution from https://github.com/NuGet/Home/issues/3891#issuecomment-2533063892 for that