### PR TITLE
R2API.Elites Refactor

### DIFF
--- a/R2API.Elites.Interop/ElitesInterop.cs
+++ b/R2API.Elites.Interop/ElitesInterop.cs
@@ -1,0 +1,13 @@
+using RoR2;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("R2API.Elites")]
+
+namespace R2API;
+
+internal static class ElitesInterop
+{
+    public static string GetEliteTierDefName(CombatDirector.EliteTierDef eliteTierDef) => eliteTierDef.r2api_name;
+
+    public static void SetEliteTierDefName(CombatDirector.EliteTierDef eliteTierDef, string value) => eliteTierDef.r2api_name = value;
+}

--- a/R2API.Elites.Interop/R2API.Elites.Interop.csproj
+++ b/R2API.Elites.Interop/R2API.Elites.Interop.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RoR2.Patched\RoR2.Patched.csproj" Private="false" PrivateAssets="all"/>
+  </ItemGroup>
+</Project>

--- a/R2API.Elites.Patcher/ElitesPatcher.cs
+++ b/R2API.Elites.Patcher/ElitesPatcher.cs
@@ -1,0 +1,23 @@
+using Mono.Cecil;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace R2API;
+
+internal static class ElitesPatcher
+{
+    public static IEnumerable<string> TargetDLLs
+    {
+        get
+        {
+            yield return "RoR2.dll";
+        }
+    }
+
+    public static void Patch(AssemblyDefinition assembly)
+    {
+        var combatDirector = assembly.MainModule.GetType("RoR2", "CombatDirector");
+        var eliteTierDef = combatDirector?.NestedTypes.FirstOrDefault(t => t.Name is "EliteTierDef");
+        eliteTierDef?.Fields.Add(new FieldDefinition("r2api_name", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(string))));
+    }
+}

--- a/R2API.Elites.Patcher/R2API.Elites.Patcher.csproj
+++ b/R2API.Elites.Patcher/R2API.Elites.Patcher.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="5.4.19" />
+  </ItemGroup>
+</Project>

--- a/R2API.Elites/ElitesPlugin.cs
+++ b/R2API.Elites/ElitesPlugin.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BepInEx;
 using BepInEx.Logging;
 using R2API.ContentManagement;
@@ -13,9 +14,14 @@ public sealed class ElitesPlugin : BaseUnityPlugin
     private void Awake()
     {
         Logger = base.Logger;
+        Stopwatch s = new Stopwatch();
+        s.Start();
 
         EliteAPI.SetHooks();
         EliteRamp.SetHooks();
+
+        s.Stop();
+        Logger.LogDebug("startup done in: " + s.Elapsed.TotalMilliseconds + "ms");
     }
 
     private void OnDestroy()

--- a/R2API.Elites/R2API.Elites.csproj
+++ b/R2API.Elites/R2API.Elites.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
-    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
-    <ProjectReference Include="../R2API.ContentManagement/R2API.ContentManagement.csproj" Private="false"/>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+    <ProjectReference Include="../R2API.ContentManagement/R2API.ContentManagement.csproj" Private="false" />
+    <ProjectReference Include="..\R2API.Elites.Interop\R2API.Elites.Interop.csproj" />
+    <ProjectReference Include="..\R2API.Elites.Patcher\R2API.Elites.Patcher.csproj" />
   </ItemGroup>
 </Project>

--- a/R2API.sln
+++ b/R2API.sln
@@ -117,6 +117,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Animations.Runtime", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2API.Animations.Editor", "R2API.Animations.Editor\R2API.Animations.Editor.csproj", "{E1F37C64-C9E2-407A-805F-032867800006}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Elites.Interop", "R2API.Elites.Interop\R2API.Elites.Interop.csproj", "{52B454DD-48BC-4F9F-B80B-5EED720BC74B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Elites.Patcher", "R2API.Elites.Patcher\R2API.Elites.Patcher.csproj", "{40564BAE-E74C-4464-9D3B-BDE73003A11D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -307,6 +311,14 @@ Global
 		{E1F37C64-C9E2-407A-805F-032867800006}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1F37C64-C9E2-407A-805F-032867800006}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1F37C64-C9E2-407A-805F-032867800006}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52B454DD-48BC-4F9F-B80B-5EED720BC74B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52B454DD-48BC-4F9F-B80B-5EED720BC74B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52B454DD-48BC-4F9F-B80B-5EED720BC74B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52B454DD-48BC-4F9F-B80B-5EED720BC74B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40564BAE-E74C-4464-9D3B-BDE73003A11D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40564BAE-E74C-4464-9D3B-BDE73003A11D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40564BAE-E74C-4464-9D3B-BDE73003A11D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40564BAE-E74C-4464-9D3B-BDE73003A11D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RoR2.Patched/EliteTierDef.cs
+++ b/RoR2.Patched/EliteTierDef.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RoR2;
+
+public class CombatDirector
+{
+    public class EliteTierDef
+    {
+        public string r2api_name;
+    }
+}


### PR DESCRIPTION
pretty large refactor internally, but this is not intended to be a breaking change for any public members

![{EC58B513-C8E8-465A-B734-3E53E558B496}](https://github.com/user-attachments/assets/43e5ca56-ea31-4e7b-9432-15118701ec03)

- Swapped the CombatDirector.Init replacement with targeted Addressable loading in IL so that the CombatDirector can initialize itself again.
  - CombatDirector.Init() is called when EliteAPI hooks are applied.
  - with the next dlc on the horizon, this will hopefully allow ElitesAPI to not break the CombatDirector.Init on update day.

![{35FD979F-C74F-4BB8-A691-EE7E254E4D92}](https://github.com/user-attachments/assets/b800d7c2-07e4-49f6-a83d-effb07b7b61b)

- Added static fields for all of the current EliteTierDefs
- Added Elites.Interop and Elites.Patcher for EliteTierDef.r2api_name support
  - These should allow for modders to find the tiers they want without doing the wack shit that normally goes on

![{CF21A21E-68B5-42BF-9754-321A616BA7C9}](https://github.com/user-attachments/assets/a127497d-9549-44bf-a034-b95e36568b01)


TODO: 
- XML 
- make the tier defs less hard coded in the event of another elite tier getting added. ideally they should be able to add a tier without impacting the existing vanilla reference fields