### PR TITLE
R2APi.CharacterBody and R2APi.Skills update. R2API.RecalculateStats tweak.

### DIFF
--- a/R2API.CharacterBody.Interop/CharacterBodyInterop.cs
+++ b/R2API.CharacterBody.Interop/CharacterBodyInterop.cs
@@ -1,4 +1,5 @@
 ﻿using RoR2;
+using System;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("R2API.CharacterBody")]
@@ -9,4 +10,161 @@ internal static class CharacterBodyInterop
 {
     public static byte[] GetModdedBodyFlags(CharacterBody characterBody) => characterBody.r2api_moddedBodyFlags;
     public static void SetModdedBodyFlags(CharacterBody characterBody, byte[] value) => characterBody.r2api_moddedBodyFlags = value;
+    public static float GetDamageSourceDamageMultiplier(CharacterBody characterBody, string value)
+    {
+        if (characterBody.r2api_damageSourceDamageMultiplier == null) characterBody.r2api_damageSourceDamageMultiplier = new System.Collections.Generic.Dictionary<string, float>();
+        float output = 1f;
+        if (value == "SkillMask")
+        {
+            output += GetDamageSourceDamageMultiplier(characterBody, "Primary") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Secondary") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Utility") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Special") - 1f;
+            return output;
+        }
+        if (characterBody.r2api_damageSourceDamageMultiplier.ContainsKey(value))
+        {
+            output = characterBody.r2api_damageSourceDamageMultiplier[value];
+        }
+        if (value == "Primary" || value == "Secondary" || value == "Utility" || value == "Special")
+        {
+            output += GetDamageSourceDamageMultiplier(characterBody, "SkillMaskOverride") - 1f;
+        }
+        return output;
+    }
+    public static void SetDamageSourceDamageMultiplier(CharacterBody characterBody, string value, float value2)
+    {
+        if (characterBody.r2api_damageSourceDamageMultiplier == null) characterBody.r2api_damageSourceDamageMultiplier = new System.Collections.Generic.Dictionary<string, float>();
+        if (value == "SkillMask")
+        {
+            SetDamageSourceDamageMultiplier(characterBody, "SkillMaskOverride", value2);
+            return;
+        }
+        if (characterBody.r2api_damageSourceDamageMultiplier.ContainsKey(value))
+        {
+            characterBody.r2api_damageSourceDamageMultiplier[value] = value2;
+        }
+        else
+        {
+            characterBody.r2api_damageSourceDamageMultiplier.Add(value, value2);
+        }
+    }
+    public static float GetDamageSourceDamageAddition(CharacterBody characterBody, string value)
+    {
+        if (characterBody.r2api_damageSourceDamageAddition == null) characterBody.r2api_damageSourceDamageAddition = new System.Collections.Generic.Dictionary<string, float>();
+        float output = 0f;
+        if (value == "SkillMask")
+        {
+            output += GetDamageSourceDamageMultiplier(characterBody, "Primary");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Secondary");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Utility");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Special");
+            return output;
+        }
+        if (characterBody.r2api_damageSourceDamageAddition.ContainsKey(value))
+        {
+            output = characterBody.r2api_damageSourceDamageAddition[value];
+        }
+        if (value == "Primary" || value == "Secondary" || value == "Utility" || value == "Special")
+        {
+            output += GetDamageSourceDamageAddition(characterBody, "SkillMaskOverride");
+        }
+        return output;
+    }
+    public static void SetDamageSourceDamageAddition(CharacterBody characterBody, string value, float value2)
+    {
+        if (characterBody.r2api_damageSourceDamageAddition == null) characterBody.r2api_damageSourceDamageAddition = new System.Collections.Generic.Dictionary<string, float>();
+        if (value == "SkillMask")
+        {
+            SetDamageSourceDamageAddition(characterBody, "SkillMaskOverride", value2);
+            return;
+        }
+        if (characterBody.r2api_damageSourceDamageAddition.ContainsKey(value))
+        {
+            characterBody.r2api_damageSourceDamageAddition[value] = value2;
+        }
+        else
+        {
+            characterBody.r2api_damageSourceDamageAddition.Add(value, value2);
+        }
+    }
+    public static float GetDamageSourceVulnerabilityMultiplier(CharacterBody characterBody, string value)
+    {
+        if (characterBody.r2api_damageSourceVulnerabilityMultiplier == null) characterBody.r2api_damageSourceVulnerabilityMultiplier = new System.Collections.Generic.Dictionary<string, float>();
+        float output = 1f;
+        if (value == "SkillMask")
+        {
+            output += GetDamageSourceDamageMultiplier(characterBody, "Primary") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Secondary") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Utility") - 1f;
+            output += GetDamageSourceDamageMultiplier(characterBody, "Special") - 1f;
+            return output;
+        }
+        if (characterBody.r2api_damageSourceVulnerabilityMultiplier.ContainsKey(value))
+        {
+            output = characterBody.r2api_damageSourceVulnerabilityMultiplier[value];
+        }
+        if (value == "Primary" || value == "Secondary" || value == "Utility" || value == "Special")
+        {
+            output += GetDamageSourceVulnerabilityMultiplier(characterBody, "SkillMaskOverride") - 1f;
+        }
+        return output;
+    }
+    public static void SetDamageSourceVulnerabilityMultiplier(CharacterBody characterBody, string value, float value2)
+    {
+        if (characterBody.r2api_damageSourceVulnerabilityMultiplier == null) characterBody.r2api_damageSourceVulnerabilityMultiplier = new System.Collections.Generic.Dictionary<string, float>();
+        if (value == "SkillMask")
+        {
+            SetDamageSourceDamageMultiplier(characterBody, "SkillMaskOverride", value2);
+            return;
+        }
+        if (characterBody.r2api_damageSourceVulnerabilityMultiplier.ContainsKey(value))
+        {
+            characterBody.r2api_damageSourceVulnerabilityMultiplier[value] = value2;
+        }
+        else
+        {   
+            characterBody.r2api_damageSourceVulnerabilityMultiplier.Add(value, value2);
+        }
+    }
+    public static float GetDamageSourceVulnerabilityAddition(CharacterBody characterBody, string value)
+    {
+        if (characterBody.r2api_damageSourceVulnerabilityAddition == null) characterBody.r2api_damageSourceVulnerabilityAddition = new System.Collections.Generic.Dictionary<string, float>();
+        float output = 0f;
+        if (value == "SkillMask")
+        {
+            output += GetDamageSourceDamageMultiplier(characterBody, "Primary");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Secondary");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Utility");
+            output += GetDamageSourceDamageMultiplier(characterBody, "Special");
+            return output;
+        }
+        if (characterBody.r2api_damageSourceVulnerabilityAddition.ContainsKey(value))
+        {
+            output = characterBody.r2api_damageSourceVulnerabilityAddition[value];
+        }
+        if (value == "Primary" || value == "Secondary" || value == "Utility" || value == "Special")
+        {
+            output += GetDamageSourceVulnerabilityAddition(characterBody, "SkillMaskOverride");
+        }
+        return output;
+    }
+    public static void SetDamageSourceVulnerabilityAddition(CharacterBody characterBody, string value, float value2)
+    {
+        if (characterBody.r2api_damageSourceVulnerabilityAddition == null) characterBody.r2api_damageSourceVulnerabilityAddition = new System.Collections.Generic.Dictionary<string, float>();
+        if (value == "SkillMask")
+        {
+            SetDamageSourceDamageAddition(characterBody, "SkillMaskOverride", value2);
+            return;
+        }
+        if (characterBody.r2api_damageSourceVulnerabilityAddition.ContainsKey(value))
+        {
+            characterBody.r2api_damageSourceVulnerabilityAddition[value] = value2;
+        }
+        else
+        {
+            characterBody.r2api_damageSourceVulnerabilityAddition.Add(value, value2);
+        }
+    }
 }
