### PR TITLE
Networking - Fix for DLC3

### DIFF
--- a/R2API.Networking/Messages/DotMessage.cs
+++ b/R2API.Networking/Messages/DotMessage.cs
@@ -7,6 +7,7 @@ namespace R2API.Networking.Messages;
 
 internal struct DotMessage : INetMessage
 {
+    static readonly bool[] _nullableFieldsSharedHasValueArray = new bool[3];
 
     public void Serialize(NetworkWriter writer)
     {
@@ -15,6 +16,29 @@ internal struct DotMessage : INetMessage
         writer.WritePackedIndex32((int)_dotIndex);
         writer.Write(_duration);
         writer.Write(_damageMultiplier);
+
+        int bitIndex = 0;
+        _nullableFieldsSharedHasValueArray[bitIndex++] = _maxStacksFromAttacker.HasValue;
+        _nullableFieldsSharedHasValueArray[bitIndex++] = _totalDamage.HasValue;
+        _nullableFieldsSharedHasValueArray[bitIndex++] = _preUpgradeDotIndex.HasValue;
+        writer.WriteBitArray(_nullableFieldsSharedHasValueArray);
+
+        if (_maxStacksFromAttacker.HasValue)
+        {
+            writer.WritePackedUInt32(_maxStacksFromAttacker.Value);
+        }
+
+        if (_totalDamage.HasValue)
+        {
+            writer.Write(_totalDamage.Value);
+        }
+
+        if (_preUpgradeDotIndex.HasValue)
+        {
+            writer.WritePackedIndex32((int)_preUpgradeDotIndex.Value);
+        }
+
+        writer.Write(_hitHurtBox);
     }
 
     public void Deserialize(NetworkReader reader)
@@ -24,17 +48,61 @@ internal struct DotMessage : INetMessage
         _dotIndex = (DotController.DotIndex)reader.ReadPackedIndex32();
         _duration = reader.ReadSingle();
         _damageMultiplier = reader.ReadSingle();
+
+        reader.ReadBitArray(_nullableFieldsSharedHasValueArray);
+
+        int bitIndex = 0;
+        bool maxStacksFromAttackerHasValue = _nullableFieldsSharedHasValueArray[bitIndex++];
+        bool totalDamageHasValue = _nullableFieldsSharedHasValueArray[bitIndex++];
+        bool preUpgradeDotIndexHasValue = _nullableFieldsSharedHasValueArray[bitIndex++];
+
+        if (maxStacksFromAttackerHasValue)
+        {
+            _maxStacksFromAttacker = reader.ReadPackedUInt32();
+        }
+
+        if (totalDamageHasValue)
+        {
+            _totalDamage = reader.ReadSingle();
+        }
+
+        if (preUpgradeDotIndexHasValue)
+        {
+            _preUpgradeDotIndex = (DotController.DotIndex)reader.ReadPackedIndex32();
+        }
+
+        _hitHurtBox = reader.ReadHurtBoxReference();
     }
 
-    public void OnReceived() => DotController.InflictDot(_victim, _attacker, _dotIndex, _duration, _damageMultiplier);
-
-    internal DotMessage(GameObject victimObject, GameObject attackerObject, DotController.DotIndex dotIndex, float duration, float damageMultiplier)
+    public void OnReceived()
     {
-        _victim = victimObject;
-        _attacker = attackerObject;
-        _dotIndex = dotIndex;
-        _duration = duration;
-        _damageMultiplier = damageMultiplier;
+        InflictDotInfo inflictDotInfo = new InflictDotInfo()
+        {
+            victimObject = _victim,
+            attackerObject = _attacker,
+            dotIndex = _dotIndex,
+            duration = _duration,
+            damageMultiplier = _damageMultiplier,
+            maxStacksFromAttacker = _maxStacksFromAttacker,
+            totalDamage = _totalDamage,
+            preUpgradeDotIndex = _preUpgradeDotIndex,
+            hitHurtBox = _hitHurtBox.ResolveHurtBox(),
+        };
+
+        DotController.InflictDot(ref inflictDotInfo);
+    }
+
+    internal DotMessage(InflictDotInfo inflictDotInfo)
+    {
+        _victim = inflictDotInfo.victimObject;
+        _attacker = inflictDotInfo.attackerObject;
+        _dotIndex = inflictDotInfo.dotIndex;
+        _duration = inflictDotInfo.duration;
+        _damageMultiplier = inflictDotInfo.damageMultiplier;
+        _maxStacksFromAttacker = inflictDotInfo.maxStacksFromAttacker;
+        _totalDamage = inflictDotInfo.totalDamage;
+        _preUpgradeDotIndex = inflictDotInfo.preUpgradeDotIndex;
+        _hitHurtBox = HurtBoxReference.FromHurtBox(inflictDotInfo.hitHurtBox);
     }
 
     private GameObject _victim;
