### PR TITLE
R2API.Skills CustomCooldownRefreshSound feature

### DIFF
--- a/R2API.Skills.Interop/SkillDefInterop.cs
+++ b/R2API.Skills.Interop/SkillDefInterop.cs
@@ -9,4 +9,6 @@ public static class SkillDefInterop
 {
     public static int GetBonusStockMultiplier(SkillDef skillDef) => skillDef.r2api_bonusStockMultiplier;
     public static void SetBonusStockMultiplier(SkillDef skillDef, int value) => skillDef.r2api_bonusStockMultiplier = value;
+    public static string GetCustomCooldownRefreshSound(SkillDef skillDef) => skillDef.r2api_customCooldownRefreshSound;
+    public static void SetCustomCooldownRefreshSound(SkillDef skillDef, string value) => skillDef.r2api_customCooldownRefreshSound = value;
 }

--- a/R2API.Skills.Patcher/SkillsPatcher.cs
+++ b/R2API.Skills.Patcher/SkillsPatcher.cs
@@ -28,6 +28,7 @@ internal static class SkillsPatcher
         if (skillDef != null)
         {
             skillDef.Fields.Add(new FieldDefinition("r2api_bonusStockMultiplier", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(int))));
+            skillDef.Fields.Add(new FieldDefinition("r2api_customCooldownRefreshSound", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(string))));
         }
     }
 }

--- a/R2API.Skills/README.md
+++ b/R2API.Skills/README.md
@@ -10,8 +10,12 @@ Adds extra fields (can be accessed with extension methods) to GenericSkill that 
 
 Adds extra fields (can be accessed with extension methods) to SkillDef:
 * GetBonusStockMultiplier and SetBonusStockMultiplier (bonus stock multiplier for this skill)
+* GetCooldownRefreshSound and SetCooldownRefreshSound (custom cooldown refresh sound for this skill)
 
 ## Changelog
+
+### '1.0.4'
+* Add GetCooldownRefreshSound and SetCooldownRefreshSound to SkillDef
 
 ### '1.0.3'
 * Remake bonusStockMultiplier logic

--- a/R2API.Skills/SkillsAPI.cs
+++ b/R2API.Skills/SkillsAPI.cs
@@ -9,6 +9,8 @@ using R2API.Utils;
 using RoR2;
 using RoR2.Skills;
 using RoR2.UI;
+using UnityEngine;
+using HarmonyLib;
 
 namespace R2API;
 
@@ -24,6 +26,7 @@ public static partial class SkillsAPI
         IL.RoR2.UI.LoadoutPanelController.Row.FromSkillSlot += LoadoutPanelControllerRowFromSkillSlotHook;
         IL.RoR2.UI.CharacterSelectController.BuildSkillStripDisplayData += CharacterSelectControllerBuildSkillStripDisplayDataHook;
         IL.RoR2.GenericSkill.RecalculateMaxStock += GenericSkill_RecalculateMaxStock;
+        IL.RoR2.UI.SkillIcon.Update += SkillIcon_Update;
     }
     internal static void UnsetHooks()
     {
@@ -31,7 +34,18 @@ public static partial class SkillsAPI
         IL.RoR2.UI.LoadoutPanelController.Row.FromSkillSlot -= LoadoutPanelControllerRowFromSkillSlotHook;
         IL.RoR2.UI.CharacterSelectController.BuildSkillStripDisplayData -= CharacterSelectControllerBuildSkillStripDisplayDataHook;
         IL.RoR2.GenericSkill.RecalculateMaxStock -= GenericSkill_RecalculateMaxStock;
+        IL.RoR2.UI.SkillIcon.Update -= SkillIcon_Update;
     }
+
+    /// <summary>
+    /// Gets the value of cooldown refresh sound of a SkillDef.
+    /// </summary>
+    public static string GetCustomCooldownRefreshSound(this SkillDef skillDef) => SkillDefInterop.GetCustomCooldownRefreshSound(skillDef);
+
+    /// <summary>
+    /// Sets the value of cooldown refresh sound of a SkillDef.
+    /// </summary>
+    public static void SetCustomCooldownRefreshSound(this SkillDef skillDef, string value) => SkillDefInterop.SetCustomCooldownRefreshSound(skillDef, value);
 
     /// <summary>
     /// Gets the value of bonus stock multiplication of a SkillDef.
@@ -258,7 +272,34 @@ public static partial class SkillsAPI
             return;
         }
     }
-    
+    private static void SkillIcon_Update(ILContext il)
+    {
+        var c = new ILCursor(il);
+        if (c.TryGotoNext(MoveType.Before,
+            x => x.MatchLdstr(out _),
+            x => x.MatchCall(typeof(RoR2Application).GetPropertyGetter(nameof(RoR2Application.instance))),
+            x => x.MatchCallvirt(typeof(Component).GetPropertyGetter(nameof(Component.gameObject))),
+            x => x.MatchCall(typeof(Util), nameof(Util.PlaySound))
+            )
+            )
+        {
+            Instruction instruction = c.Next;
+            Instruction instruction2 = c.Next.Next;
+            c.Emit(OpCodes.Ldarg_0);
+            c.EmitDelegate(CheckCustomCooldownRefreshSound);
+            bool CheckCustomCooldownRefreshSound(SkillIcon skillIcon) => skillIcon.targetSkill.skillDef.GetCustomCooldownRefreshSound() == null;
+            c.Emit(OpCodes.Brtrue_S, instruction);
+            c.Emit(OpCodes.Ldarg_0);
+            c.EmitDelegate(GetCustomCooldownRefreshSound);
+            string GetCustomCooldownRefreshSound(SkillIcon skillIcon) => skillIcon.targetSkill.skillDef.GetCustomCooldownRefreshSound();
+            c.Emit(OpCodes.Br, instruction2);
+        }
+        else
+        {
+            SkillsPlugin.Logger.LogError($"Failed to apply {nameof(SkillIcon_Update)}");
+            return;
+        }
+    }
     private struct GenericSkillComparer : IComparer<GenericSkill>
     {
         public readonly int Compare(GenericSkill x, GenericSkill y) => x.GetOrderPriority() - y.GetOrderPriority();

--- a/R2API.Skills/thunderstore.toml
+++ b/R2API.Skills/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Skills"
-versionNumber = "1.0.3"
+versionNumber = "1.0.4"
 description = "API for skills"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/RoR2.Patched/SkillDef.cs
+++ b/RoR2.Patched/SkillDef.cs
@@ -6,4 +6,5 @@ namespace RoR2.Skills;
 public class SkillDef
 {
     public int r2api_bonusStockMultiplier;
+    public string r2api_customCooldownRefreshSound;
 }


### PR DESCRIPTION
Adds a feature to set custom cooldown refresh sound instead of default "Play_UI_cooldownRefresh" if it is not null.

Set and get custom cooldown refresh sound field with `SetCustomCooldownRefreshSound` and `GetCustomCooldownRefreshSound` respectfully.

Small showcase: https://github.com/user-attachments/assets/4ff97a2c-3ac9-4938-b60d-e054d7f6688b