+

--- a/R2API.CharacterBody.Patcher/CharacterBodyPatcher.cs
+++ b/R2API.CharacterBody.Patcher/CharacterBodyPatcher.cs
@@ -22,6 +22,17 @@ internal static class CharacterBodyPatcher
     {
         var characterBody = assembly.MainModule.GetType("RoR2", "CharacterBody");
         var moddedBodyFlags = new FieldDefinition("r2api_moddedBodyFlags", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[])));
-        characterBody?.Fields.Add(moddedBodyFlags);
+        var damageSourceDamageMultiplier = new FieldDefinition("r2api_damageSourceDamageMultiplier", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Dictionary<string, float>)));
+        var damageSourceDamageAddition = new FieldDefinition("r2api_damageSourceDamageAddition", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Dictionary<string, float>)));
+        var damageSourceVulnerabilityMultiplier = new FieldDefinition("r2api_damageSourceVulnerabilityMultiplier", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Dictionary<string, float>)));
+        var damageSourceVulnerabilityAddition = new FieldDefinition("r2api_damageSourceVulnerabilityAddition", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Dictionary<string, float>)));
+        if (characterBody != null)
+        {
+            characterBody.Fields.Add(moddedBodyFlags);
+            characterBody.Fields.Add(damageSourceDamageMultiplier);
+            characterBody.Fields.Add(damageSourceDamageAddition);
+            characterBody.Fields.Add(damageSourceVulnerabilityMultiplier);
+            characterBody.Fields.Add(damageSourceVulnerabilityAddition);
+        }
     }
 }

