### PR TITLE
R2API.Teams submodule

### DIFF
--- a/R2API.Core/AssemblyInfo.cs
+++ b/R2API.Core/AssemblyInfo.cs
@@ -46,3 +46,4 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
 [assembly: IVT("R2API.Skins")]
 [assembly: IVT("R2API.StringSerializerExtensions")]
 [assembly: IVT("R2API.CharacterBody")]
+[assembly: IVT("R2API.Teams")]

--- a/R2API.Core/R2API.cs
+++ b/R2API.Core/R2API.cs
@@ -73,6 +73,10 @@ public partial class R2API : BaseUnityPlugin
         _networkCompatibilityHandler.BuildModList();
 
         On.RoR2.RoR2Application.Awake += CheckIfUsedOnRightGameVersion;
+
+#if DEBUG
+        EnumPatcher.SetHooks();
+#endif
     }
 
     private void Start()
@@ -91,6 +95,7 @@ public partial class R2API : BaseUnityPlugin
     private void OnDestroy()
     {
         _networkCompatibilityHandler.CleanupModList();
+        EnumPatcher.UnsetHooks();
     }
 
     private static void DebugUpdate()

--- a/R2API.Core/README.md
+++ b/R2API.Core/README.md
@@ -18,6 +18,10 @@ Do not hesitate to ask in [the modding discord](https://discord.gg/5MbXZvd) too!
 
 ## Changelog
 
+### '5.1.7'
+
+* R2API.Teams compatibility
+
 ### '5.1.6'
 
 * Added RoR2BepinexPack as a required BepInDependency

--- a/R2API.Core/Utils/EnumPatcher.cs
+++ b/R2API.Core/Utils/EnumPatcher.cs
@@ -1,0 +1,391 @@
+﻿using HarmonyLib;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace R2API.Utils;
+
+internal static class EnumPatcher
+{
+    static readonly Dictionary<Type, EnumData> _enumDataByType = [];
+
+    static readonly List<IDetour> _hookInstances = [];
+
+    static bool _hooksEnabled;
+
+    internal static void SetHooks()
+    {
+        if (_hooksEnabled)
+            return;
+
+        MethodInfo getValuesAndNamesMethod = AccessTools.DeclaredMethod(typeof(Enum), "GetCachedValuesAndNames");
+        if (getValuesAndNamesMethod != null)
+        {
+            _hookInstances.Add(new ILHook(getValuesAndNamesMethod, AppendEnumValuesAndNamesHook));
+        }
+
+        _hooksEnabled = true;
+    }
+
+    internal static void UnsetHooks()
+    {
+        if (!_hooksEnabled)
+            return;
+
+        foreach (IDetour detour in _hookInstances)
+        {
+            detour?.Dispose();
+        }
+
+        _hookInstances.Clear();
+
+        _hooksEnabled = false;
+    }
+
+    private static void AppendEnumValuesAndNamesHook(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+
+        TypeReference returnTypeReference = il.Method.ReturnType;
+        TypeDefinition returnType = returnTypeReference.SafeResolve();
+        if (returnType == null)
+        {
+            R2API.Logger.LogError($"EnumPatcher.AppendEnumValuesAndNamesHook: Failed to resolve return type of {il.Method.FullName}");
+            return;
+        }
+
+        FieldDefinition valuesField = returnType.FindField("Values");
+        if (valuesField == null)
+        {
+            R2API.Logger.LogError($"EnumPatcher.AppendEnumValuesAndNamesHook ({il.Method.FullName}): Failed to find Values field");
+            return;
+        }
+
+        FieldDefinition namesField = returnType.FindField("Names");
+        if (namesField == null)
+        {
+            R2API.Logger.LogError($"EnumPatcher.AppendEnumValuesAndNamesHook ({il.Method.FullName}): Failed to find Names field");
+            return;
+        }
+
+        VariableDefinition returnTypeTempVar = new VariableDefinition(returnTypeReference);
+        il.Method.Body.Variables.Add(returnTypeTempVar);
+
+        while (c.TryGotoNext(MoveType.AfterLabel,
+                             x => x.MatchRet()))
+        {
+            ILLabel retLabel = c.DefineLabel();
+
+            c.Emit(OpCodes.Stloc, returnTypeTempVar);
+            c.Emit(OpCodes.Ldloc, returnTypeTempVar);
+            c.Emit(OpCodes.Brfalse, retLabel);
+
+            c.Emit(OpCodes.Ldarg_0);
+
+            c.Emit(OpCodes.Ldloc, returnTypeTempVar);
+            c.Emit(OpCodes.Ldflda, valuesField);
+
+            c.Emit(OpCodes.Ldloc, returnTypeTempVar);
+            c.Emit(OpCodes.Ldflda, namesField);
+
+            static void modifyEnumValues(Type enumType, ref ulong[] values, ref string[] names)
+            {
+                if (_enumDataByType.TryGetValue(enumType, out EnumData enumData))
+                {
+                    enumData.ModifyEnumValues(ref names, ref values);
+                }
+            }
+
+            c.EmitDelegate(modifyEnumValues);
+
+            c.MarkLabel(retLabel);
+            c.Emit(OpCodes.Ldloc, returnTypeTempVar);
+
+            c.SearchTarget = SearchTarget.Next;
+        }
+    }
+
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are applied in the called method")]
+    public static EnumValueHandle SetEnumValue<TEnum>(string name, TEnum value) where TEnum : Enum
+    {
+        return SetEnumValue(typeof(TEnum), name, value);
+    }
+
+    public static EnumValueHandle SetEnumValue(Type enumType, string name, object enumValue)
+    {
+        if (enumType is null)
+            throw new ArgumentNullException(nameof(enumType));
+
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException($"'{nameof(name)}' cannot be null or empty.", nameof(name));
+
+        if (enumValue is null)
+            throw new ArgumentNullException(nameof(enumValue));
+
+        if (!enumType.IsEnum)
+            throw new ArgumentException($"'{nameof(enumType)}' must be an enum type", nameof(enumType));
+
+        if (!enumType.IsAssignableFrom(enumValue.GetType()))
+            throw new ArgumentException($"'{nameof(enumValue)}' must be of type '{nameof(enumType)}'");
+
+        SetHooks();
+
+        if (!_enumDataByType.TryGetValue(enumType, out EnumData enumData))
+        {
+            enumData = new EnumData(enumType);
+            _enumDataByType.Add(enumType, enumData);
+        }
+
+        return enumData.AddEntry(name, enumValue);
+    }
+
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static void RemoveEnumValueEntry(in EnumValueHandle handle)
+    {
+        if (!IsValid(handle))
+            return;
+
+        if (_enumDataByType.TryGetValue(handle.EnumType, out EnumData enumData))
+        {
+            enumData.RemoveEntry(handle);
+
+            if (enumData.EntryCount <= 0)
+            {
+                _enumDataByType.Remove(handle.EnumType);
+            }
+        }
+    }
+
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static bool IsValid(in EnumValueHandle handle)
+    {
+        if (handle.EnumType == null || handle.Value == 0)
+            return false;
+
+        return _enumDataByType.TryGetValue(handle.EnumType, out EnumData enumData) && enumData.IsHandleValid(handle);
+    }
+
+    class EnumData
+    {
+        const int EntriesCapacityIncrement = 4;
+
+        public Type Type { get; }
+
+        readonly Type _underlyingType;
+        readonly bool _isUnderlyingTypeUnsigned;
+
+        ulong _nextEntryHandle = 1;
+
+        string[] _baseNames;
+        ulong[] _baseValues;
+
+        int _entriesCount;
+
+        EnumValueEntry[] _entries = new EnumValueEntry[EntriesCapacityIncrement];
+
+        bool _combinedValuesDirty;
+
+        string[] _cachedCombinedNames;
+        ulong[] _cachedCombinedValues;
+
+        public int EntryCount => _entriesCount;
+
+        internal EnumData(Type type)
+        {
+            Type = type;
+            _underlyingType = Type.GetEnumUnderlyingType();
+            _isUnderlyingTypeUnsigned = Type.GetTypeCode(_underlyingType) switch
+            {
+                TypeCode.Byte or TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64 => true,
+                _ => false
+            };
+        }
+
+        private void EnsureDesiredEntriesCapacity()
+        {
+            int desiredSize = ((_entriesCount / EntriesCapacityIncrement) + 1) * EntriesCapacityIncrement;
+            if (_entries.Length != desiredSize)
+            {
+                Array.Resize(ref _entries, desiredSize);
+            }
+        }
+
+        internal ulong ToUInt64(object value)
+        {
+            if (_isUnderlyingTypeUnsigned)
+            {
+                return Convert.ToUInt64(value);
+            }
+            else
+            {
+                // Convert to signed int first to handle negative numbers
+                return unchecked((ulong)Convert.ToInt64(value));
+            }
+        }
+
+        internal object ToEnumValue(ulong value)
+        {
+            if (_isUnderlyingTypeUnsigned)
+            {
+                return Convert.ChangeType(value, _underlyingType);
+            }
+            else
+            {
+                return Convert.ChangeType(unchecked((long)value), _underlyingType);
+            }
+        }
+
+        internal EnumValueHandle AddEntry(string name, object value)
+        {
+            EnsureDesiredEntriesCapacity();
+
+            EnumValueHandle handle = new EnumValueHandle(Type, _nextEntryHandle++);
+
+            _entries[_entriesCount++] = new EnumValueEntry(name, ToUInt64(value), handle);
+
+            _combinedValuesDirty = true;
+
+            return handle;
+        }
+
+        private void RemoveEntryAt(int entryIndex)
+        {
+            Array.Copy(_entries, entryIndex + 1, _entries, entryIndex, _entriesCount - entryIndex - 1);
+            _entriesCount--;
+        }
+
+        internal void RemoveEntry(in EnumValueHandle handle)
+        {
+            for (int i = 0; i < _entriesCount; i++)
+            {
+                if (_entries[i].Handle.Value == handle.Value)
+                {
+                    RemoveEntryAt(i);
+                    break;
+                }
+            }
+
+            EnsureDesiredEntriesCapacity();
+        }
+
+        internal bool IsHandleValid(in EnumValueHandle handle)
+        {
+            for (int i = 0; i < _entriesCount; i++)
+            {
+                if (_entries[i].Handle.Value == handle.Value)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal void ModifyEnumValues(ref string[] names, ref ulong[] values)
+        {
+            if (_entriesCount <= 0)
+                return;
+
+            if (_baseNames == null || _baseValues == null)
+            {
+                _baseNames = names;
+                _baseValues = values;
+
+                _combinedValuesDirty = true;
+            }
+
+            if (_combinedValuesDirty)
+            {
+                _combinedValuesDirty = false;
+                RecalculateCombinedValues();
+            }
+
+            names = _cachedCombinedNames;
+            values = _cachedCombinedValues;
+        }
+
+        private void RecalculateCombinedValues()
+        {
+            int combinedEntriesCount = _baseValues.Length;
+            for (int i = 0; i < _entriesCount; i++)
+            {
+                if (Array.BinarySearch(_baseValues, _entries[i].Value) < 0)
+                {
+                    combinedEntriesCount++;
+                }
+            }
+
+            if (_cachedCombinedNames == null || _cachedCombinedNames.Length != combinedEntriesCount)
+            {
+                _cachedCombinedNames = new string[combinedEntriesCount];
+                _cachedCombinedValues = new ulong[combinedEntriesCount];
+            }
+
+            Array.Copy(_baseValues, _cachedCombinedValues, _baseValues.Length);
+            Array.Copy(_baseNames, _cachedCombinedNames, _baseNames.Length);
+
+            int combinedArraySize = _baseValues.Length;
+
+            for (int i = 0; i < _entriesCount; i++)
+            {
+                int existingValueIndex = Array.BinarySearch(_baseValues, _entries[i].Value);
+                if (existingValueIndex >= 0)
+                {
+#if DEBUG
+                    R2API.LogDebug($"Replacing enum value {_cachedCombinedNames[existingValueIndex]}={_cachedCombinedValues[existingValueIndex]} with {_entries[i].Name} for {Type.FullName}");
+#endif
+
+                    _cachedCombinedValues[existingValueIndex] = _entries[i].Value;
+                    _cachedCombinedNames[existingValueIndex] = _entries[i].Name;
+                }
+                else
+                {
+#if DEBUG
+                    R2API.LogDebug($"Appending enum value {_entries[i].Name}={ToEnumValue(_entries[i].Value)} for {Type.FullName}");
+#endif
+
+                    _cachedCombinedValues[combinedArraySize] = _entries[i].Value;
+                    _cachedCombinedNames[combinedArraySize] = _entries[i].Name;
+
+                    combinedArraySize++;
+                }
+            }
+
+            Array.Sort(_cachedCombinedValues, _cachedCombinedNames);
+        }
+
+        readonly struct EnumValueEntry
+        {
+            public readonly string Name;
+            public readonly ulong Value;
+
+            public readonly EnumValueHandle Handle;
+
+            internal EnumValueEntry(string name, ulong value, EnumValueHandle handle)
+            {
+                Name = name;
+                Value = value;
+                Handle = handle;
+            }
+        }
+    }
+
+    public readonly struct EnumValueHandle
+    {
+        internal readonly Type EnumType;
+
+        internal readonly ulong Value;
+
+        internal EnumValueHandle(Type enumType, ulong value)
+        {
+            EnumType = enumType;
+            Value = value;
+        }
+    }
+}

--- a/R2API.Core/thunderstore.toml
+++ b/R2API.Core/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Core"
-versionNumber = "5.1.6"
+versionNumber = "5.1.7"
 description = "Core R2API module"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.Teams.Interop/R2API.Teams.Interop.csproj
+++ b/R2API.Teams.Interop/R2API.Teams.Interop.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RoR2.Patched\RoR2.Patched.csproj" Private="false" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/R2API.Teams.Interop/TeamsInterop.cs
+++ b/R2API.Teams.Interop/TeamsInterop.cs
@@ -1,0 +1,15 @@
+﻿using RoR2;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("R2API.Teams")]
+
+namespace R2API;
+
+internal static class TeamsInterop
+{
+    public static byte[] GetModdedMask(in TeamMask teamMask) => teamMask.r2api_moddedMask;
+
+    public static ref byte[] GetModdedMaskRef(ref TeamMask teamMask) => ref teamMask.r2api_moddedMask;
+
+    public static void SetModdedMask(ref TeamMask teamMask, byte[] value) => teamMask.r2api_moddedMask = value;
+}

--- a/R2API.Teams.Patcher/R2API.Teams.Patcher.csproj
+++ b/R2API.Teams.Patcher/R2API.Teams.Patcher.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <RootNamespace>R2API</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="5.4.19" />
+  </ItemGroup>
+</Project>

--- a/R2API.Teams.Patcher/TeamsPatcher.cs
+++ b/R2API.Teams.Patcher/TeamsPatcher.cs
@@ -1,0 +1,15 @@
+﻿using Mono.Cecil;
+using System.Collections.Generic;
+
+namespace R2API;
+
+internal static class TeamsPatcher
+{
+    public static IEnumerable<string> TargetDLLs { get; } = ["RoR2.dll"];
+
+    public static void Patch(AssemblyDefinition assembly)
+    {
+        TypeDefinition procChainMask = assembly.MainModule.GetType("RoR2", "TeamMask");
+        procChainMask?.Fields.Add(new FieldDefinition("r2api_moddedMask", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[]))));
+    }
+}

