### PR TITLE
Fix Addressables submodule's 1.1.0 being completely broken

### DIFF
--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedAsset.cs
@@ -1,6 +1,8 @@
 ﻿using BepInEx;
+using HG.Coroutines;
 using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
 using UObject = UnityEngine.Object;
 
 namespace R2API.AddressReferencedAssets;
@@ -43,12 +46,10 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
              * In other cases, we'll just load the asset immediatly.
              */
 
-            //If we have the asset, just return it.
             if (_asset)
                 return _asset;
 
-            //If we're not past the loading screen, and it can load from catalog, log a warning. and try to load anyways.
-            if(!Initialized && CanLoadFromCatalog)
+            if (!Initialized && CanLoadFromCatalog)
             {
                 string typeName = GetType().Name;
                 var stackTrace = new StackTrace();
@@ -57,22 +58,20 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
                     $"\n Consider using AddressReferencedAssets.OnAddressReferencedAssetsLoaded for running code that depends on AddressableAssets! (Method: {method.DeclaringType.FullName}.{method.Name}()");
                 Load();
             }
-            else if(IsValidForLoadingWithAddress()) //If we can load from address, try to do it, unless we already failed.
+            else if (IsValidForLoadingWithAddress())
             {
-                if(_AddressFailedToLoad)
+                if (_AddressFailedToLoad)
                 {
                     AddressablesPlugin.Logger.LogWarning($"Not trying to load {this} because it's address has already failed to load beforehand. Null will be returned.");
-                    return null;
                 }
                 else
                 {
-                    //Load the asset NOW.
                     if(_asyncOperationHandle.IsValid())
                     {
                         _asset = _asyncOperationHandle.WaitForCompletion();
                         return _asset;
                     }
-                    LoadFromAddress();
+                    Load();
                     return _asset;
                 }
             }
@@ -86,6 +85,28 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
             _useDirectReference = _asset;
         }
     }
+
+    /// <summary>
+    /// <inheritdoc cref="AddressReferencedAsset.BoxedAsset"/>
+    /// </summary>
+    public override UObject BoxedAsset => _asset;
+
+    /// <summary>
+    /// <inheritdoc cref="AddressReferencedAsset.AsyncOperationHandle"/>
+    /// </summary>
+    public new AsyncOperationHandle<T> AsyncOperationHandle
+    {
+        get
+        {
+            return _asyncOperationHandle;
+        }
+        protected set
+        {
+            _asyncOperationHandle = value;
+            base.AsyncOperationHandle = value;
+        }
+    }
+    private AsyncOperationHandle<T> _asyncOperationHandle;
 
     /// <summary>
     /// Determines wether <see cref="Asset"/>'s backing field has a value.
@@ -112,7 +133,14 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
             _asset = null;
             _useDirectReference = false;
             _AddressFailedToLoad = false;
-            if(RoR2Application.loadFinished)
+
+            //Release the handle
+            if (_asyncOperationHandle.IsValid())
+            {
+                Addressables.Release(_asyncOperationHandle);
+            }
+
+            if (RoR2Application.loadFinished)
             {
                 Load();
             }
@@ -139,13 +167,13 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// <br>Mainly used for Editor related scripts</br>
     /// </summary>
     public bool UseDirectReference => _useDirectReference;
-    [SerializeField,HideInInspector] private bool _useDirectReference;
+    [SerializeField, HideInInspector] private bool _useDirectReference;
 
     /// <summary>
     /// Wether this AddressReferencedAsset can load an Asset using the game's catalogues.
     /// <br>If this is true, you're encouraged to wait for AddressReferencedAsset to initialize fully using <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/></br>
     /// </summary>
-    public virtual bool CanLoadFromCatalog { get; } = false;
+    public virtual bool CanLoadFromCatalog { get; protected set; } = false;
 
     private bool _AddressFailedToLoad;
 
@@ -153,13 +181,11 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     {
         return !_asset && !string.IsNullOrEmpty(_address);
     }