--- a/R2API.CharacterBody/CharacterBodyAPI.cs
+++ b/R2API.CharacterBody/CharacterBodyAPI.cs
@@ -110,14 +110,14 @@ public static partial class CharacterBodyAPI
     /// <returns></returns>
     public static bool HasModdedBodyFlag(this CharacterBody characterBody, ModdedBodyFlag moddedBodyFlag) => HasModdedBodyFlagInternal(characterBody, moddedBodyFlag);
     /// <summary>
-    /// Get damage multiplier for the specified damage source.
+    /// Get damage multiplier for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
     /// <returns></returns>
     public static float GetDamageSourceDamageMultiplier(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceDamageMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
     /// <summary>
-    /// Set damage multiplier for the specified damage source.
+    /// Set damage multiplier for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
@@ -125,14 +125,14 @@ public static partial class CharacterBodyAPI
     /// <returns></returns>
     public static void SetDamageSourceDamageMultiplier(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceDamageMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
     /// <summary>
-    /// Get damage flat addition for the specified damage source.
+    /// Get damage flat addition for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
     /// <returns></returns>
     public static float GetDamageSourceDamageAddition(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceDamageAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
     /// <summary>
-    /// Set damage flat addition for the specified damage source.
+    /// Set damage flat addition for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
@@ -140,14 +140,14 @@ public static partial class CharacterBodyAPI
     /// <returns></returns>
     public static void SetDamageSourceDamageAddition(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceDamageAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
     /// <summary>
-    /// Get damage vulnerability multiplier for the specified damage source.
+    /// Get damage vulnerability multiplier for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
     /// <returns></returns>
     public static float GetDamageSourceVulnerabilityMultiplier(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceVulnerabilityMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
     /// <summary>
-    /// Set damage vulnerability multiplier for the specified damage source.
+    /// Set damage vulnerability multiplier for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
@@ -155,14 +155,14 @@ public static partial class CharacterBodyAPI
     /// <returns></returns>
     public static void SetDamageSourceVulnerabilityMultiplier(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceVulnerabilityMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
     /// <summary>
-    /// Get damage vulnerability flat addition for the specified damage source.
+    /// Get damage vulnerability flat addition for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>
     /// <returns></returns>
     public static float GetDamageSourceVulnerabilityAddition(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceVulnerabilityAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
     /// <summary>
-    /// Set damage vulnerability flat addition for the specified damage source.
+    /// Set damage vulnerability flat addition for the specified damage source. Value resets on Recalculate Stats
     /// </summary>
     /// <param name="characterBody"></param>
     /// <param name="damageSource"></param>

--- a/R2API.CharacterBody/CharacterBodyAPI.cs
+++ b/R2API.CharacterBody/CharacterBodyAPI.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using HarmonyLib;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 using MonoMod.Cil;
@@ -34,11 +35,15 @@ public static partial class CharacterBodyAPI
     {   
         if (_hooksEnabled) return;
         _hooksEnabled = true;
+        IL.RoR2.HealthComponent.TakeDamageProcess += HealthComponent_TakeDamageProcess;
+        IL.RoR2.CharacterBody.RecalculateStats += CharacterBody_RecalculateStats;
     }
     internal static void UnsetHooks()
     {
         if (!_hooksEnabled) return;
         _hooksEnabled = false;
+        IL.RoR2.HealthComponent.TakeDamageProcess -= HealthComponent_TakeDamageProcess;
+        IL.RoR2.CharacterBody.RecalculateStats -= CharacterBody_RecalculateStats;
     }
     public enum ModdedBodyFlag { };
     /// <summary>
@@ -97,7 +102,6 @@ public static partial class CharacterBodyAPI
         var bodtFlags = CharacterBodyInterop.GetModdedBodyFlags(characterBody);
         return bodtFlags is not null && bodtFlags.Length > 0;
     }
-
     /// <summary>
     /// Checks if CharacterBody instance has ModdedBodyFlag assigned. One CharacterBody can have more than one body flag.
     /// </summary>
@@ -105,6 +109,66 @@ public static partial class CharacterBodyAPI
     /// <param name="moddedBodyFlag"></param>
     /// <returns></returns>
     public static bool HasModdedBodyFlag(this CharacterBody characterBody, ModdedBodyFlag moddedBodyFlag) => HasModdedBodyFlagInternal(characterBody, moddedBodyFlag);
+    /// <summary>
+    /// Get damage multiplier for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <returns></returns>
+    public static float GetDamageSourceDamageMultiplier(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceDamageMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
+    /// <summary>
+    /// Set damage multiplier for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static void SetDamageSourceDamageMultiplier(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceDamageMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
+    /// <summary>
+    /// Get damage flat addition for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <returns></returns>
+    public static float GetDamageSourceDamageAddition(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceDamageAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
+    /// <summary>
+    /// Set damage flat addition for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static void SetDamageSourceDamageAddition(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceDamageAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
+    /// <summary>
+    /// Get damage vulnerability multiplier for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <returns></returns>
+    public static float GetDamageSourceVulnerabilityMultiplier(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceVulnerabilityMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
+    /// <summary>
+    /// Set damage vulnerability multiplier for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static void SetDamageSourceVulnerabilityMultiplier(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceVulnerabilityMultiplier(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
+    /// <summary>
+    /// Get damage vulnerability flat addition for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <returns></returns>
+    public static float GetDamageSourceVulnerabilityAddition(this CharacterBody characterBody, DamageSource damageSource) => CharacterBodyInterop.GetDamageSourceVulnerabilityAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource));
+    /// <summary>
+    /// Set damage vulnerability flat addition for the specified damage source.
+    /// </summary>
+    /// <param name="characterBody"></param>
+    /// <param name="damageSource"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static void SetDamageSourceVulnerabilityAddition(this CharacterBody characterBody, DamageSource damageSource, float value) => CharacterBodyInterop.SetDamageSourceVulnerabilityAddition(characterBody, Enum.GetName(typeof(DamageSource), damageSource), value);
     private static void AddModdedBodyFlagInternal(CharacterBody characterBody, ModdedBodyFlag moddedBodyFlag)
     {
         SetHooks();
@@ -143,5 +207,88 @@ public static partial class CharacterBodyAPI
             return false;
         }
         return true;
+    }
+    private static void CharacterBody_RecalculateStats(ILContext il)
+    {
+        var c = new ILCursor(il);
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(balls);
+        void balls(CharacterBody characterBody)
+        {
+            var values = Enum.GetValues(typeof(DamageSource)).Cast<DamageSource>();
+            foreach (var value in values)
+            {
+                characterBody.SetDamageSourceDamageAddition(value, 0f);
+                characterBody.SetDamageSourceDamageMultiplier(value, 1f);
+                characterBody.SetDamageSourceDamageAddition(value, 0f);
+                characterBody.SetDamageSourceDamageMultiplier(value, 1f);
+            }
+        }
+    }
+    private static void HealthComponent_TakeDamageProcess(ILContext il)
+    {
+        var c = new ILCursor(il);
+        FieldReference fieldReference = null;
+        FieldReference fieldReference2 = null;
+        if (
+            c.TryGotoNext(MoveType.Before,
+            x => x.MatchLdloca(0),
+            x => x.MatchLdloc(0),
+            x => x.MatchLdfld(out fieldReference),
+            x => x.MatchLdfld<DamageInfo>(nameof(DamageInfo.attacker)),
+            x => x.MatchCallvirt<GameObject>(nameof(GameObject.GetComponent)),
+            x => x.MatchStfld(out fieldReference2)
+            ))
+        {
+            c = new ILCursor(il);
+            ILLabel iLLabel = null;
+            int i = 7;
+            if (c.TryGotoNext(MoveType.After,
+            x => x.MatchLdarg(0),
+            x => x.MatchLdfld<HealthComponent>(nameof(HealthComponent.body)),
+            x => x.MatchLdsfld(typeof(RoR2Content.Buffs), nameof(RoR2Content.Buffs.DeathMark)),
+            x => x.MatchCallvirt<CharacterBody>(nameof(CharacterBody.HasBuff)),
+            x => x.MatchBrfalse(out iLLabel),
+            x => x.MatchLdloc(out i)
+            )
+            )
+            {
+                c.Index -= 2;
+                c.Remove();
+                Instruction instruction = null;
+                Instruction instruction2 = c.Next;
+                c.GotoLabel(iLLabel);
+                instruction = c.Emit(OpCodes.Ldloc_0).Prev;
+                c.Goto(instruction2);
+                c.Emit(OpCodes.Brfalse_S, instruction);
+                c.Goto(instruction);
+                c.Index++;
+                c.Emit(OpCodes.Ldfld, fieldReference);
+                c.Emit(OpCodes.Ldloc_0);
+                c.Emit(OpCodes.Ldfld, fieldReference2);
+                c.Emit(OpCodes.Ldloc, i);
+                c.Emit(OpCodes.Ldarg_0);
+                c.EmitDelegate(MultiplyByDamageSource);
+                float MultiplyByDamageSource(DamageInfo damageInfo, CharacterBody characterBody, float damage, HealthComponent healthComponent)
+                {
+                    bool victimNullCheck = healthComponent.body;
+                    bool attackerNullCheck = characterBody;
+                    if (victimNullCheck) damage *= healthComponent.body.GetDamageSourceVulnerabilityMultiplier(damageInfo.damageType.damageSource);
+                    if (attackerNullCheck) damage *= characterBody.GetDamageSourceDamageMultiplier(damageInfo.damageType.damageSource);
+                    if (victimNullCheck) damage += healthComponent.body.GetDamageSourceVulnerabilityAddition(damageInfo.damageType.damageSource);
+                    if (attackerNullCheck) damage += characterBody.GetDamageSourceDamageAddition(damageInfo.damageType.damageSource);
+                    return damage;
+                }
+                c.Emit(OpCodes.Stloc, i);
+            }
+            else
+            {
+                CharacterBodyPlugin.Logger.LogError($"Failed to apply {nameof(HealthComponent_TakeDamageProcess)} 3");
+            }
+        }
+        else
+        {
+            CharacterBodyPlugin.Logger.LogError($"Failed to apply {nameof(HealthComponent_TakeDamageProcess)} 1");
+        }
     }
 }

--- a/R2API.CharacterBody/thunderstore.toml
+++ b/R2API.CharacterBody/thunderstore.toml
@@ -5,8 +5,8 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_CharacterBody"
-versionNumber = "1.0.0"
-description = "API for adding various stuff to Character Body such as: Modded Body Flags"
+versionNumber = "1.1.0"
+description = "API for adding various stuff to Character Body such as: Modded Body Flags and damage increases based on Damage Source"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 

--- a/R2API.Core/R2API.cs
+++ b/R2API.Core/R2API.cs
@@ -33,6 +33,7 @@ namespace R2API;
 [BepInDependency(PluginGUID + ".sound", BepInDependency.DependencyFlags.SoftDependency)]
 [BepInDependency(PluginGUID + ".tempvisualeffect", BepInDependency.DependencyFlags.SoftDependency)]
 [BepInDependency(PluginGUID + ".unlockable", BepInDependency.DependencyFlags.SoftDependency)]
+[BepInDependency(PluginGUID + ".character_body", BepInDependency.DependencyFlags.SoftDependency)]
 [BepInDependency(RoR2BepInExPack.RoR2BepInExPack.PluginGUID, BepInDependency.DependencyFlags.HardDependency)]
 [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
 [AutoVersion]

--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -20,6 +20,10 @@ Do not hesitate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ### '5.1.6'
 
+* Added R2API.CharacterBody as a soft BepInDependency
+
+### '5.1.6'
+
 * Added RoR2BepinexPack as a required BepInDependency
 
 ### '5.1.5'

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.1.6"
+versionNumber = "5.1.7"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.RecalculateStats/README.md
+++ b/R2API.RecalculateStats/README.md
@@ -29,6 +29,9 @@ These stat changes are represented in the StatHookEventArgs, which includes argu
 
 ## Changelog
 
+### `1.6.1`
+* Moved GetStatMods event delegate
+
 ### `1.6.0`
 * Added multiplicative stat modifiers `healthTotalMult`, `shieldTotalMult`, `regenTotalMult`, `moveSpeedTotalMult`, `jumpPowerTotalMult`, `damageTotalMult` `attackSpeedTotalMult`, `critMult`, `bleedChanceMult`, `armorMult`, and `curseTotalMult`.
 

--- a/R2API.RecalculateStats/thunderstore.toml
+++ b/R2API.RecalculateStats/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_RecalculateStats"
-versionNumber = "1.6.0"
+versionNumber = "1.6.1"
 description = "API for manipulating Character Stats"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.Skills.Interop/SkillDefInterop.cs
+++ b/R2API.Skills.Interop/SkillDefInterop.cs
@@ -9,4 +9,6 @@ public static class SkillDefInterop
 {
     public static int GetBonusStockMultiplier(SkillDef skillDef) => skillDef.r2api_bonusStockMultiplier;
     public static void SetBonusStockMultiplier(SkillDef skillDef, int value) => skillDef.r2api_bonusStockMultiplier = value;
+    public static bool GetBlacklistAmmoPack(SkillDef skillDef) => skillDef.r2api_blacklistAmmoPack;
+    public static void SetBlacklistAmmoPack(SkillDef skillDef, bool value) => skillDef.r2api_blacklistAmmoPack = value;
 }

--- a/R2API.Skills.Patcher/SkillsPatcher.cs
+++ b/R2API.Skills.Patcher/SkillsPatcher.cs
@@ -17,11 +17,18 @@ internal static class SkillsPatcher
     public static void Patch(AssemblyDefinition assembly)
     {
         TypeDefinition genericSkill = assembly.MainModule.GetType("RoR2", "GenericSkill");
-        genericSkill?.Fields.Add(new FieldDefinition("r2api_hideInLoadout", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(bool))));
-        genericSkill?.Fields.Add(new FieldDefinition("r2api_hideInCharacterSelectIfFirstSkillSelected", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(bool))));
-        genericSkill?.Fields.Add(new FieldDefinition("r2api_orderPriority", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(int))));
-        genericSkill?.Fields.Add(new FieldDefinition("r2api_loadoutTitleTokenOverride", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(string))));
+        if (genericSkill != null)
+        {
+            genericSkill.Fields.Add(new FieldDefinition("r2api_hideInLoadout", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(bool))));
+            genericSkill.Fields.Add(new FieldDefinition("r2api_hideInCharacterSelectIfFirstSkillSelected", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(bool))));
+            genericSkill.Fields.Add(new FieldDefinition("r2api_orderPriority", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(int))));
+            genericSkill.Fields.Add(new FieldDefinition("r2api_loadoutTitleTokenOverride", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(string))));
+        }
         TypeDefinition skillDef = assembly.MainModule.GetType("RoR2.Skills", "SkillDef");