--- a/R2API.Teams.Patcher/TeamsPatcher.cs
+++ b/R2API.Teams.Patcher/TeamsPatcher.cs
@@ -9,7 +9,7 @@ internal static class TeamsPatcher
 
     public static void Patch(AssemblyDefinition assembly)
     {
-        TypeDefinition procChainMask = assembly.MainModule.GetType("RoR2", "TeamMask");
-        procChainMask?.Fields.Add(new FieldDefinition("r2api_moddedMask", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[]))));
+        TypeDefinition teamMask = assembly.MainModule.GetType("RoR2", "TeamMask");
+        teamMask?.Fields.Add(new FieldDefinition("r2api_moddedMask", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[]))));
     }
 }

--- a/R2API.Teams/Log.cs
+++ b/R2API.Teams/Log.cs
@@ -1,0 +1,52 @@
+﻿using BepInEx.Logging;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace R2API;
+
+internal static class Log
+{
+    static ManualLogSource _logSource;
+
+    public static void Init(ManualLogSource logSource)
+    {
+        _logSource = logSource;
+    }
+
+    [Conditional("DEBUG")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Debug(object data)
+    {
+        _logSource.LogDebug(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Info(object data)
+    {
+        _logSource.LogInfo(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Message(object data)
+    {
+        _logSource.LogMessage(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Warning(object data)
+    {
+        _logSource.LogWarning(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Error(object data)
+    {
+        _logSource.LogError(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Fatal(object data)
+    {
+        _logSource.LogFatal(data);
+    }
+}

--- a/R2API.Teams/R2API.Teams.csproj
+++ b/R2API.Teams/R2API.Teams.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../R2API.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+    <ProjectReference Include="..\R2API.Teams.Interop\R2API.Teams.Interop.csproj" Private="false" PrivateAssets="all" />
+    <ProjectReference Include="..\R2API.Teams.Patcher\R2API.Teams.Patcher.csproj" Private="false" PrivateAssets="all" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/R2API.Teams/README.md
+++ b/R2API.Teams/README.md
@@ -1,0 +1,18 @@
+# R2API.Teams - Custom teams addition
+
+## About
+
+An R2API submodule that allows the creation of custom character teams.
+
+## Use Cases / Features
+
+R2API.Teams can be used to add your own teams to the game for more complex combat relationships.
+
+Use `TeamsAPI.RegisterTeam` to add a new team, the `TeamIndex` of the new team is returned. Any Enum parsing/ToString of TeamIndex is redirected to the added TeamIndex for compatibility.
+
+## Related Pages
+
+## Changelog
+
+### '1.0.0'
+* Initial Release

--- a/R2API.Teams/TeamsAPI.cs
+++ b/R2API.Teams/TeamsAPI.cs
@@ -1,0 +1,741 @@
+﻿using HarmonyLib;
+using HG;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
+using R2API.AutoVersionGen;
+using R2API.Utils;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace R2API;
+
+#pragma warning disable CS0436 // Type conflicts with imported type
+[AutoVersion]
+#pragma warning restore CS0436 // Type conflicts with imported type
+public static partial class TeamsAPI
+{
+    public const string PluginGUID = R2API.PluginGUID + ".teams";
+    public const string PluginName = R2API.PluginName + ".Teams";
+
+    /// <summary>
+    /// The absolute maximum amount of teams there that can be in the catalog
+    /// </summary>
+    public static int TeamCountLimit => sbyte.MaxValue - 1;
+
+    /// <summary>
+    /// How many teams there are in total, this should be used instead of TeamIndex.Count wherever possible as this accounts for modded teams
+    /// </summary>
+    public static int TeamCount => TeamCatalog.teamDefs.Length;
+
+    /// <summary>
+    /// The absolute maximum amount of modded teams that can be in the catalog
+    /// </summary>
+    public static int ModdedTeamCountLimit => TeamCountLimit - _vanillaTeamsCount;
+
+    /// <summary>
+    /// How many modded teams that have been registered
+    /// </summary>
+    public static int ModdedTeamCount => Math.Max(0, TeamCount - _vanillaTeamsCount);
+
+    static readonly int _vanillaTeamsCount = TeamCatalog.teamDefs.Length;
+
+    static readonly int _allVanillaTeamsDirtyBits = (1 << _vanillaTeamsCount) - 1;
+
+    static byte[] _allModdedTeamsDirtyBits = [];
+
+    static TeamBehavior[] _moddedTeamBehaviors = new TeamBehavior[4];
+
+    static EnumPatcher.EnumValueHandle _teamCountHandle;
+
+    internal static void Init()
+    {
+        // Force the TeamCatalog static constructor to run before anything else is initialized,
+        // this prevents a crash during loading, something related to asset loading from a component constructor.
+        _ = TeamCatalog.teamDefs;
+    }
+
+    #region Hooks
+    static bool _hooksEnabled;
+
+    static readonly List<IDetour> _hookInstances = [];
+
+    internal static void SetHooks()
+    {
+        if (_hooksEnabled)
+            return;
+        
+        IL.EntityStates.GrandParentBoss.Offspring.FindTargetFarthest += ReplaceTeamIndexCount;
+        IL.RoR2.AffixBeadAttachment.ClearEnemyLunarRuinDamage += ReplaceTeamIndexCount;
+        IL.RoR2.BuffWard.FixedUpdate += ReplaceTeamIndexCount;
+        IL.RoR2.FogDamageController.MyFixedUpdate += ReplaceTeamIndexCount;
+        IL.RoR2.GhostGunController.FindTarget += ReplaceTeamIndexCount;
+        IL.RoR2.GoldTitanManager.CalcTitanPowerAndBestTeam += ReplaceTeamIndexCount;
+        IL.RoR2.HoldoutZoneController.UpdateHealingNovas += ReplaceTeamIndexCount;
+        IL.RoR2.TeamComponent.TeamIsValid += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.Start += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamExperience += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamCurrentLevelExperience += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamNextLevelExperience += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamLevel += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.SetTeamLevel += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GiveTeamMoney_TeamIndex_int += ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GiveTeamItem += ReplaceTeamIndexCount;
+        IL.RoR2.Util.GetEnemyEasyTarget += ReplaceTeamIndexCount;
+
+        On.RoR2.TeamManager.Start += TeamManager_Start;
+        IL.RoR2.TeamManager.SetTeamExperience += TeamManager_SetTeamExperience;
+        On.RoR2.TeamManager.OnSerialize += TeamManager_OnSerialize;
+        On.RoR2.TeamManager.OnDeserialize += TeamManager_OnDeserialize;
+
+        On.RoR2.LayerIndex.GetAppropriateLayerForTeam += LayerIndex_GetAppropriateLayerForTeam;
+        On.RoR2.LayerIndex.GetAppropriateFakeLayerForTeam += LayerIndex_GetAppropriateFakeLayerForTeam;
+
+        On.RoR2.TeamMask.HasTeam += TeamMask_HasTeam;
+        On.RoR2.TeamMask.AddTeam += TeamMask_AddTeam;
+        On.RoR2.TeamMask.RemoveTeam += TeamMask_RemoveTeam;
+
+        MethodInfo fogDamageGetAffectedBodiesMoveNextMethod = null;
+
+        MethodInfo fogDamageGetAffectedBodiesMethod = SymbolExtensions.GetMethodInfo<FogDamageController>(_ => _.GetAffectedBodies());
+        if (fogDamageGetAffectedBodiesMethod != null)
+        {
+            fogDamageGetAffectedBodiesMoveNextMethod = AccessTools.EnumeratorMoveNext(fogDamageGetAffectedBodiesMethod);
+        }
+
+        if (fogDamageGetAffectedBodiesMoveNextMethod != null)
+        {
+            _hookInstances.Add(new ILHook(fogDamageGetAffectedBodiesMoveNextMethod, ReplaceTeamIndexCount));
+        }
+        else
+        {
+            Log.Error("Failed to find FogDamageController.GetAffectedBodies enumerator MoveNext method for patches");
+        }
+
+        ConstructorInfo holdoutZoneControllerCtor = AccessTools.DeclaredConstructor(typeof(HoldoutZoneController));
+        if (holdoutZoneControllerCtor != null)
+        {
+            _hookInstances.Add(new ILHook(holdoutZoneControllerCtor, ReplaceTeamArraySize));
+        }
+        else
+        {
+            Log.Error("Failed to find HoldoutZoneController constructor for patches");
+        }
+
+        ConstructorInfo teamManagerCtor = AccessTools.DeclaredConstructor(typeof(TeamManager));
+        if (teamManagerCtor != null)
+        {
+            _hookInstances.Add(new ILHook(teamManagerCtor, ReplaceTeamArraySize));
+        }
+        else
+        {
+            Log.Error("Failed to find TeamManager constructor for patches");
+        }
+
+        _hooksEnabled = true;
+    }
+
+    internal static void UnsetHooks()
+    {
+        if (!_hooksEnabled)
+            return;
+
+        IL.EntityStates.GrandParentBoss.Offspring.FindTargetFarthest -= ReplaceTeamIndexCount;
+        IL.RoR2.AffixBeadAttachment.ClearEnemyLunarRuinDamage -= ReplaceTeamIndexCount;
+        IL.RoR2.BuffWard.FixedUpdate -= ReplaceTeamIndexCount;
+        IL.RoR2.FogDamageController.MyFixedUpdate -= ReplaceTeamIndexCount;
+        IL.RoR2.GhostGunController.FindTarget -= ReplaceTeamIndexCount;
+        IL.RoR2.GoldTitanManager.CalcTitanPowerAndBestTeam -= ReplaceTeamIndexCount;
+        IL.RoR2.HoldoutZoneController.UpdateHealingNovas -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamComponent.TeamIsValid -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.Start -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.OnSerialize -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.OnDeserialize -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamExperience -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamCurrentLevelExperience -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamNextLevelExperience -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GetTeamLevel -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.SetTeamLevel -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GiveTeamMoney_TeamIndex_int -= ReplaceTeamIndexCount;
+        IL.RoR2.TeamManager.GiveTeamItem -= ReplaceTeamIndexCount;
+        IL.RoR2.Util.GetEnemyEasyTarget -= ReplaceTeamIndexCount;
+
+        On.RoR2.TeamManager.Start -= TeamManager_Start;
+        IL.RoR2.TeamManager.SetTeamExperience -= TeamManager_SetTeamExperience;
+        On.RoR2.TeamManager.OnSerialize -= TeamManager_OnSerialize;
+        On.RoR2.TeamManager.OnDeserialize -= TeamManager_OnDeserialize;
+
+        On.RoR2.LayerIndex.GetAppropriateLayerForTeam -= LayerIndex_GetAppropriateLayerForTeam;
+        On.RoR2.LayerIndex.GetAppropriateFakeLayerForTeam -= LayerIndex_GetAppropriateFakeLayerForTeam;
+
+        On.RoR2.TeamMask.HasTeam -= TeamMask_HasTeam;
+        On.RoR2.TeamMask.AddTeam -= TeamMask_AddTeam;
+        On.RoR2.TeamMask.RemoveTeam -= TeamMask_RemoveTeam;
+
+        foreach (IDetour hookInstance in _hookInstances)
+        {
+            hookInstance?.Dispose();
+        }
+
+        _hookInstances.Clear();
+
+        _hooksEnabled = false;
+    }
+
+    // Purpose: Replace 'new T[(int)TeamIndex.Count]' with 'new T[TeamsAPI.TeamCount]'
+    static void ReplaceTeamArraySize(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+
+        MethodInfo teamCountGetterMethod = AccessTools.PropertyGetter(typeof(TeamsAPI), nameof(TeamCount));
+
+        int patchCount = 0;
+
+        while (c.TryGotoNext(MoveType.Before,
+                             x => x.MatchLdcI4(_vanillaTeamsCount),
+                             x => x.MatchNewarr(out _)))
+        {
+            c.Index++;
+            c.MoveAfterLabels();
+
+            c.Emit(OpCodes.Pop);
+            c.Emit(OpCodes.Call, teamCountGetterMethod);
+
+            patchCount++;
+        }
+
+        if (patchCount == 0)
+        {
+            Log.Error($"Failed to find any TeamIndex.Count array size patch locations for {il.Method.FullName}");
+        }
+        else
+        {
+            Log.Debug($"TeamIndex.Count array size patch for {il.Method.FullName} found {patchCount} location(s)");
+        }
+    }
+
+    // Purpose: Replace 'X < TeamIndex.Count' with modded TeamIndex "in-bounds" check, also accounts for other conditions/comparisons
+    static void ReplaceTeamIndexCount(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+
+        static bool matchCompareOrBranch(Instruction x)
+        {
+            return x.OpCode.FlowControl == FlowControl.Cond_Branch || // Match any conditional branch (blt, beq, bgt, etc.)
+                   x.OpCode == OpCodes.Ceq ||
+                   x.OpCode == OpCodes.Cgt ||
+                   x.OpCode == OpCodes.Cgt_Un ||
+                   x.OpCode == OpCodes.Clt ||
+                   x.OpCode == OpCodes.Clt_Un; // Match any comparison
+        }
+
+        int patchCount = 0;
+
+        while (c.TryGotoNext(MoveType.Before,
+                             x => x.MatchLdcI4(_vanillaTeamsCount),
+                             x => matchCompareOrBranch(x)))
+        {
+            // A bit gross, but we need the instruction after TeamIndex.Count without moving the cursor
+            // It's all within the match though, so no risks taken really.
+            Instruction teamIndexCompareOrBranchInstruction = c.Next.Next;
+
+            // Specify delegate signature to ensure hook won't silently fail if IsValidTeam signature changes
+            c.EmitDelegate<Func<TeamIndex, bool>>(IsValidTeam);
+
+            if (teamIndexCompareOrBranchInstruction.OpCode.FlowControl == FlowControl.Cond_Branch)
+            {
+                bool isInBoundsCheck = teamIndexCompareOrBranchInstruction.MatchBlt(out _) ||
+                                       teamIndexCompareOrBranchInstruction.MatchBltUn(out _) ||
+                                       teamIndexCompareOrBranchInstruction.MatchBneUn(out _);
+
+                c.Emit(isInBoundsCheck ? OpCodes.Brtrue : OpCodes.Brfalse, teamIndexCompareOrBranchInstruction.Operand);
+            }
+            else // non-branching comparison
+            {
+                bool isInBoundsCheck = teamIndexCompareOrBranchInstruction.MatchClt() ||
+                                       teamIndexCompareOrBranchInstruction.MatchCltUn();
+
+                if (!isInBoundsCheck)
+                {
+                    c.Emit(OpCodes.Not);
+                }
+            }
+
+            ILLabel skipTeamIndexOperationLabel = c.DefineLabel();
+            c.Emit(OpCodes.Br, skipTeamIndexOperationLabel);
+
+            // Even though the original instruction will always be skipped,
+            // we still need to make sure the stack isn't unbalanced
+            c.Emit(OpCodes.Ldc_I4_M1);
+            c.Index += 2; // Move past TeamIndex.Count & compare/branch operation
+            c.MarkLabel(skipTeamIndexOperationLabel);
+
+            patchCount++;
+        }
+
+        if (patchCount == 0)
+        {
+            Log.Error($"Failed to find any TeamIndex.Count patch locations for {il.Method.FullName}");
+        }
+        else
+        {
+            Log.Debug($"TeamIndex.Count patch for {il.Method.FullName} found {patchCount} location(s)");
+        }
+    }
+
+    static int LayerIndex_GetAppropriateLayerForTeam(On.RoR2.LayerIndex.orig_GetAppropriateLayerForTeam orig, TeamIndex teamIndex)
+    {
+        int layer = orig(teamIndex);
+
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex >= 0 && moddedTeamIndex < ModdedTeamCount)
+        {
+            TeamBehavior teamBehavior = ArrayUtils.GetSafe(_moddedTeamBehaviors, moddedTeamIndex);
+            if (teamBehavior != null)
+            {
+                layer = teamBehavior.TeamLayer.intVal;
+            }
+        }
+
+        return layer;
+    }
+
+    static LayerIndex LayerIndex_GetAppropriateFakeLayerForTeam(On.RoR2.LayerIndex.orig_GetAppropriateFakeLayerForTeam orig, TeamIndex teamIndex)
+    {
+        LayerIndex fakeLayer = orig(teamIndex);
+
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex >= 0 && moddedTeamIndex < ModdedTeamCount)
+        {
+            TeamBehavior teamBehavior = ArrayUtils.GetSafe(_moddedTeamBehaviors, moddedTeamIndex);
+            if (teamBehavior != null)
+            {
+                fakeLayer = teamBehavior.TeamFakeLayer;
+            }
+        }
+
+        return fakeLayer;
+    }
+
+    static bool TeamMask_HasTeam(On.RoR2.TeamMask.orig_HasTeam orig, ref TeamMask self, TeamIndex teamIndex)
+    {
+        bool hasTeam = orig(ref self, teamIndex);
+
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex >= 0 && moddedTeamIndex < ModdedTeamCount)
+        {
+            hasTeam = GetModdedTeamMaskBit(self, moddedTeamIndex);
+        }
+
+        return hasTeam;
+    }
+
+    static void TeamMask_AddTeam(On.RoR2.TeamMask.orig_AddTeam orig, ref TeamMask self, TeamIndex teamIndex)
+    {
+        orig(ref self, teamIndex);
+
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex >= 0 && moddedTeamIndex < ModdedTeamCount)
+        {
+            SetModdedTeamMaskBit(ref self, moddedTeamIndex, true);
+        }
+    }
+
+    static void TeamMask_RemoveTeam(On.RoR2.TeamMask.orig_RemoveTeam orig, ref TeamMask self, TeamIndex teamIndex)
+    {
+        orig(ref self, teamIndex);
+
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex >= 0 && moddedTeamIndex < ModdedTeamCount)
+        {
+            SetModdedTeamMaskBit(ref self, moddedTeamIndex, false);
+        }
+    }
+
+    static void TeamManager_Start(On.RoR2.TeamManager.orig_Start orig, TeamManager self)
+    {
+        self.gameObject.EnsureComponent<TeamManagerModdedTeamsHelper>();
+        orig(self);
+    }
+
+    // Purpose: Replace 'base.SetDirtyBit(1U << (int)teamIndex)' with custom implementation for modded teams
+    static void TeamManager_SetTeamExperience(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+
+        ParameterDefinition teamIndexParameter = il.Method.Parameters.FirstOrDefault(p => p.ParameterType.Is(typeof(TeamIndex)));
+        if (teamIndexParameter == null)
+        {
+            Log.Error("TeamManager.SetTeamExperience hook failed to find TeamIndex parameter");
+            return;
+        }
+
+        if (!c.TryGotoNext(MoveType.After, x => x.MatchCallOrCallvirt<NetworkBehaviour>(nameof(NetworkBehaviour.SetDirtyBit))))
+        {
+            Log.Error("Failed to find TeamManager.SetTeamExperience SetDirtyBit call");
+            return;
+        }
+
+        ILLabel vanillaSetDirtyBitEndLabel = c.MarkLabel();
+
+        if (!c.TryGotoPrev(MoveType.AfterLabel, x => x.MatchLdarg(0)))
+        {
+            Log.Error("Failed to find TeamManager.SetTeamExperience SetDirtyBit patch location");
+            return;
+        }
+
+        ILLabel vanillaSetDirtyBitStartLabel = c.MarkLabel();
+        c.MoveBeforeLabels();
+
+        c.Emit(OpCodes.Ldarg, teamIndexParameter);
+        c.EmitDelegate<Func<TeamIndex, bool>>(IsModdedTeam);
+        c.Emit(OpCodes.Brfalse, vanillaSetDirtyBitStartLabel);
+
+        c.Emit(OpCodes.Ldarg_0);
+        c.Emit(OpCodes.Ldarg, teamIndexParameter);
+        c.EmitDelegate(setModdedTeamDirtyBit);
+        static void setModdedTeamDirtyBit(TeamManager self, TeamIndex teamIndex)
+        {
+            if (self.TryGetComponent(out TeamManagerModdedTeamsHelper moddedTeamsHelper))
+            {
+                moddedTeamsHelper.SetDirtyBit(GetModdedTeamIndex(teamIndex));
+            }
+            else
+            {
+                Log.Error($"TeamManager wants to set dirty bit of modded team '{teamIndex}', but modded teams helper is not attached!");
+            }
+        }
+
+        c.Emit(OpCodes.Br, vanillaSetDirtyBitEndLabel);
+    }
+
+    static bool TeamManager_OnSerialize(On.RoR2.TeamManager.orig_OnSerialize orig, TeamManager self, NetworkWriter writer, bool initialState)
+    {
+        bool anythingWritten = orig(self, writer, initialState);
+
+        if (self.TryGetComponent(out TeamManagerModdedTeamsHelper moddedTeamsHelper))
+        {
+            byte[] dirtyModdedTeamsBits;
+            if (initialState)
+            {
+                // No need to access dirty bits in initialState, since we know all of them are dirty.
+                // Also since receiver will know to read all of them during initial deserialization, there is no need to write them either.
+                dirtyModdedTeamsBits = null;
+            }
+            else
+            {
+                dirtyModdedTeamsBits = moddedTeamsHelper.ModdedTeamsDirtyBits ?? [];
+                CompressedFlagArrayUtilities.WriteToNetworkWriter(dirtyModdedTeamsBits, writer, ModdedTeamCount);
+            }
+
+            for (int i = 0; i < ModdedTeamCount; i++)
+            {
+                if (initialState || CompressedFlagArrayUtilities.Has(dirtyModdedTeamsBits, i))
+                {
+                    writer.WritePackedUInt64(self.teamExperience[_vanillaTeamsCount + i]);
+                }
+            }
+
+            anythingWritten = true;
+
+            moddedTeamsHelper.ClearDirtyBits();
+        }
+
+        return anythingWritten;
+    }
+
+    static void TeamManager_OnDeserialize(On.RoR2.TeamManager.orig_OnDeserialize orig, TeamManager self, NetworkReader reader, bool initialState)
+    {
+        orig(self, reader, initialState);
+
+        if (self.TryGetComponent(out TeamManagerModdedTeamsHelper moddedTeamsHelper))
+        {
+            byte[] dirtyModdedTeamsBits = initialState ? null : CompressedFlagArrayUtilities.ReadFromNetworkReader(reader, ModdedTeamCount);
+
+            for (int i = 0; i < ModdedTeamCount; i++)
+            {
+                if (initialState || CompressedFlagArrayUtilities.Has(dirtyModdedTeamsBits, i))
+                {
+                    ulong experience = reader.ReadPackedUInt64();
+                    self.SetTeamExperience(GetTeamIndex(i), experience);
+                }
+            }
+        }
+    }
+
+    class TeamManagerModdedTeamsHelper : MonoBehaviour
+    {
+        public byte[] ModdedTeamsDirtyBits;
+
+        internal void SetDirtyBit(int moddedTeamIndex)
+        {
+            CompressedFlagArrayUtilities.AddImmutable(ref ModdedTeamsDirtyBits, moddedTeamIndex);
+        }
+
+        internal void ClearDirtyBits()
+        {
+            ModdedTeamsDirtyBits = null;
+        }
+    }
+    #endregion
+
+    static bool GetModdedTeamMaskBit(in TeamMask teamMask, int moddedTeamIndex)
+    {
+        byte[] moddedTeamsMask = TeamsInterop.GetModdedMask(teamMask);
+        return CompressedFlagArrayUtilities.Has(moddedTeamsMask, moddedTeamIndex);
+    }
+
+    static void SetModdedTeamMaskBit(ref TeamMask teamMask, int moddedTeamIndex, bool bitState)
+    {
+        ref byte[] moddedTeamsMask = ref TeamsInterop.GetModdedMaskRef(ref teamMask);
+
+        if (bitState)
+        {
+            CompressedFlagArrayUtilities.AddImmutable(ref moddedTeamsMask, moddedTeamIndex);
+        }
+        else
+        {
+            CompressedFlagArrayUtilities.RemoveImmutable(ref moddedTeamsMask, moddedTeamIndex);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static int GetModdedTeamIndex(TeamIndex teamIndex)
+    {
+        return (int)teamIndex - _vanillaTeamsCount;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static TeamIndex GetTeamIndex(int moddedTeamIndex)
+    {
+        return (TeamIndex)(_vanillaTeamsCount + moddedTeamIndex);
+    }
+
+    #region Public
+    /// <summary>
+    /// Determines if a <see cref="TeamIndex"/> is a valid modded team
+    /// </summary>
+    /// <param name="teamIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static bool IsModdedTeam(TeamIndex teamIndex)
+    {
+        return teamIndex != TeamIndex.None && (byte)teamIndex >= (byte)_vanillaTeamsCount && (byte)teamIndex < TeamCount;
+    }
+
+    /// <summary>
+    /// Determines if a <see cref="TeamIndex"/> is valid, prefer to use this instead of comparing with <see cref="TeamIndex.Count"/>
+    /// </summary>
+    /// <param name="teamIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static bool IsValidTeam(TeamIndex teamIndex)
+    {
+        return teamIndex != TeamIndex.None && (byte)teamIndex < TeamCount;
+    }
+
+    /// <summary>
+    /// Enumerates all registered teams, prefer to use this over iterating through [0 .. <see cref="TeamCount"/>) yourself
+    /// </summary>
+    /// <returns>An enumerable for all registered team indices</returns>
+    /// <remarks>
+    /// Teams are returned in order, vanilla teams first [<see cref="TeamIndex.Neutral"/> .. <see cref="TeamIndex.Count"/>) then modded teams, in the order they were registered.
+    /// </remarks>
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static IEnumerable<TeamIndex> TeamsEnumerator()
+    {
+        for (int i = 0; i < TeamCount; i++)
+        {
+            yield return (TeamIndex)i;
+        }
+    }
+
+    /// <summary>
+    /// Registers a new team to the catalog and returns it's <see cref="TeamIndex"/>
+    /// </summary>
+    /// <remarks>
+    /// If a team has already been added with the same name configured in <paramref name="teamBehavior"/>, then the previously registered team's <see cref="TeamIndex"/> will be returned.
+    /// </remarks>
+    /// <param name="teamDef">The <see cref="TeamDef"/> of the new team.</param>
+    /// <param name="teamBehavior">Additional configuration not covered by the <see cref="TeamDef"/></param>
+    /// <returns>The <see cref="TeamIndex"/> of the newly added team, or <see cref="TeamIndex.None"/> if the team limit has been reached.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="teamDef"/> or <paramref name="teamBehavior"/> are <see langword="null"/></exception>
+    /// <exception cref="InvalidOperationException">This method is called after game initialization has finished.</exception>
+    public static TeamIndex RegisterTeam(TeamDef teamDef, TeamBehavior teamBehavior)
+    {
+        if (teamDef is null)
+            throw new ArgumentNullException(nameof(teamDef));
+
+        if (teamBehavior is null)
+            throw new ArgumentNullException(nameof(teamBehavior));
+
+        if (RoR2Application.loadFinished)
+            throw new InvalidOperationException("Cannot register a new team post initialization");
+
+        int newTeamIndex = TeamCatalog.teamDefs.Length;
+        int newTeamCount = newTeamIndex + 1;
+
+        if (newTeamIndex >= TeamCountLimit)
+        {
+            Log.Fatal($"Failed to add team '{teamBehavior.Name}': Modded team limit of {ModdedTeamCountLimit} has been reached.");
+            return TeamIndex.None;
+        }
+
+        // Will catch any name clashes with vanilla teams or registered modded ones
+        if (Enum.TryParse(teamBehavior.Name, out TeamIndex existingTeamIndex))
+        {
+            Log.Error($"Attempting to register team with name '{teamBehavior.Name}' multiple times, previously assigned TeamIndex will be returned, TeamDef and TeamBehavior will be discarded");
+            return existingTeamIndex;
+        }
+
+        if (Enum.TryParse(teamBehavior.Name, true, out TeamIndex existingTeamIndexCaseInsensitive))
+        {
+            Log.Warning($"Registering team '{teamBehavior.Name}' with the same case-insensitive name as an existing team '{existingTeamIndexCaseInsensitive}', consider re-naming your team to avoid name clashes.");
+        }
+
+        SetHooks();
+
+        ArrayUtils.EnsureCapacity(ref TeamCatalog.teamDefs, newTeamCount);
+        TeamCatalog.Register((TeamIndex)newTeamIndex, teamDef);
+
+        ArrayUtils.EnsureCapacity(ref TeamComponent.teamsList, newTeamCount);
+        TeamComponent.teamsList[newTeamIndex].Init((TeamIndex)newTeamIndex);
+
+        if (EnumPatcher.IsValid(_teamCountHandle))
+        {
+            EnumPatcher.RemoveEnumValueEntry(_teamCountHandle);
+        }
+
+        EnumPatcher.SetEnumValue(teamBehavior.Name, (TeamIndex)newTeamIndex);
+
+        // Keep TeamIndex.Count updated, just in case someone accesses it via Enum
+        _teamCountHandle = EnumPatcher.SetEnumValue(nameof(TeamIndex.Count), (TeamIndex)newTeamCount);
+
+        TeamMask.all.AddTeam((TeamIndex)newTeamIndex);
+
+        if ((teamBehavior.Classification & TeamClassification.Neutral) == 0)
+        {
+            TeamMask.allButNeutral.AddTeam((TeamIndex)newTeamIndex);
+        }
+
+        int moddedTeamIndex = GetModdedTeamIndex((TeamIndex)newTeamIndex);
+        if (moddedTeamIndex >= _moddedTeamBehaviors.Length)
+        {
+            Array.Resize(ref _moddedTeamBehaviors, Math.Clamp(_moddedTeamBehaviors.Length * 2, moddedTeamIndex + 1, ModdedTeamCountLimit));
+        }
+
+        _moddedTeamBehaviors[moddedTeamIndex] = teamBehavior;
+
+        CompressedFlagArrayUtilities.AddImmutable(ref _allModdedTeamsDirtyBits, moddedTeamIndex);
+
+        return (TeamIndex)newTeamIndex;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="TeamBehavior"/> instance of a modded team
+    /// </summary>
+    /// <param name="teamIndex"></param>
+    /// <returns>The <see cref="TeamBehavior"/> instance of the modded team associated with <paramref name="teamIndex"/>, or <see langword="null"/> if <paramref name="teamIndex"/> is a vanilla team or outside the bounds of modded teams</returns>
+    [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+    public static TeamBehavior GetTeamBehavior(TeamIndex teamIndex)
+    {
+        int moddedTeamIndex = GetModdedTeamIndex(teamIndex);
+        if (moddedTeamIndex < 0)
+            return null;
+
+        return ArrayUtils.GetSafe(_moddedTeamBehaviors, moddedTeamIndex);
+    }
+
+    /// <summary>
+    /// Determines how a team should behave and interact with the game.
+    /// </summary>
+    /// <remarks>
+    /// Properties that support changing mid-game are marked <see langword="virtual"/>, inherit this class to implement custom behavior for them.
+    /// </remarks>
+    public class TeamBehavior
+    {
+        /// <summary>
+        /// The internal name of this team, used in place of an enum string representation
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// What vanilla team's behavior this team should be based on
+        /// </summary>
+        public TeamClassification Classification { get; }
+
+        /// <summary>
+        /// The layer used by members of this team, returned by <see cref="LayerIndex.GetAppropriateLayerForTeam(TeamIndex)"/> for the TeamIndex assigned to this team
+        /// </summary>
+        public virtual LayerIndex TeamLayer => (Classification & TeamClassification.Player) != 0 ? LayerIndex.playerBody : LayerIndex.enemyBody;
+
+        /// <summary>
+        /// The fake layer used by members of this team, returned by <see cref="LayerIndex.GetAppropriateFakeLayerForTeam(TeamIndex)"/> for the TeamIndex assigned to this team
+        /// </summary>
+        public virtual LayerIndex TeamFakeLayer => (Classification & TeamClassification.Player) != 0 ? LayerIndex.playerFakeActor : LayerIndex.fakeActor;
+
+        /// <summary>
+        /// Constructs a <see cref="TeamBehavior"/> with all required values set
+        /// </summary>
+        /// <param name="name">The internal name of this team, used in place of an enum string representation</param>
+        /// <param name="teamClassification">What vanilla team's behavior this team should be based on</param>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/>, empty, or contains only whitespace characters.</exception>
+        [SuppressMessage("Design", "R2APISubmodulesAnalyzer:Public API Method is not enabling the hooks if needed.", Justification = "Hooks are not necessary here")]
+        public TeamBehavior(string name, TeamClassification teamClassification)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException($"'{nameof(name)}' cannot be null or whitespace.", nameof(name));
+
+            Name = name;
+            Classification = teamClassification;
+        }
+    }
+
+    /// <summary>
+    /// What vanilla team's behavior a modded team should be based on
+    /// </summary>
+    [Flags]
+    public enum TeamClassification
+    {
+        /// <summary>
+        /// No behavior is shared
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Certain behavior is shared with <see cref="TeamIndex.Neutral"/>
+        /// </summary>
+        /// <remarks>
+        /// If set, a team will not be added to <see cref="TeamMask.allButNeutral"/>
+        /// </remarks>
+        Neutral = 1 << 0,
+
+        /// <summary>
+        /// Certain behavior is shared with any non-player, non-neutral teams
+        /// </summary>
+        /// <remarks>
+        /// Not currently implemented
+        /// </remarks>
+        Enemy = 1 << 1,
+
+        /// <summary>
+        /// Certain behavior is shared with <see cref="TeamIndex.Player"/>
+        /// </summary>
+        /// <remarks>
+        /// Default implementation of <see cref="TeamBehavior.TeamLayer"/> and <see cref="TeamBehavior.TeamFakeLayer"/> checks against this for determining desired layer
+        /// </remarks>
+        Player = 1 << 2,
+    }
+    #endregion
+}

--- a/R2API.Teams/TeamsAPI.cs
+++ b/R2API.Teams/TeamsAPI.cs
@@ -367,7 +367,11 @@ public static partial class TeamsAPI
         orig(self);
     }
 
-    // Purpose: Replace 'base.SetDirtyBit(1U << (int)teamIndex)' with custom implementation for modded teams
+    // Purpose: Replace 'base.SetDirtyBit(1U << (int)teamIndex)' with
+    // if (IsModdedTeam(teamIndex))
+    //     setModdedTeamDirtyBit(this, teamIndex);
+    // else
+    //     base.SetDirtyBit(1U << (int)teamIndex)
     static void TeamManager_SetTeamExperience(ILContext il)
     {
         ILCursor c = new ILCursor(il);

--- a/R2API.Teams/TeamsAPI.cs
+++ b/R2API.Teams/TeamsAPI.cs
@@ -28,7 +28,7 @@ public static partial class TeamsAPI
     public const string PluginName = R2API.PluginName + ".Teams";
 
     /// <summary>
-    /// The absolute maximum amount of teams there that can be in the catalog
+    /// The absolute maximum amount of teams there can be in the catalog
     /// </summary>
     public static int TeamCountLimit => sbyte.MaxValue - 1;
 
@@ -38,7 +38,7 @@ public static partial class TeamsAPI
     public static int TeamCount => TeamCatalog.teamDefs.Length;
 
     /// <summary>
-    /// The absolute maximum amount of modded teams that can be in the catalog
+    /// The absolute maximum amount of modded teams there can be in the catalog
     /// </summary>
     public static int ModdedTeamCountLimit => TeamCountLimit - _vanillaTeamsCount;
 

--- a/R2API.Teams/TeamsAPI.cs
+++ b/R2API.Teams/TeamsAPI.cs
@@ -445,7 +445,7 @@ public static partial class TeamsAPI
             {
                 if (initialState || CompressedFlagArrayUtilities.Has(dirtyModdedTeamsBits, i))
                 {
-                    writer.WritePackedUInt64(self.teamExperience[_vanillaTeamsCount + i]);
+                    writer.WritePackedUInt64(self.teamExperience[(int)GetTeamIndex(i)]);
                 }
             }
 

--- a/R2API.Teams/TeamsAPINetworkExtensions.cs
+++ b/R2API.Teams/TeamsAPINetworkExtensions.cs
@@ -1,0 +1,47 @@
+﻿using RoR2;
+using UnityEngine.Networking;
+
+namespace R2API.Utils;
+
+/// <summary>
+/// Network extensions for TeamsAPI
+/// </summary>
+public static class TeamsAPINetworkExtensions
+{
+    /// <summary>
+    /// Writes a <see cref="TeamMask"/> to a network buffer
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="teamMask"></param>
+    public static void Write(this NetworkWriter writer, in TeamMask teamMask)
+    {
+        writer.Write(teamMask.a);
+
+        if (TeamsAPI.ModdedTeamCount > 0)
+        {
+            CompressedFlagArrayUtilities.WriteToNetworkWriter(TeamsInterop.GetModdedMask(teamMask) ?? [], writer, TeamsAPI.ModdedTeamCount);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="TeamMask"/> from a network buffer
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <returns></returns>
+    public static TeamMask ReadTeamMask(this NetworkReader reader)
+    {
+        TeamMask teamMask = new TeamMask();
+        teamMask.a = reader.ReadByte();
+
+        if (TeamsAPI.ModdedTeamCount > 0)
+        {
+            byte[] moddedTeamsMask = CompressedFlagArrayUtilities.ReadFromNetworkReader(reader, TeamsAPI.ModdedTeamCount);
+            if (moddedTeamsMask != null && moddedTeamsMask.Length > 0)
+            {
+                TeamsInterop.SetModdedMask(ref teamMask, moddedTeamsMask);
+            }
+        }
+
+        return teamMask;
+    }
+}

--- a/R2API.Teams/TeamsPlugin.cs
+++ b/R2API.Teams/TeamsPlugin.cs
@@ -1,0 +1,24 @@
+﻿using BepInEx;
+
+namespace R2API;
+
+[BepInPlugin(TeamsAPI.PluginGUID, TeamsAPI.PluginName, TeamsAPI.PluginVersion)]
+public sealed class TeamsPlugin : BaseUnityPlugin
+{
+    void Awake()
+    {
+        Log.Init(Logger);
+
+        TeamsAPI.Init();
+
+#if DEBUG
+        // Enable hooks immediately for debugging
+        TeamsAPI.SetHooks();
+#endif
+    }
+
+    void OnDestroy()
+    {
+        TeamsAPI.UnsetHooks();
+    }
+}

--- a/R2API.Teams/thunderstore.toml
+++ b/R2API.Teams/thunderstore.toml
@@ -1,0 +1,42 @@
+
+[config]
+schemaVersion = "0.0.1"
+
+[package]
+namespace = "RiskofThunder"
+name = "R2API_Teams"
+versionNumber = "1.0.0"
+description = "API for registering and handling custom teams"
+websiteUrl = "https://github.com/risk-of-thunder/R2API"
+containsNsfwContent = false
+
+[package.dependencies]
+bbepis-BepInExPack = "5.4.2109"
+RiskofThunder-HookGenPatcher = "1.2.3"
+RiskofThunder-R2API_Core = "5.1.7"
+
+[build]
+icon = "../icon.png"
+readme = "./README.md"
+outdir = "./build"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.Teams.dll"
+target = "./plugins/R2API.Teams/R2API.Teams.dll"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.Teams.xml"
+target = "./plugins/R2API.Teams/R2API.Teams.xml"
+
+[[build.copy]]
+source = "../R2API.Teams.Interop/ReleaseOutput/R2API.Teams.Interop.dll"
+target = "./plugins/R2API.Teams/R2API.Teams.Interop.dll"
+
+[[build.copy]]
+source = "../R2API.Teams.Patcher/ReleaseOutput/R2API.Teams.Patcher.dll"
+target = "./patchers/R2API.Teams/R2API.Teams.Patcher.dll"
+
+[publish]
+repository = "https://thunderstore.io"
+communities = ["riskofrain2"]
+categories = ["libraries"]

--- a/R2API.sln
+++ b/R2API.sln
@@ -127,6 +127,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Skins.Patcher", "R2AP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Skins.Interop", "R2API.Skins.Interop\R2API.Skins.Interop.csproj", "{5CD82D06-22F1-4F28-8340-4F6D3448BDE9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Teams", "R2API.Teams\R2API.Teams.csproj", "{DE9CB919-E7A4-A858-2133-F31E54CCFCB0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Teams.Interop", "R2API.Teams.Interop\R2API.Teams.Interop.csproj", "{9182FF4A-9015-C09A-7609-3A23457F5202}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Teams.Patcher", "R2API.Teams.Patcher\R2API.Teams.Patcher.csproj", "{682E79EF-4429-FB40-9BF6-63D133C2EF04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -337,6 +343,18 @@ Global
 		{5CD82D06-22F1-4F28-8340-4F6D3448BDE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CD82D06-22F1-4F28-8340-4F6D3448BDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CD82D06-22F1-4F28-8340-4F6D3448BDE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE9CB919-E7A4-A858-2133-F31E54CCFCB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE9CB919-E7A4-A858-2133-F31E54CCFCB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE9CB919-E7A4-A858-2133-F31E54CCFCB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE9CB919-E7A4-A858-2133-F31E54CCFCB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9182FF4A-9015-C09A-7609-3A23457F5202}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9182FF4A-9015-C09A-7609-3A23457F5202}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9182FF4A-9015-C09A-7609-3A23457F5202}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9182FF4A-9015-C09A-7609-3A23457F5202}.Release|Any CPU.Build.0 = Release|Any CPU
+		{682E79EF-4429-FB40-9BF6-63D133C2EF04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{682E79EF-4429-FB40-9BF6-63D133C2EF04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{682E79EF-4429-FB40-9BF6-63D133C2EF04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{682E79EF-4429-FB40-9BF6-63D133C2EF04}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RoR2.Patched/TeamMask.cs
+++ b/RoR2.Patched/TeamMask.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RoR2;
+
+public struct TeamMask
+{
+    public byte[] r2api_moddedMask;
+}


### PR DESCRIPTION
Allows for addition of modded Teams.

There is a hard limit of how many teams can be added due to TeamIndex being backed by an sbyte, though this limit is 121 with the current amount of vanilla teams, so it really shouldn't be an issue. There is potential to double the team limit by using the negative values of TeamIndex (-128 ... -2), though this would require significant patching for proper overflow handling, so I didn't deem it necessary for now.

For compatibility purposes, EnumPatcher allows Enum.Parse/ToString/GetValues/GetNames/etc. to use modded TeamIndex entries as if they were vanilla ones.

I figured other modules could also make use of the EnumPatcher in the future, so it's in Core rather than Teams, so this does require a version bump of R2API.Core.