### PR TITLE
Added MixEnemiesDccsActions action that would allow interaction with MixEnemy artifact DCCS replacement.

### DIFF
--- a/R2API.Director/DirectorAPIexternal.cs
+++ b/R2API.Director/DirectorAPIexternal.cs
@@ -91,6 +91,19 @@ public static partial class DirectorAPI
 
     /// <summary>
     /// <para>
+    /// Event used to interact with DCCS of MixEnemy artifact (Artifact of Dissonance).
+    /// </para>
+    ///
+    /// <para>
+    /// First parameter is the <see cref="RoR2.DirectorCardCategorySelection"/>,
+    /// it is used by DirectorAPI to replace default <see cref="RoR2.DirectorCardCategorySelection"/> of MixEnemy artifact.
+    /// </para>
+    ///
+    /// </summary>
+    public static event Action<DirectorCardCategorySelection>? MixEnemiesDccsActions;
+
+    /// <summary>
+    /// <para>
     /// Event used to edit the pool of interactables that can spawn in a given stage.
     /// </para>
     ///

--- a/R2API.Director/DirectorAPIinternal.cs
+++ b/R2API.Director/DirectorAPIinternal.cs
@@ -267,6 +267,21 @@ public static partial class DirectorAPI
         }
 
         ApplyNewCardHoldersToDCCS(_dccsMixEnemyArtifact, cardHoldersMixEnemyArtifact);
+
+        if(MixEnemiesDccsActions != null)
+        {
+            foreach(Action<DirectorCardCategorySelection> item in MixEnemiesDccsActions.GetInvocationList())
+            {
+                try
+                {
+                    item(_dccsMixEnemyArtifact);
+                }
+                catch (Exception e)
+                {
+                    DirectorPlugin.Logger.LogError(e);
+                }
+            }
+        }
     }
 
     // Somehow the changes persist across stages sometimes, so... copy the originals,

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,9 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.3.5'
+* Added MixEnemiesDccsActions action that would allow interaction with MixEnemy artifact DCCS replacement.
+
 ### '2.3.4'
 
 * Fixes.

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.4"
+versionNumber = "2.3.5"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Implementation is basically the same as iDeath suggestion in modcord.