-        skillDef?.Fields.Add(new FieldDefinition("r2api_bonusStockMultiplier", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(int))));
+        if (skillDef != null)
+        {
+            skillDef.Fields.Add(new FieldDefinition("r2api_bonusStockMultiplier", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(int))));
+            skillDef.Fields.Add(new FieldDefinition("r2api_blacklistAmmoPack", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(bool))));
+        }
     }
 }

--- a/R2API.Skills/README.md
+++ b/R2API.Skills/README.md
@@ -13,6 +13,9 @@ Adds extra fields (can be accessed with extension methods) to SkillDef:
 
 ## Changelog
 
+### '1.0.3'
+* Add GetBlacklistAmmoPack and SetBlacklistAmmoPack to SkillDef
+
 ### '1.0.2'
 * Add GetBonusStockMultiplier and SetBonusStockMultiplier to SkillDef
 

--- a/R2API.Skills/thunderstore.toml
+++ b/R2API.Skills/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Skills"
-versionNumber = "1.0.2"
+versionNumber = "1.0.3"
 description = "API for skills"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/RoR2.Patched/CharacterBody.cs
+++ b/RoR2.Patched/CharacterBody.cs
@@ -6,4 +6,8 @@ namespace RoR2;
 public class CharacterBody
 {
     public byte[] r2api_moddedBodyFlags;
+    public Dictionary<string, float> r2api_damageSourceDamageMultiplier;
+    public Dictionary<string, float> r2api_damageSourceDamageAddition;
+    public Dictionary<string, float> r2api_damageSourceVulnerabilityMultiplier;
+    public Dictionary<string, float> r2api_damageSourceVulnerabilityAddition;
 }

