### PR TITLE
R2API_RecalculateStats: Fixed overburdened jump count stat hook 

### DIFF
--- a/R2API.RecalculateStats/RecalculateStatsAPI.cs
+++ b/R2API.RecalculateStats/RecalculateStatsAPI.cs
@@ -687,18 +687,12 @@ public static partial class RecalculateStatsAPI
         c.Index = 0;
 
         bool ILFound = c.TryGotoNext(
-            MoveType.After,
-            x => x.MatchLdarg(0),
-            x => x.MatchLdarg(0),
-            x => x.MatchLdfld<CharacterBody>(nameof(CharacterBody.baseJumpCount)),
-            x => x.MatchLdloc(out _),
-            x => x.MatchAdd(),
+            MoveType.Before,
             x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetPropertySetter(nameof(CharacterBody.maxJumpCount)))
         );
 
         if (ILFound)
         {
-            c.Index--;
             c.EmitDelegate<Func<int>>(() => StatMods.jumpCountAdd);
             c.Emit(OpCodes.Add);
 


### PR DESCRIPTION
The jump count stat hook currently has an issue where it fails/breaks if any mod tries to alter vanilla jump count stats (like by modifying hopoo feather's stacking for example). This is exclusively due to matching against too many consecutive ILCodes, making it an easy fix.