-    /// <summary>
-    /// Loads the asset asynchronously if <see cref="Asset"/> is not null and <see cref="Address"/> is not null or empty.
-    /// <br>This is automatically called by the AddressReferencedAsset system and should not be called manually.</br>
-    /// </summary>
+
+    [Obsolete("Call \"LoadAssetAsyncCoroutine()\" instead.")]
     protected sealed override async Task LoadAssetAsync()
     {
-        if(IsValidForLoadingWithAddress())
+        if (IsValidForLoadingWithAddress())
         {
             await LoadAsync();
         }
@@ -171,10 +197,10 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// <returns>A Coroutine, which can be awaited</returns>
     protected sealed override IEnumerator LoadAssetAsyncCoroutine()
     {
-        if(IsValidForLoadingWithAddress())
+        if (IsValidForLoadingWithAddress())
         {
             var coroutine = LoadAsyncCoroutine();
-            while(coroutine.MoveNext())
+            while (coroutine.MoveNext())
             {
                 yield return null;
             }
@@ -182,12 +208,12 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     }
 
     /// <summary>
-    /// Loads the asset immediatly, instead of relying on <see cref="Asset"/>'s safety rails.
+    /// Loads the asset immediatly, instead of awaiting for <see cref="AddressReferencedAsset.OnAddressReferencedAssetsLoaded"/>
     /// </summary>
     /// <returns>The loaded asset, or null if no asset was found.</returns>
     public T LoadAssetNow()
     {
-        if(!AssetExists)
+        if (!AssetExists)
             Load();
 
         return Asset;
@@ -204,10 +230,10 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// <returns>Yield returns null until the asset is loaded, afterwards it returns </returns>
     public virtual IEnumerator LoadAssetNowCoroutine(Action<T> onLoaded)
     {
-        if(!AssetExists)
+        if (!AssetExists)
         {
             var loadCoroutine = LoadAsyncCoroutine();
-            while(loadCoroutine.MoveNext())
+            while (loadCoroutine.MoveNext())
             {
                 yield return null;
             }
@@ -228,6 +254,17 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// <summary>
     /// Implement how the Asset of type <typeparamref name="T"/> is loaded asynchronously when <see cref="Asset"/> is null
     /// </summary>
+    /// <returns></returns>
+    protected virtual IEnumerator LoadAsyncCoroutine()
+    {
+        var loadCoroutine = LoadFromAddressAsyncCoroutine();
+        while (loadCoroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Use \"LoadAsyncCoroutine()\" Instead")]
     protected virtual async Task LoadAsync()
     {
         await LoadFromAddressAsync();
@@ -238,29 +275,27 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// </summary>
     protected IEnumerator LoadFromAddressAsyncCoroutine()
     {
-        if(addressesThatFailedToBeValidated.Contains(_address))
-        {
+        if (addressesThatFailedToBeValidated.Contains(_address))
             yield break;
-        }
 
         bool? result = null;
         IEnumerator<bool?> addressValidCoroutine = IsAdressValidAsync();
-        while(addressValidCoroutine.MoveNext())
+        while (result != null && addressValidCoroutine.MoveNext())
         {
             result = addressValidCoroutine.Current;
-            yield return null;
         }
 
         result ??= false;
-        if(result == false)
+        if (result == false)
         {
-            AddressablesPlugin.Logger.LogWarning($"{this} failed to load from it's address because the address is either invalid, or malformed. Any other attempt at loading the address {_address} will be ignored.");
+            AddressablesPlugin.Logger.LogWarning($"{this} failed to load from it's address because the address is either invalid, or malformed.");
             addressesThatFailedToBeValidated.Add(_address);
             _AddressFailedToLoad = true;
+            yield break;
         }
 
         AsyncOperationHandle = Addressables.LoadAssetAsync<T>(_address);
-        while(!AsyncOperationHandle.IsDone)
+        while (!AsyncOperationHandle.IsDone)
         {
             yield return null;
         }
@@ -270,30 +305,27 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     [Obsolete("Use \"LoadFromAdressAsyncCoroutine\" Instead")]
     protected async Task LoadFromAddressAsync()
     {
-        if(addressesThatFailedToBeValidated.Contains(_address))
-        {
-            return;
-        }
-
         bool? result = null;
         IEnumerator<bool?> coroutine = IsAdressValidAsync();
-        while (coroutine.MoveNext())
+        while (result != null)
         {
-            result = coroutine.Current;
-            if (result != null)
-                break;
+            if (coroutine.MoveNext())
+            {
+                result = coroutine.Current;
+            }
+            break;
         }
 
-        result ??= false;
-        if(result == false)
+        if (result == false)
         {
-            AddressablesPlugin.Logger.LogWarning($"{this} failed to load from it's address because the address is either invalid, or malformed. Any other attempt at loading the address {_address} will be ignored.");
+            AddressablesPlugin.Logger.LogWarning($"{this} failed to load from it's address because the address is either invalid, or malformed.");
             addressesThatFailedToBeValidated.Add(_address);
             _AddressFailedToLoad = true;
             return;
         }
 
-        var task = Addressables.LoadAssetAsync<T>(_address).Task;
+        AsyncOperationHandle = Addressables.LoadAssetAsync<T>(_address);
+        var task = AsyncOperationHandle.Task;
         _asset = await task;
     }
 
@@ -302,35 +334,54 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
     /// </summary>
     protected void LoadFromAddress()
     {
-        if(!IsAddressValid())
+        if (!IsAddressValid())
         {
             AddressablesPlugin.Logger.LogWarning($"{this} failed to load from it's address because the address is either invalid, or malformed.");
             _AddressFailedToLoad = true;
+            addressesThatFailedToBeValidated.Add(_address);
             return;
         }
-        _asset = Addressables.LoadAssetAsync<T>(_address).WaitForCompletion();
+        AsyncOperationHandle = Addressables.LoadAssetAsync<T>(_address);
+        _asset = AsyncOperationHandle.WaitForCompletion();
     }
 
     private bool IsAddressValid()
     {
         var location = Addressables.LoadResourceLocationsAsync(_address).WaitForCompletion();
 
-        AddressablesPlugin.Logger.LogFatal($"Location for address {Address} exists?: {location.Any()}");
         return location.Any();
     }
 
-    private async Task<bool> IsAddressValidAsync()
+    private IEnumerator<bool?> IsAdressValidAsync()
     {
-        yield return null;
-
         var locationTask = Addressables.LoadResourceLocationsAsync(_address);
-        var result = await locationTask.Task;
-        return result.Any();
+        while (!locationTask.IsDone)
+        {
+            yield return null;
+        }
+
+        var result = locationTask.Result;
+        yield return result.Any();
     }
 
+    /// <summary>
+    /// Returns a human readable representation of this AddressReferencedAsset
+    /// </summary>
+    /// <returns></returns>
     public override string ToString()
     {
         return $"{GetType().Name}(Asset={(_asset ? _asset : "null")}.Address={Address}";
+    }
+
+    /// <summary>
+    /// Calls <see cref="Addressables.Release{TObject}(AsyncOperationHandle{TObject})"/> on <see cref="AsyncOperationHandle"/>
+    /// </summary>
+    public override void Dispose()
+    {
+        if (AsyncOperationHandle.IsValid())
+        {
+            Addressables.Release(AsyncOperationHandle);
+        }
     }
 
     /// <summary>
@@ -414,11 +465,15 @@ public class AddressReferencedAsset<T> : AddressReferencedAsset where T : UObjec
 /// A <see cref="AddressReferencedAsset"/> is a class that's used for referencing assets ingame.
 /// <br>You're strongly adviced to use <see cref="AddressReferencedAsset{T}"/> instead.</br> 
 /// </summary>
-public abstract class AddressReferencedAsset
+public abstract class AddressReferencedAsset : IDisposable
 {
-    [Obsolete("Instances of AddressReferencedAssets are no longer used.")]
+    protected static readonly HashSet<string> addressesThatFailedToBeValidated = new HashSet<string>();
     protected static readonly HashSet<AddressReferencedAsset> instances = new();
-    protected static readonly HashSet<string> addressesThatFailedToBeValidated = new();
+
+    /// <summary>
+    /// The asset loaded, boxed inside a regular unity object.
+    /// </summary>
+    public abstract UObject BoxedAsset { get; }
 
     /// <summary>
     /// Wether or not the <see cref="AddressReferencedAsset"/> system has initialized.
@@ -431,17 +486,25 @@ public abstract class AddressReferencedAsset
     public static event Action OnAddressReferencedAssetsLoaded;
 
     /// <summary>
+    /// An exposure to the internal AsyncOperationHandle, this operation handle is only valid if the object was loaded via an address.
+    /// </summary>
+    public AsyncOperationHandle AsyncOperationHandle { get; protected set; }
+
+    /// <summary>
     /// Sets hooks for the AddressReferencedSystem, any constructor from classes inheriting <see cref="AddressReferencedAsset"/> must call it.
     /// </summary>
     protected void SetHooks()
     {
-        if(RoR2Application.loadFinished)
+        if (RoR2Application.loadFinished)
         {
             CallInitialized();
+            //StartCoroutineOnLoad();
             return;
         }
         RoR2Application.onLoad -= CallInitialized;
         RoR2Application.onLoad += CallInitialized;
+        //RoR2Application.onLoad -= StartCoroutineOnLoad;
+        //RoR2Application.onLoad += StartCoroutineOnLoad;
     }
 
     /// <summary>
@@ -451,12 +514,82 @@ public abstract class AddressReferencedAsset
     {
         if (!RoR2Application.loadFinished)
             RoR2Application.onLoad -= CallInitialized;
+            //RoR2Application.onLoad -= StartCoroutineOnLoad;
     }
 
     private void CallInitialized()
     {
+        if (_initialized)
+            return;
+
+        AddressablesPlugin.Logger.LogMessage("AddressReferencedAssets initialized");
         _initialized = true;
         OnAddressReferencedAssetsLoaded?.Invoke();
     }
+
+    private void StartCoroutineOnLoad()
+    {
+        AddressablesPlugin.Instance.StartCoroutine(LoadReferencesAsync());
+    }
+
+    private static IEnumerator LoadReferencesAsync()
+    {
+        ParallelCoroutine parallelCoroutine = new ParallelCoroutine();
+        foreach (var instance in instances)
+        {
+            if (instance.BoxedAsset)
+            {
+                continue;
+            }
+
+            parallelCoroutine.Add(instance.LoadAssetAsyncCoroutine());
+        }
+
+        while (parallelCoroutine.MoveNext())
+        {
+            yield return null;
+        }
+
+        //Backwards compat for the task version.
+        List<Task> tasks = new List<Task>();
+        foreach (AddressReferencedAsset instance in instances)
+        {
+            if (instance.BoxedAsset)
+            {
+                continue;
+            }
+
+            tasks.Add(instance.LoadAssetAsync());
+        }
+
+        var supertask = Task.WhenAll(tasks);
+        while (!supertask.IsCompleted)
+        {
+            yield return null;
+        }
+
+        _initialized = true;
+        OnAddressReferencedAssetsLoaded?.Invoke();
+    }
+
+    [Obsolete("If you need to implement this, implement a method that just returns Task.CompeltedTask, loading is now done via LoadAssetAsyncCoroutine instead.")]
     protected abstract Task LoadAssetAsync();
+
+    /// <summary>
+    /// Implement how the asset is loaded asynchronously using a coroutine
+    /// </summary>
+    protected abstract IEnumerator LoadAssetAsyncCoroutine();
+
+#pragma warning disable R2APISubmodulesAnalyzer
+    /// <summary>
+    /// Calls <see cref="Addressables.Release{TObject}(AsyncOperationHandle{TObject})"/> on <see cref="AsyncOperationHandle"/>
+    /// </summary>
+    public virtual void Dispose()
+    {
+        if (AsyncOperationHandle.IsValid())
+        {
+            Addressables.Release(AsyncOperationHandle);
+        }
+    }
+#pragma warning restore R2APISubmodulesAnalyzer
 }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedBuffDef.cs
@@ -1,8 +1,10 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -14,25 +16,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedBuffDef : AddressReferencedAsset<BuffDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
+
+    [SerializeField, HideInInspector]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if (index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while (subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
-        if (index != BuffIndex.None)
+        if (CanLoadFromCatalog)
         {
-            Asset = BuffCatalog.GetBuffDef(index);
-            return;
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if (index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        BuffIndex index = BuffCatalog.FindBuffIndex(Address);
-        if (index != BuffIndex.None)
+        if (CanLoadFromCatalog)
         {
-            Asset = BuffCatalog.GetBuffDef(index);
-            return;
+            BuffIndex index = BuffCatalog.FindBuffIndex(Address);
+            if (index != BuffIndex.None)
+            {
+                Asset = BuffCatalog.GetBuffDef(index);
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEliteDef.cs
@@ -1,10 +1,13 @@
-﻿using RoR2;
+﻿
+using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -16,25 +19,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEliteDef : AddressReferencedAsset<EliteDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
+
+    [SerializeField, HideInInspector]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while (subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (def != null)
+        if (CanLoadFromCatalog)
         {
-            Asset = def;
-            return;
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (def != null)
+        if (CanLoadFromCatalog)
         {
-            Asset = def;
-            return;
+            EliteDef def = EliteCatalog.eliteDefs.FirstOrDefault(x => x.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (def != null)
+            {
+                Asset = def;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedEquipmentDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,25 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedEquipmentDef : AddressReferencedAsset<EquipmentDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
+
+    [SerializeField, HideInInspector]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while (subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead.")]
     protected override async Task LoadAsync()
     {
-        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
-        if (index != EquipmentIndex.None)
+        if (CanLoadFromCatalog)
         {
-            Asset = EquipmentCatalog.GetEquipmentDef(index);
-            return;
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
-        if (index != EquipmentIndex.None)
+        if (CanLoadFromCatalog)
         {
-            Asset = EquipmentCatalog.GetEquipmentDef(index);
-            return;
+            EquipmentIndex index = EquipmentCatalog.FindEquipmentIndex(Address);
+            if (index != EquipmentIndex.None)
+            {
+                Asset = EquipmentCatalog.GetEquipmentDef(index);
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedExpansionDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2.ExpansionManagement;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,24 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedExpansionDef : AddressReferencedAsset<ExpansionDef>
 {
-    public override bool CanLoadFromCatalog => true;
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
 
+    [SerializeField, HideInInspector]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while (subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (expansionDef != null)
+        if (CanLoadFromCatalog)
         {
-            Asset = expansionDef;
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
-        if (expansionDef != null)
+        if (CanLoadFromCatalog)
         {
-            Asset = expansionDef;
+            ExpansionDef expansionDef = ExpansionCatalog.expansionDefs.FirstOrDefault(ed => ed.name.Equals(Address, StringComparison.OrdinalIgnoreCase));
+            if (expansionDef != null)
+            {
+                Asset = expansionDef;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
+++ b/R2API.Addressables/AddressReferencedAssets/AddressReferencedUnlockableDef.cs
@@ -1,9 +1,11 @@
 ﻿using RoR2;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace R2API.AddressReferencedAssets;
 
@@ -15,24 +17,54 @@ namespace R2API.AddressReferencedAssets;
 [Serializable]
 public class AddressReferencedUnlockableDef : AddressReferencedAsset<UnlockableDef>
 {
+    public override bool CanLoadFromCatalog { get => _canLoadFromCatalog; protected set => _canLoadFromCatalog = value; }
+
+    [SerializeField, HideInInspector]
+    private bool _canLoadFromCatalog = true;
+
+    protected override IEnumerator LoadAsyncCoroutine()
+    {
+        if (CanLoadFromCatalog)
+        {
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                yield break;
+            }
+        }
+        var subroutine = LoadFromAddressAsyncCoroutine();
+        while (subroutine.MoveNext())
+        {
+            yield return null;
+        }
+    }
+
+    [Obsolete("Call LoadAsyncCoroutine instead")]
     protected override async Task LoadAsync()
     {
-        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
-        if (unlockable)
+        if (CanLoadFromCatalog)
         {
-            Asset = unlockable;
-            return;
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                return;
+            }
         }
         await LoadFromAddressAsync();
     }
 
     protected override void Load()
     {
-        UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
-        if (unlockable)
+        if (CanLoadFromCatalog)
         {
-            Asset = unlockable;
-            return;
+            UnlockableDef unlockable = UnlockableCatalog.GetUnlockableDef(Address);
+            if (unlockable)
+            {
+                Asset = unlockable;
+                return;
+            }
         }
         LoadFromAddress();
     }

--- a/R2API.Addressables/AddressablesPlugin.cs
+++ b/R2API.Addressables/AddressablesPlugin.cs
@@ -15,8 +15,11 @@ public sealed partial class AddressablesPlugin : BaseUnityPlugin
     public const string PluginName = R2API.PluginName + ".Addressables";
     internal static new ManualLogSource Logger { get; set; }
 
+    public static AddressablesPlugin Instance { get; private set; }
+
     private void Awake()
     {
         Logger = base.Logger;
+        Instance = this;
     }
 }

--- a/R2API.Addressables/README.md
+++ b/R2API.Addressables/README.md
@@ -8,6 +8,10 @@ Currently it adds the AddressReferencedAsset system, which allows you on the Edi
 
 ## Changelog
 
+### '1.1.2'
+
+* Reimplemented version '1.1.0' with fixes, changes and improvements.
+
 ### '1.1.1'
 
 * Revert 1.1.0

--- a/R2API.Director/AddressableDCCSPool.cs
+++ b/R2API.Director/AddressableDCCSPool.cs
@@ -37,9 +37,16 @@ public class AddressableDCCSPool : ScriptableObject
 
     private void Upgrade()
     {
-        DccsPool.Category[] categories = poolCategories.Select(x => x.Upgrade()).ToArray();
-        targetPool.poolCategories = categories;
-        poolCategories = null;
+        try
+        {
+            DccsPool.Category[] categories = poolCategories.Select(x => x.Upgrade()).ToArray();
+            targetPool.poolCategories = categories;
+            poolCategories = null;
+        }
+        catch(Exception e)
+        {
+            DirectorPlugin.Logger.LogError($"{this} failed to upgrade.\n{e}");
+        }
     }
 
     private void Awake() => instances.Add(this);

--- a/R2API.Director/AddressableDCCSPool.cs
+++ b/R2API.Director/AddressableDCCSPool.cs
@@ -1,5 +1,6 @@
 ﻿using R2API.AddressReferencedAssets;
 using RoR2;
+using RoR2.ExpansionManagement;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,23 +31,36 @@ public class AddressableDCCSPool : ScriptableObject
         {
             foreach (var instance in instances)
             {
-                instance.Upgrade();
+                try
+                {
+                    instance.Upgrade();
+                }
+                catch(Exception ex)
+                {
+                    DirectorPlugin.Logger.LogError($"{instance} failed to upgrade.\n{ex}");
+                }
             }
         };
     }
 
     private void Upgrade()
     {
-        try
+        List<DccsPool.Category> upgradedCategories = new List<DccsPool.Category>();
+        for (int i = 0; i < poolCategories.Length; i++)
         {
-            DccsPool.Category[] categories = poolCategories.Select(x => x.Upgrade()).ToArray();
-            targetPool.poolCategories = categories;
-            poolCategories = null;
+            Category cat = poolCategories[i];
+            var result = cat?.Upgrade();
+
+            if(result == null)
+            {
+                DirectorPlugin.Logger.LogWarning($"{this}'s {i}th index of categories failed to upgrade.");
+                continue;
+            }
+
+            upgradedCategories.Add(result);
         }
-        catch(Exception e)
-        {
-            DirectorPlugin.Logger.LogError($"{this} failed to upgrade.\n{e}");
-        }
+        targetPool.poolCategories = upgradedCategories.ToArray();
+        poolCategories = null;
     }
 
     private void Awake() => instances.Add(this);
@@ -68,11 +82,22 @@ public class AddressableDCCSPool : ScriptableObject
 
         internal virtual DccsPool.PoolEntry Upgrade()
         {
+
             return new DccsPool.PoolEntry
             {
-                dccs = familyDccs.AssetExists ? familyDccs.Asset : dccs.targetCardCategorySelection,
+                dccs = GetDirectorCardCategorySelection(),
                 weight = weight
             };
+        }
+
+        protected DirectorCardCategorySelection GetDirectorCardCategorySelection()
+        {
+            var familyDccsResult = familyDccs.Asset;
+
+            if (familyDccsResult)
+                return familyDccsResult;
+
+            return dccs.targetCardCategorySelection;
         }
     }
 
@@ -88,12 +113,25 @@ public class AddressableDCCSPool : ScriptableObject
 
         internal override DccsPool.PoolEntry Upgrade()
         {
-            return new DccsPool.ConditionalPoolEntry
+            var result = new DccsPool.ConditionalPoolEntry
             {
-                dccs = familyDccs.AssetExists ? familyDccs.Asset : dccs.targetCardCategorySelection,
-                requiredExpansions = requiredExpansions.Select(x => x.Asset).ToArray(),
+                dccs = GetDirectorCardCategorySelection(),
                 weight = weight
             };
+
+            var expansionDefs = new List<ExpansionDef>();
+
+            foreach (var def in requiredExpansions)
+            {
+                var asset = def.Asset;
+                if (!asset)
+                    continue;
+
+                expansionDefs.Add(asset);
+            }
+            result.requiredExpansions = expansionDefs.ToArray();
+
+            return result;
         }
     }
 
@@ -116,14 +154,64 @@ public class AddressableDCCSPool : ScriptableObject
 
         internal DccsPool.Category Upgrade()
         {
-            return new DccsPool.Category
+            var resultCategory = new DccsPool.Category
             {
                 name = name,
                 categoryWeight = categoryWeight,
-                alwaysIncluded = alwaysIncluded.Select(x => x.Upgrade()).ToArray(),
-                includedIfConditionsMet = includedIfConditionsMet.Select(x => x.Upgrade()).Cast<DccsPool.ConditionalPoolEntry>().ToArray(),
-                includedIfNoConditionsMet = includedIfNoConditionsMet.Select(x => x.Upgrade()).ToArray()
             };
+
+            List<DccsPool.PoolEntry> upgradedPoolEntries = new List<DccsPool.PoolEntry>();
+            List<DccsPool.ConditionalPoolEntry> upgradedConditionalPoolEntries = new List<DccsPool.ConditionalPoolEntry>();
+
+            foreach (var alwaysIncluded in alwaysIncluded)
+            {
+                var result = alwaysIncluded.Upgrade();
+                if (result == null)
+                    continue;
+
+                if (!result.dccs)
+                    continue;
+
+                upgradedPoolEntries.Add(result);
+            }
+            resultCategory.alwaysIncluded = upgradedPoolEntries.ToArray();
+
+            foreach (var conditionallyIncluded in includedIfConditionsMet)
+            {
+                var result = conditionallyIncluded.Upgrade();
+
+                if (result == null)
+                    continue;
+
+                if (result is not DccsPool.ConditionalPoolEntry _conditionalPoolEntry)
+                    continue;
+
+                if (!_conditionalPoolEntry.dccs)
+                    continue;
+
+                if (_conditionalPoolEntry.requiredExpansions == null || _conditionalPoolEntry.requiredExpansions.Length == 0 || !_conditionalPoolEntry.requiredExpansions.Any())
+                    continue;
+
+                upgradedConditionalPoolEntries.Add(_conditionalPoolEntry);
+            }
+            resultCategory.includedIfConditionsMet = upgradedConditionalPoolEntries.ToArray();
+
+            upgradedPoolEntries.Clear();
+            foreach (var noConditionsMet in includedIfNoConditionsMet)
+            {
+                var result = noConditionsMet.Upgrade();
+
+                if (result == null)
+                    continue;
+
+                if (!result.dccs)
+                    continue;
+
+                upgradedPoolEntries.Add(result);
+            }
+            resultCategory.includedIfNoConditionsMet = upgradedPoolEntries.ToArray();
+
+            return resultCategory;
         }
     }
 }

--- a/R2API.Director/AddressableDirectorCardCategorySelection.cs
+++ b/R2API.Director/AddressableDirectorCardCategorySelection.cs
@@ -27,8 +27,15 @@ public class AddressableDirectorCardCategorySelection : ScriptableObject
 
     private void Upgrade()
     {
-        targetCardCategorySelection.categories = categories.Select(x => x.Upgrade()).ToArray();
-        categories = null;
+        try
+        {
+            targetCardCategorySelection.categories = categories.Select(x => x.Upgrade()).ToArray();
+            categories = null;
+        }
+        catch (Exception e)
+        {
+            DirectorPlugin.Logger.LogError($"{this} failed to upgrade.\n{e}");
+        }
     }
 
     private void Awake() => instances.Add(this);

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,10 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.3.6'
+* Both AddressableDirectorCardCategorySelection and AddressableDCCSPool now have more intricate validation during upgrading process.
+  * This means that they should catch issues such as invalid spawn cards, invalid addresses and more.
+
 ### '2.3.5'
 * Added MixEnemiesDccsActions action that would allow interaction with MixEnemy artifact DCCS replacement.
 

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.5"
+versionNumber = "2.3.6"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
This is a proper fix for 1.1.0 after coming back from PAX WEST.

This has been tested against a 350+ mod profile with multiple different mods that may use both the director plugin and the addressables plugin. No major issues where spotted during testing.

The intense log spam reported by one of the members of the modcord has been fixed, it was caused by a run-away call of the onAddressablesAssetsInitialized event being called multiple times.

----
For the director, i've proceeded to unwind the LINQ calls into proper calls that should fail gracefully if something goes wrong, for example, even if an old map tries to load the old cscBeetle using its old path address, it will fail to add it to the dccs but it wont crash the game.