--- a/RoR2.Patched/SkillDef.cs
+++ b/RoR2.Patched/SkillDef.cs
@@ -6,4 +6,5 @@ namespace RoR2.Skills;
 public class SkillDef
 {
     public int r2api_bonusStockMultiplier;
+    public bool r2api_blacklistAmmoPack;
 }


### PR DESCRIPTION
R2APi.CharacterBody

Add DamageSourceDamageMultipler, DamageSourceDamageAddition, DamageSourceVulnerabilityMultipler, DamageSourceVulnerabilityAddition features. Increase outcoming and incoming damage for each DamageSource via multipler and flat addition

R2API.Skills

Add BlacklistAmmoPack feature. Set SkillDef to be unaffected by ApplyAmmoPack (aka Bandolier). Also moves CanApplyAmmoPack check from ApplyAmmoPack from SkillLocator to ApplyAmmoPack from GenericSkill

R2API.RecalculateStats

Moved GetStatMods event delegate to run after Run.instance null check. This has been made to run GetStatMods after all mods has run their RecalculateStats hooks that run before everything. This makes new R2API.CharacterBody values possible to be edited using R2API.RecalculateStats easily as R2API.CharacterBody resets its new values in its RecalculateStats hook and then R2API.RecalculateStats runs its RecalculateStats hook