### PR TITLE
Fix ambiguity in DotAPI methods

### DIFF
--- a/R2API.Dot/DotAPI.cs
+++ b/R2API.Dot/DotAPI.cs
@@ -137,7 +137,7 @@ public static partial class DotAPI
     /// <param name="customDotVisual"></param>
     /// <returns></returns>
     public static DotController.DotIndex RegisterDotDef(DotController.DotDef? dotDef,
-        CustomDotBehaviour? customDotBehaviour = null, CustomDotVisual? customDotVisual = null)
+        CustomDotBehaviour? customDotBehaviour, CustomDotVisual? customDotVisual)
     {
         DotAPI.SetHooks();
         return RegisterDotDef(dotDef, customDotBehaviour, customDotVisual, null);
@@ -180,8 +180,8 @@ public static partial class DotAPI
     /// <param name="customDotVisual"></param>
     /// <returns></returns>
     public static DotController.DotIndex RegisterDotDef(float interval, float damageCoefficient,
-        DamageColorIndex colorIndex, BuffDef associatedBuff = null, CustomDotBehaviour customDotBehaviour = null,
-        CustomDotVisual customDotVisual = null)
+        DamageColorIndex colorIndex, BuffDef associatedBuff, CustomDotBehaviour customDotBehaviour,
+        CustomDotVisual customDotVisual)
     {
         DotAPI.SetHooks();
         return RegisterDotDef(interval, damageCoefficient, colorIndex, associatedBuff, customDotBehaviour, customDotVisual, null);

--- a/R2API.Dot/README.md
+++ b/R2API.Dot/README.md
@@ -18,6 +18,9 @@ Alongside adding new DotIndices and DotDefs, One can also provide CustomDotBehav
 
 ## Changelog
 
+### '1.1.1'
+* Removed ambiguity in methods.
+
 ### '1.1.0'
 * Add CustomDotDamageEvaluation feature.
 

--- a/R2API.Dot/thunderstore.toml
+++ b/R2API.Dot/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Dot"
-versionNumber = "1.1.0"
+versionNumber = "1.1.1"
 description = "API for adding custom damage over time effects"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Overloads shared all but on one optional parameter, which resulted in ambiguous call if you were using only required parameters.
Removed default values in one overload, which solves the ambiguity.