### PR TITLE
R2API.CharacteBody Add `CustomSprintIcon` feature

### DIFF
--- a/R2API.CharacterBody.Interop/CharacterBodyInterop.cs
+++ b/R2API.CharacterBody.Interop/CharacterBodyInterop.cs
@@ -1,5 +1,7 @@
 ﻿using RoR2;
+using RoR2.UI;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 
 [assembly: InternalsVisibleTo("R2API.CharacterBody")]
 
@@ -9,4 +11,10 @@ internal static class CharacterBodyInterop
 {
     public static byte[] GetModdedBodyFlags(CharacterBody characterBody) => characterBody.r2api_moddedBodyFlags;
     public static void SetModdedBodyFlags(CharacterBody characterBody, byte[] value) => characterBody.r2api_moddedBodyFlags = value;
+    public static Sprite GetCustomSprintIcon(CharacterBody characterBody) => characterBody.r2api_customSprintIcon;
+    public static void SetCustomSprintIcon(CharacterBody characterBody, Sprite value) => characterBody.r2api_customSprintIcon = value;
+    public static GameObject GetCustomIconObject(SprintIcon sprintIcon) => sprintIcon.r2api_customIconObject;
+    public static void SetCustomIconObject(SprintIcon sprintIcon, GameObject value) => sprintIcon.r2api_customIconObject = value;
+    public static Sprite GetCurrentCustomSprintIcon(SprintIcon sprintIcon) => sprintIcon.r2api_currentCustomSprintIcon;
+    public static void SetCurrentCustomSprintIcon(SprintIcon sprintIcon, Sprite value) => sprintIcon.r2api_currentCustomSprintIcon = value;
 }

--- a/R2API.CharacterBody.Patcher/CharacterBodyPatcher.cs
+++ b/R2API.CharacterBody.Patcher/CharacterBodyPatcher.cs
@@ -2,6 +2,7 @@ using Mono.Cecil;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using UnityEngine;
 
 namespace R2API;
 
@@ -17,11 +18,24 @@ internal static class CharacterBodyPatcher
     public static void Patch(AssemblyDefinition assembly)
     {
         PatchCharacterBody(assembly);
+        PatchSprintIcon(assembly);
+    }
+    private static void PatchSprintIcon(AssemblyDefinition assembly)
+    {
+        var sprintIcon = assembly.MainModule.GetType("RoR2.UI.SprintIcon");
+        if (sprintIcon != null)
+        {
+            sprintIcon.Fields.Add(new FieldDefinition("r2api_customIconObject", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(GameObject))));
+            sprintIcon.Fields.Add(new FieldDefinition("r2api_currentCustomSprintIcon", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Sprite))));
+        }
     }
     private static void PatchCharacterBody(AssemblyDefinition assembly)
     {
         var characterBody = assembly.MainModule.GetType("RoR2", "CharacterBody");
-        var moddedBodyFlags = new FieldDefinition("r2api_moddedBodyFlags", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[])));
-        characterBody?.Fields.Add(moddedBodyFlags);
+        if (characterBody != null)
+        {
+            characterBody.Fields.Add(new FieldDefinition("r2api_moddedBodyFlags", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(byte[]))));
+            characterBody.Fields.Add(new FieldDefinition("r2api_customSprintIcon", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(Sprite))));
+        }
     }
 }

--- a/R2API.CharacterBody.Patcher/R2API.CharacterBody.Patcher.csproj
+++ b/R2API.CharacterBody.Patcher/R2API.CharacterBody.Patcher.csproj
@@ -10,5 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.19" />
+    <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
   </ItemGroup>
 </Project>

--- a/R2API.CharacterBody/README.md
+++ b/R2API.CharacterBody/README.md
@@ -2,9 +2,12 @@
 
 ## About
 
-R2API.CharacterBody is a submodule for R2API that currently adds Modded Body Flags and support for modded HealthBar Overlays.
+R2API.CharacterBody is a submodule for R2API that currently adds Modded Body Flags, Custom Sprint Icon and support for modded HealthBar Overlays.
 
 ## Changelog
+
+### '1.2.0'
+* Add `CustomSprintIcon` feature.
 
 ### '1.1.0'
 * Add HealthBarAPI for managing HealthBar visual and numerical overlays.

--- a/R2API.CharacterBody/thunderstore.toml
+++ b/R2API.CharacterBody/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_CharacterBody"
-versionNumber = "1.1.0"
+versionNumber = "1.2.0"
 description = "API for adding various stuff to Character Body such as: Modded Body Flags"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false

--- a/RoR2.Patched/CharacterBody.cs
+++ b/RoR2.Patched/CharacterBody.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using UnityEngine;
 
 namespace RoR2;
 public class CharacterBody
 {
     public byte[] r2api_moddedBodyFlags;
+    public Sprite r2api_customSprintIcon;
 }

--- a/RoR2.Patched/RoR2.Patched.csproj
+++ b/RoR2.Patched/RoR2.Patched.csproj
@@ -17,5 +17,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <IsPublishable>False</IsPublishable>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
+  </ItemGroup>
 
 </Project>

--- a/RoR2.Patched/SprintIcon.cs
+++ b/RoR2.Patched/SprintIcon.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace RoR2.UI;
+public class SprintIcon
+{
+    public GameObject r2api_customIconObject;
+    public Sprite r2api_currentCustomSprintIcon;
+}


### PR DESCRIPTION
Adds a feature to add custom sprint sprite for a character body. During sprint icon fixed update it will check for custom sprint icon, if there is one, it checks for custom icon object, if there is none, it creates one from instantiating "SprintIcon" child of sprint icon object, gets image component and sets its sprite to custom sprint icon and also sets current custom sprint icon to the new custom sprint icon. If there is custom icon object already, it compares current custom sprint icon with new custom sprint icon and if they are different, get image component from custom icon object and set its sprite to custom sprint icon and also set current custom sprint icon to the new custom sprint icon. After that disable base sprint objects. In base sprint object activations disable custom icon object.

Test result screenshot 
<img width="226" height="193" alt="image" src="https://github.com/user-attachments/assets/0f7c8780-139f-4a32-9f12-cf2a1e7f5908" />

This pull request adds UnityEngine package reference to R2API.CharacterBody.Patcher and RoR2.Patched solutions. When testing I had no problems with it, but if it somehow gets broken on deploy this might be the reason