### PR TITLE
R2API.Addressables revamp and improvements

### DIFF
--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
@@ -198,14 +198,14 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     }
 
     /// <summary>
-    /// Allows you to Resolve the asset immediatly, instead of awaiting for <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/>.
-    /// <br></br>
-    /// If <see cref="CanLoadFromCatalog"/> is true, then you should at the very least await for said asset's catalog to initialize, otherwise null might return.
+    /// Loads the asset immediatly, instead of awaiting for <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/>
     /// </summary>
-    /// <returns>The direct referenced asset or the loaded asset</returns>
-    public virtual T ResolveAsset()
+    /// <returns>The loaded asset, or null if no asset was found.</returns>
+    public T LoadAssetNow()
     {
-        Load();
+        if(!AssetExists)
+            Load();
+
         return Asset;
     }
 
@@ -213,15 +213,20 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// Allows you to Resolve the asset immediatly using a coroutine, instead of awaiting for <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/>.
     /// <br></br>
     /// If <see cref="CanLoadFromCatalog"/> is true, then you should at the very least await for said asset's catalog to initialize, otherwise null might return.
+    /// <br></br>
+    /// If you want to immediatly load the asset, you can do so by calling LoadAssetNow
     /// </summary>
     /// <param name="onLoaded">An action to execute once the asset is loaded.</param>
     /// <returns>Yield returns null until the asset is loaded, afterwards it returns </returns>
-    public virtual IEnumerator ResolveAssetCoroutine(Action<T> onLoaded)
+    public virtual IEnumerator LoadAssetNowCoroutine(Action<T> onLoaded)
     {
-        var loadCoroutine = LoadAsyncCoroutine();
-        while(loadCoroutine.MoveNext())
+        if(!AssetExists)
         {
-            yield return null;
+            var loadCoroutine = LoadAsyncCoroutine();
+            while(loadCoroutine.MoveNext())
+            {
+                yield return null;
+            }
         }
 
         onLoaded?.Invoke(Asset);

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
@@ -163,7 +163,7 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// Wether this AddressReferencedAsset can load an Asset using the game's catalogues.
     /// <br>If this is true, you're encouraged to wait for AddressReferencedAsset to initialize fully using <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/></br>
     /// </summary>
-    public virtual bool CanLoadFromCatalog { get; } = false;
+    public virtual bool CanLoadFromCatalog { get; protected set; } = false;
 
     private bool _AddressFailedToLoad;
 

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
@@ -18,7 +18,7 @@ public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()
@@ -39,7 +39,7 @@ public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
         }
     }
 