@@ -42,4 +110,8 @@ internal struct DotMessage : INetMessage
     private DotController.DotIndex _dotIndex;
     private float _duration;
     private float _damageMultiplier;
+    private uint? _maxStacksFromAttacker;
+    private float? _totalDamage;
+    private DotController.DotIndex? _preUpgradeDotIndex;
+    private HurtBoxReference _hitHurtBox;
 }

--- a/R2API.Networking/NetworkingHelpers.cs
+++ b/R2API.Networking/NetworkingHelpers.cs
@@ -79,13 +79,25 @@ public static class NetworkingHelpers
     public static void ApplyDot(this HealthComponent victim, GameObject attacker,
         DotController.DotIndex dotIndex, float duration = 8f, float damageMultiplier = 1f)
     {
+        ApplyDot(victim, new InflictDotInfo
+        {
+            victimObject = victim.gameObject,
+            attackerObject = attacker,
+            dotIndex = dotIndex,
+            duration = duration,
+            damageMultiplier = damageMultiplier
+        });
+    }
+
+    public static void ApplyDot(this HealthComponent victim, InflictDotInfo inflictDotInfo)
+    {
         if (NetworkServer.active)
         {
-            DotController.InflictDot(victim.gameObject, attacker, dotIndex, duration, damageMultiplier);
+            DotController.InflictDot(ref inflictDotInfo);
         }
         else
         {
-            new DotMessage(victim.gameObject, attacker, dotIndex, duration, damageMultiplier)
+            new DotMessage(inflictDotInfo)
                 .Send(NetworkDestination.Server);
         }
     }

--- a/R2API.Networking/README.md
+++ b/R2API.Networking/README.md
@@ -8,6 +8,9 @@ An example tutorial on how to use this api can be found [here](https://risk-of-t
 
 ## Changelog
 
+### '1.0.4'
+* Updated for Alloyed Collective.
+
 ### '1.0.3'
 * Add setting plugin hooks to plugin initialization. 
 

--- a/R2API.Networking/thunderstore.toml
+++ b/R2API.Networking/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Networking"
-versionNumber = "1.0.3"
+versionNumber = "1.0.4"
 description = "Networking API around the Unity UNet Low Level API (LLAPI)"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/R2API.props
+++ b/R2API.props
@@ -22,12 +22,12 @@
 
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.9-r.0" NoWarn="NU5104" />
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.4.0-r.0" NoWarn="NU5104" />
 
 		<PackageReference Include="BepInEx.Core" Version="5.4.21" />
 		<PackageReference Include="RoR2BepInExPack" Version="*" />
 
-		<PackageReference Include="MMHOOK.RoR2" Version="2025.6.3" NoWarn="NU1701" />
+		<PackageReference Include="MMHOOK.RoR2" Version="2025.11.19" NoWarn="NU1701" />
 
 		<PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
 	</ItemGroup>


### PR DESCRIPTION
Build only fails due to other modules not being updated.

Switch to using InflictDotInfo internally for ApplyDot extension. Also add serialization for `maxStacksFromAttacker`, `totalDamage`, and `preUpgradeDotIndex` as well as the new `hitHurtBox` fields when applying from clients.