-    [Obsolete("Call LoadAsyncCoroutine isntead")]
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
         if(CanLoadFromCatalog)

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
@@ -16,7 +16,7 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
     [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
@@ -1,8 +1,10 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -14,25 +16,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if(CanLoadFromCatalog)
+        {
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if(index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine isntead")]
     protected override async Task LoadAsync()
     {
-        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
-        if (index != BuffIndex.None)
+        if(CanLoadFromCatalog)
         {
-            Asset = BuffCatalog.GetBuffDef(index);
-            return;
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if (index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
-        if (index != BuffIndex.None)
+        if(CanLoadFromCatalog)
         {
-            Asset = BuffCatalog.GetBuffDef(index);
-            return;
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if (index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
@@ -18,9 +18,9 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEliteDef : AddressReferencedAsset<EliteDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
-    [SerializeField,HideInInspector]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
@@ -20,7 +20,7 @@ public class AddressReferencedEliteDef : AddressReferencedAsset<EliteDef>
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField,HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
@@ -1,10 +1,12 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -16,25 +18,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEliteDef : AddressReferencedAsset<EliteDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (def != null)
+        if(CanLoadFromCatalog)
         {
-            Asset = def;
-            return;
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (def != null)
+        if(CanLoadFromCatalog)
         {
-            Asset = def;
-            return;
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,25 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEquipmentDef : AddressReferencedAsset<EquipmentDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead.")]
     protected override async Task LoadAsync()
     {
-        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
-        if (index != EquipmentIndex.None)
+        if(CanLoadFromCatalog)
         {
-            Asset = EquipmentCatalog.GetEquipmentDef(index);
-            return;
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
-        if (index != EquipmentIndex.None)
+        if(CanLoadFromCatalog)
         {
-            Asset = EquipmentCatalog.GetEquipmentDef(index);
-            return;
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
@@ -17,7 +17,7 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEquipmentDef : AddressReferencedAsset<EquipmentDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
     [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
@@ -19,7 +19,7 @@ public class AddressReferencedEquipmentDef : AddressReferencedAsset<EquipmentDef
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -19,7 +19,7 @@ public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2.ExpansionManagement;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,24 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if(CanLoadFromCatalog)
+        {
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (expansionDef != null)
+        if(CanLoadFromCatalog)
         {
-            Asset = expansionDef;
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (expansionDef != null)
+        if(CanLoadFromCatalog)
         {
-            Asset = expansionDef;
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -17,7 +17,7 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
     [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
@@ -18,7 +18,7 @@ public class AddressReferencedItemDef : AddressReferencedAsset<ItemDef>
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()
@@ -29,7 +29,7 @@ public class AddressReferencedItemDef : AddressReferencedAsset<ItemDef>
             if (index != ItemIndex.None)
             {
                 Asset = ItemCatalog.GetItemDef(index);
-                return;
+                yield break;
             }
         }
         var subroutine = LoadFromAddressAsyncCoroutine();

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
@@ -1,8 +1,10 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -14,25 +16,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedItemDef : AddressReferencedAsset<ItemDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            ItemIndex index = ItemCatalog.FindItemIndex(Address);
+            if (index != ItemIndex.None)
+            {
+                Asset = ItemCatalog.GetItemDef(index);
+                return;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        ItemIndex index = ItemCatalog.FindItemIndex(Address);
-        if (index != ItemIndex.None)
+        if(CanLoadFromCatalog)
         {
-            Asset = ItemCatalog.GetItemDef(index);
-            return;
+            ItemIndex index = ItemCatalog.FindItemIndex(Address);
+            if (index != ItemIndex.None)
+            {
+                Asset = ItemCatalog.GetItemDef(index);
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        ItemIndex index = ItemCatalog.FindItemIndex(Address);
-        if (index != ItemIndex.None)
+        if (CanLoadFromCatalog)
         {
-            Asset = ItemCatalog.GetItemDef(index);
-            return;
+            ItemIndex index = ItemCatalog.FindItemIndex(Address);
+            if (index != ItemIndex.None)
+            {
+                Asset = ItemCatalog.GetItemDef(index);
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedItemDef.cs
@@ -16,7 +16,7 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedItemDef : AddressReferencedAsset<ItemDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
     [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
@@ -19,7 +19,7 @@ public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableD
 {
     public override bool CanLoadFromCatalog => _canLoadFromCatalog;
 
-    [SerializeField]
+    [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;
 
     protected override IEnumerator LoadAsyncCoroutine()
@@ -30,7 +30,7 @@ public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableD
             if (unlockable)
             {
                 Asset = unlockable;
-                return;
+                yield break;
             }
         }
         var subroutine = LoadFromAddressAsyncCoroutine();

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,24 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableDef>
 {
+    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+
+    [SerializeField]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                return;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while(subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
-        if (unlockable)
+        if(CanLoadFromCatalog)
         {
-            Asset = unlockable;
-            return;
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
-        if (unlockable)
+        if (CanLoadFromCatalog)
         {
-            Asset = unlockable;
-            return;
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
@@ -17,7 +17,7 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableDef>
 {
-    public override bool CanLoadFromCatalog => _canLoadFromCatalog;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
     [SerializeField, HideInInspector]
     private bool _canLoadFromCatalog = true;

--- a/R2API.Addressables/AddressablesPlugin.cs
+++ b/R2API.Addressables/AddressablesPlugin.cs
@@ -15,8 +15,11 @@ public sealed partial class AddressablesPlugin : BaseUnityPlugin
     public const string PluginName = R2API.PluginName + ".Addressables";
     internal static new ManualLogSource Logger { get; set; }
 
+    public static AddressablesPlugin Instance { get; private set; }
+
     private void Awake()
     {
         Logger = base.Logger;
+        Instance = this;
     }
 }

--- a/R2API.Addressables/README.md
+++ b/R2API.Addressables/README.md
@@ -8,6 +8,13 @@ Currently it adds the AddressReferencedAsset system, which allows you on the Edi
 
 ## Changelog
 
+### '1.1.0'
+
+* Implemented the ability to restrict a load to not use the ingame catalogs, forcing an address to be used instead.
+* implemented IDisposeable an AddressReferencedAsset, which releases an internal handle for the addressable asset.
+* Added the ability to bypass the secure loading by calling ResolveAsset().
+* Replaced most of the Task returning methods with IEnumerator coroutines.
+
 ### '1.0.4'
 
 * Added Safeguards for the loading process to avoid loading assets with addresses that are invalid or malformed.

--- a/R2API.Addressables/thunderstore.toml
+++ b/R2API.Addressables/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Addressables"
-versionNumber = "1.0.4"
+versionNumber = "1.1.0"
 description = "R2API Submodule for implementing Addressables functionality"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
* Implemented the ability to restrict a load to not use the ingame catalogs, forcing an address to be used instead.
* implemented IDisposeable an AddressReferencedAsset, which releases an internal handle for the addressable asset.
* Added the ability to bypass the secure loading by calling ResolveAsset().
* Replaced most of the Task returning methods with IEnumerator coroutines.