### PR TITLE
R2API.Buffs module addition

### DIFF
--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -42,7 +42,7 @@ public static partial class BuffsAPI
         IL.RoR2.UI.BuffIcon.UpdateIcon += BuffIcon_UpdateIcon;
         On.RoR2.UI.BuffIcon.OnEnable += BuffIcon_OnEnable;
         On.RoR2.BuffCatalog.SetBuffDefs += BuffCatalog_SetBuffDefs;
-        NoneStackingDisplayMethod = RegisterStackingDisplayMethod(null);
+        if (NoneStackingDisplayMethod == StackingDisplayMethod.Default) NoneStackingDisplayMethod = RegisterStackingDisplayMethod(null);
     }
     internal static void UnsetHooks()
     {

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -55,7 +55,7 @@ public static partial class BuffsAPI
     private static void BuffIcon_OnEnable(On.RoR2.UI.BuffIcon.orig_OnEnable orig, BuffIcon self)
     {
         orig(self);
-        if (_buffIconSimpleSpriteAnimator.TryGetValue(self, out SimpleSpriteAnimator simpleSpriteAnimator)) simpleSpriteAnimator.Tick();
+        if (_buffIconSimpleSpriteAnimator.TryGetValue(self, out SimpleSpriteAnimator simpleSpriteAnimator) && simpleSpriteAnimator.enabled) simpleSpriteAnimator.Tick();
     }
 
     private static byte[][] _moddedBuffFlags = [];

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -1,0 +1,414 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using R2API.AutoVersionGen;
+using R2API.Utils;
+using RoR2;
+using RoR2.UI;
+using RoR2BepInExPack.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEngine;
+using UnityEngine.UI;
+using static R2API.BuffsAPI;
+using static RoR2.BuffDef;
+
+namespace R2API;
+
+/// <summary>
+/// API for adding various stuff to Character Body such as: Modded Body Flags
+/// </summary>
+
+#pragma warning disable CS0436 // Type conflicts with imported type
+[AutoVersion]
+#pragma warning restore CS0436 // Type conflicts with imported type
+
+public static partial class BuffsAPI
+{
+    public const string PluginGUID = R2API.PluginGUID + ".buffs";
+    public const string PluginName = R2API.PluginName + ".Buffs";
+    private static bool _hooksEnabled;
+    /// <summary>
+    /// Ready-to-use custom StackingDisplayMethod to hide stacking buff display text while also retaining its stacking functionality
+    /// </summary>
+    public static StackingDisplayMethod NoneStackingDisplayMethod;
+
+    #region Hooks
+    internal static void SetHooks()
+    {
+        if (_hooksEnabled) return;
+        _hooksEnabled = true;
+        VanillaStackingDisplayMethodCount = Enum.GetValues(typeof(StackingDisplayMethod)).Length;
+        IL.RoR2.UI.BuffIcon.UpdateIcon += BuffIcon_UpdateIcon;
+        On.RoR2.UI.BuffIcon.OnEnable += BuffIcon_OnEnable;
+        On.RoR2.BuffCatalog.SetBuffDefs += BuffCatalog_SetBuffDefs;
+        NoneStackingDisplayMethod = RegisterStackingDisplayMethod(null);
+    }
+    internal static void UnsetHooks()
+    {
+        if (!_hooksEnabled) return;
+        _hooksEnabled = false;
+        IL.RoR2.UI.BuffIcon.UpdateIcon -= BuffIcon_UpdateIcon;
+        On.RoR2.UI.BuffIcon.OnEnable -= BuffIcon_OnEnable;
+        On.RoR2.BuffCatalog.SetBuffDefs -= BuffCatalog_SetBuffDefs;
+    }
+    private static void BuffIcon_OnEnable(On.RoR2.UI.BuffIcon.orig_OnEnable orig, BuffIcon self)
+    {
+        orig(self);
+        if (_buffIconSimpleSpriteAnimator.TryGetValue(self, out SimpleSpriteAnimator simpleSpriteAnimator)) simpleSpriteAnimator.Tick();
+    }
+
+    private static byte[][] _moddedBuffFlags = [];
+    private static SimpleSpriteAnimation[] _buffDefSimpleSpriteAnimation = [];
+    private static bool _init;
+    private static void BuffCatalog_SetBuffDefs(On.RoR2.BuffCatalog.orig_SetBuffDefs orig, BuffDef[] newBuffDefs)
+    {
+        orig(newBuffDefs);
+        if (_init) return;
+        _moddedBuffFlags = new byte[BuffCatalog.buffCount][];
+        _buffDefSimpleSpriteAnimation = new SimpleSpriteAnimation[BuffCatalog.buffCount];
+        foreach (var def in _pendingModdedBuffFlags)
+        {
+            BuffDef buffDef = def.Key;
+            if (!buffDef) continue;
+            byte[] bytes = def.Value;
+            if (bytes == null || bytes.Length == 0) continue;
+            _moddedBuffFlags[(int)buffDef.buffIndex] = bytes;
+        }
+        _pendingModdedBuffFlags.Clear();
+        _pendingModdedBuffFlags = null;
+        foreach (var def in _pendingSimpleSpriteAnimation)
+        {
+            BuffDef buffDef = def.Key;
+            if (!buffDef) continue;
+            SimpleSpriteAnimation simpleSpriteAnimation = def.Value;
+            if (!simpleSpriteAnimation) continue;
+            _buffDefSimpleSpriteAnimation[(int)buffDef.buffIndex] = simpleSpriteAnimation;
+        }
+        _pendingSimpleSpriteAnimation.Clear();
+        _pendingSimpleSpriteAnimation = null;
+        _init = true;
+    }
+
+    private static void BuffIcon_UpdateIcon(MonoMod.Cil.ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        if (
+             !c.TryGotoNext(MoveType.Before,
+                 x => x.MatchLdarg(0),
+                 x => x.MatchLdfld<BuffIcon>(nameof(BuffIcon.iconImage)),
+                 x => x.MatchLdloc(out _),
+                 x => x.MatchCallvirt(typeof(Image).GetPropertySetter(nameof(Image.sprite)))
+             ))
+        {
+            BuffsPlugin.Logger.LogError(il.Method.Name + " IL Hook 1 failed!");
+        }
+        else
+        {
+            Instruction instruction1 = c.Next.Next.Next.Next.Next;
+            c.Emit(OpCodes.Ldarg_0);
+            c.EmitDelegate(HandleSimpleSpriteAnimation);
+            c.Emit(OpCodes.Brtrue_S, instruction1);
+        }
+        ILLabel iLLabel = null;
+        if (
+             !c.TryGotoNext(MoveType.After,
+                 x => x.MatchLdarg(0),
+                 x => x.MatchLdfld<BuffIcon>(nameof(BuffIcon.buffDef)),
+                 x => x.MatchLdfld<BuffDef>(nameof(BuffDef.canStack)),
+                 x => x.MatchBrfalse(out iLLabel)
+             ))
+        {
+            BuffsPlugin.Logger.LogError(il.Method.Name + " IL Hook 2 failed!");
+        }
+        else
+        {
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit(OpCodes.Ldfld, HarmonyLib.AccessTools.Field(typeof(BuffIcon), nameof(BuffIcon.stackCount)));
+            c.Emit(OpCodes.Ldfld, HarmonyLib.AccessTools.Field(typeof(BuffDef), nameof(BuffDef.stackingDisplayMethod)));
+            c.Emit(OpCodes.Ldsfld, HarmonyLib.AccessTools.Field(typeof(BuffsAPI), nameof(NoneStackingDisplayMethod)));
+            c.Emit(OpCodes.Beq_S, iLLabel);
+        }
+        if (
+             !c.TryGotoNext(MoveType.Before,
+                 x => x.MatchLdarg(0),
+                 x => x.MatchLdfld<BuffIcon>(nameof(BuffIcon.stackCount)),
+                 x => x.MatchLdcI4(1),
+                 x => x.MatchCallvirt(typeof(Behaviour).GetPropertySetter(nameof(Behaviour.enabled)))
+             ))
+        {
+            BuffsPlugin.Logger.LogError(il.Method.Name + " IL Hook 3 failed!");
+            return;
+        }
+        Instruction instruction = c.Next;
+        int stackingDisplayMethodLoc = 0;
+        if (
+             !c.TryGotoPrev(MoveType.After,
+                 x => x.MatchLdarg(0),
+                 x => x.MatchLdfld<BuffIcon>(nameof(BuffIcon.buffDef)),
+                 x => x.MatchLdfld<BuffDef>(nameof(BuffDef.stackingDisplayMethod)),
+                 x => x.MatchStloc(out stackingDisplayMethodLoc)
+             ))
+        {
+            BuffsPlugin.Logger.LogError(il.Method.Name + " IL Hook 4 failed!");
+            return;
+        }
+        c.Emit(OpCodes.Ldarg_0);
+        c.Emit(OpCodes.Ldloc, stackingDisplayMethodLoc);
+        c.EmitDelegate(HandleCustomStackingDisplayMethods);
+        c.Emit(OpCodes.Brtrue_S, instruction);
+    }
+
+    #endregion;
+
+    #region Public
+
+    public static int VanillaStackingDisplayMethodCount;
+    public static int CustomStackingDisplayMethodCount => CustomStackingDisplayMethods.Count;
+
+    /// <summary>
+    /// Create and reserve StackingDisplayMethod for custom buff display text. Modify <see cref="BuffIcon.sharedStringBuilder"/> inside of your CustomStackingDisplayMethod method
+    /// </summary>
+    public static StackingDisplayMethod RegisterStackingDisplayMethod(CustomStackingDisplayMethod customStackingDisplayMethod)
+    {
+        SetHooks();
+        int dotDefIndex = VanillaStackingDisplayMethodCount + CustomStackingDisplayMethodCount;
+        int customArrayIndex = _customStackingDisplayMethod.Length;
+        Array.Resize(ref _customStackingDisplayMethod, _customStackingDisplayMethod.Length + 1);
+        _customStackingDisplayMethod[customArrayIndex] = customStackingDisplayMethod;
+        StackingDisplayMethod stackingDisplayMethod = (StackingDisplayMethod)dotDefIndex;
+        CustomStackingDisplayMethods.Add(stackingDisplayMethod);
+        return stackingDisplayMethod;
+    }
+    /// <summary>
+    /// Set animated sprite for your BuffDef
+    /// </summary>
+    /// <param name="buffDef"></param>
+    /// <param name="simpleSpriteAnimation"></param>
+    public static void SetSimpleSpriteAnimation(this BuffDef buffDef, SimpleSpriteAnimation simpleSpriteAnimation)
+    {
+        SetHooks();
+        if (_init)
+        {
+            _buffDefSimpleSpriteAnimation[(int)buffDef.buffIndex] = simpleSpriteAnimation;
+            return;
+        }
+        if (_pendingSimpleSpriteAnimation.ContainsKey(buffDef))
+        {
+            _pendingSimpleSpriteAnimation[buffDef] = simpleSpriteAnimation;
+        }
+        else
+        {
+            _pendingSimpleSpriteAnimation.Add(buffDef, simpleSpriteAnimation);
+        }
+    }
+    /// <summary>
+    /// Get animated sprite of your BuffDef
+    /// </summary>
+    /// <param name="buffDef"></param>
+    public static SimpleSpriteAnimation GetSimpleSpriteAnimation(this BuffDef buffDef)
+    {
+        SetHooks();
+        SimpleSpriteAnimation simpleSpriteAnimation;
+        if (_init)
+        {
+            return _buffDefSimpleSpriteAnimation[(int)buffDef.buffIndex];
+        }
+        if (_pendingSimpleSpriteAnimation.TryGetValue(buffDef, out simpleSpriteAnimation))
+        {
+            return simpleSpriteAnimation;
+        }
+        return null;
+    }
+    public enum ModdedBuffFlag { };
+    /// <summary>
+    /// Reserve ModdedBodyFlag to use it with
+    /// <see cref="AddModdedBuffFlag(BuffDef, ModdedBuffFlag)"/>,
+    /// <see cref="RemoveModdedBuffFlag(BuffDef, ModdedBuffFlag)"/> and
+    /// <see cref="HasModdedBuffFlag(BuffDef, ModdedBuffFlag))"/>
+    /// </summary>
+    /// <returns></returns>
+    public static ModdedBuffFlag ReserveBuffFlag()
+    {
+        SetHooks();
+        if (ModdedBuffFlagCount >= CompressedFlagArrayUtilities.sectionsCount * CompressedFlagArrayUtilities.flagsPerSection)
+        {
+            //I doubt this is ever gonna happen, but just in case.
+            throw new IndexOutOfRangeException($"Reached the limit of {CompressedFlagArrayUtilities.sectionsCount * CompressedFlagArrayUtilities.flagsPerSection} ModdedBuffFlags. Please contact R2API developers to increase the limit");
+        }
+
+        ModdedBuffFlagCount++;
+
+        return (ModdedBuffFlag)ModdedBuffFlagCount;
+    }
+    /// <summary>
+    /// Reserved ModdedBuffFlagCount count
+    /// </summary>
+    public static int ModdedBuffFlagCount { get; private set; }
+    /// <summary>
+    /// Adding ModdedBuffFlag to BuffDef. You can add more than one body flag to one BuffDef
+    /// </summary>
+    /// <param name="buffDef"></param>
+    /// <param name="moddedBuffFlag"></param>
+    public static void AddModdedBuffFlag(this BuffDef buffDef, ModdedBuffFlag moddedBuffFlag) => AddModdedBuffFlagInternal(buffDef, moddedBuffFlag);
+    /// <summary>
+    /// Removing ModdedBuffFlag from BuffDef instance.
+    /// </summary>
+    /// <param name="buffDef"></param>
+    /// <param name="moddedBuffFlag"></param>
+    public static bool RemoveModdedBuffFlag(this BuffDef buffDef, ModdedBuffFlag moddedBuffFlag) => RemoveModdedBuffFlagInternal(buffDef, moddedBuffFlag);
+    /// <summary>
+    /// Checks if BuffDef instance has any ModdedBuffFlag assigned. One BuffDef can have more than one buff flag.
+    /// </summary>
+    /// <param name="buffDef"></param>
+    /// <returns></returns>
+    public static bool HasAnyModdedBodyFlag(this BuffDef buffDef)
+    {
+        SetHooks();
+        byte[] bytes;
+        if (_init)
+        {
+            bytes = _moddedBuffFlags[(int)buffDef.buffIndex];
+            return bytes is not null && bytes.Length > 0;
+        }
+        if (_pendingModdedBuffFlags.TryGetValue(buffDef, out bytes))
+        {
+            return bytes is not null && bytes.Length > 0;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if BuffDef instance has ModdedBuffFlag assigned. One BuffDef can have more than one buff flag.
+    /// </summary>
+    /// <param name="buffDef"></param>
+    /// <param name="moddedBuffFlag"></param>
+    /// <returns></returns>
+    public static bool HasModdedBuffFlag(this BuffDef buffDef, ModdedBuffFlag moddedBuffFlag) => HasModdedBuffFlagInternal(buffDef, moddedBuffFlag);
+    #endregion
+
+    #region Internal
+    private static void AddModdedBuffFlagInternal(BuffDef buffDef, ModdedBuffFlag moddedBuffFlag)
+    {
+        SetHooks();
+        if (!CheckRange(moddedBuffFlag)) return;
+        byte[] bytes;
+        if (_init)
+        {
+            bytes = _moddedBuffFlags[(int)buffDef.buffIndex];
+            if (bytes == null)
+            {
+                bytes = new byte[0];
+            }
+            CompressedFlagArrayUtilities.AddImmutable(ref bytes, (int)moddedBuffFlag - 1);
+            _moddedBuffFlags[(int)buffDef.buffIndex] = bytes;
+            return;
+        }
+        if (_pendingModdedBuffFlags.TryGetValue(buffDef, out bytes))
+        {
+            CompressedFlagArrayUtilities.AddImmutable(ref bytes, (int)moddedBuffFlag - 1);
+            _pendingModdedBuffFlags[buffDef] = bytes;
+        }
+        else
+        {
+            bytes = new byte[0];
+            CompressedFlagArrayUtilities.AddImmutable(ref bytes, (int)moddedBuffFlag - 1);
+            _pendingModdedBuffFlags.Add(buffDef, bytes);
+        }
+    }
+    private static bool RemoveModdedBuffFlagInternal(BuffDef buffDef, ModdedBuffFlag moddedBuffFlag)
+    {
+        SetHooks();
+        if (!CheckRange(moddedBuffFlag)) return false;
+        byte[] bytes;
+        if (_init)
+        {
+            bytes = _moddedBuffFlags[(int)buffDef.buffIndex];
+            if (bytes == null) return false;
+            var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref bytes, (int)moddedBuffFlag - 1);
+            _moddedBuffFlags[(int)buffDef.buffIndex] = bytes;
+            return removed;
+        }
+        if (_pendingModdedBuffFlags.TryGetValue(buffDef, out bytes))
+        {
+            var removed = CompressedFlagArrayUtilities.RemoveImmutable(ref bytes, (int)moddedBuffFlag - 1);
+            _pendingModdedBuffFlags[buffDef] = bytes;
+            return removed;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    private static bool HasModdedBuffFlagInternal(BuffDef buffDef, ModdedBuffFlag moddedBuffFlag)
+    {
+        SetHooks();
+        if (!CheckRange(moddedBuffFlag)) return false;
+        byte[] bytes;
+        if (_init)
+        {
+            bytes = _moddedBuffFlags[(int)buffDef.buffIndex];
+            if (bytes == null) return false;
+            return CompressedFlagArrayUtilities.Has(bytes, (int)moddedBuffFlag - 1);
+        }
+        if (_pendingModdedBuffFlags.TryGetValue(buffDef, out bytes))
+        {
+            return CompressedFlagArrayUtilities.Has(bytes, (int)moddedBuffFlag - 1);
+        }
+        else
+        {
+            return false;
+        }
+        
+    }
+    private static bool CheckRange(ModdedBuffFlag moddedBuffFlag)
+    {
+        if ((int)moddedBuffFlag > ModdedBuffFlagCount || (int)moddedBuffFlag < 1)
+        {
+            BuffsPlugin.Logger.LogError($"Parameter '{nameof(moddedBuffFlag)}' with value {moddedBuffFlag} is out of range of registered types (1-{ModdedBuffFlagCount})\n{new StackTrace(true)}");
+            return false;
+        }
+        return true;
+    }
+    private static readonly List<StackingDisplayMethod> CustomStackingDisplayMethods = new List<StackingDisplayMethod>();
+    public delegate void CustomStackingDisplayMethod(BuffIcon buffIcon);
+    private static CustomStackingDisplayMethod[] _customStackingDisplayMethod = new CustomStackingDisplayMethod[0];
+    private static Dictionary<BuffDef, byte[]> _pendingModdedBuffFlags = [];
+    private static Dictionary<BuffDef, SimpleSpriteAnimation> _pendingSimpleSpriteAnimation = [];
+    private static FixedConditionalWeakTable<BuffIcon, SimpleSpriteAnimator> _buffIconSimpleSpriteAnimator = [];
+    private static bool HandleSimpleSpriteAnimation(BuffIcon buffIcon)
+    {
+        if (!_init) return false;
+        SimpleSpriteAnimation simpleSpriteAnimation = buffIcon.buffDef.GetSimpleSpriteAnimation();
+        if (simpleSpriteAnimation)
+        {
+            if (!_buffIconSimpleSpriteAnimator.TryGetValue(buffIcon, out SimpleSpriteAnimator simpleSpriteAnimator))
+            {
+                simpleSpriteAnimator = buffIcon.gameObject.AddComponent<SimpleSpriteAnimator>();
+                simpleSpriteAnimator.target = buffIcon.iconImage;
+                simpleSpriteAnimator.animation = simpleSpriteAnimation;
+                simpleSpriteAnimator.Tick();
+                _buffIconSimpleSpriteAnimator.Add(buffIcon, simpleSpriteAnimator);
+            }
+            return true;
+        }
+        else
+        {
+            if (_buffIconSimpleSpriteAnimator.TryGetValue(buffIcon, out SimpleSpriteAnimator simpleSpriteAnimator)) simpleSpriteAnimator.enabled = false;
+            return false;
+        }
+    }
+    private static bool HandleCustomStackingDisplayMethods(BuffIcon buffIcon, StackingDisplayMethod stackingDisplayMethod)
+    {
+        if ((int)stackingDisplayMethod >= VanillaStackingDisplayMethodCount)
+        {
+            _customStackingDisplayMethod[(int)stackingDisplayMethod - VanillaStackingDisplayMethodCount]?.Invoke(buffIcon);
+            return true;
+        }
+        return false;
+    }
+    #endregion
+}

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -393,6 +393,10 @@ public static partial class BuffsAPI
                 simpleSpriteAnimator.Tick();
                 _buffIconSimpleSpriteAnimator.Add(buffIcon, simpleSpriteAnimator);
             }
+            else
+            {
+                simpleSpriteAnimator.animation = simpleSpriteAnimation;
+            }
             return true;
         }
         else

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -400,7 +400,7 @@ public static partial class BuffsAPI
                     simpleSpriteAnimator.animation = simpleSpriteAnimation;
                     simpleSpriteAnimator.Tick();
                 }
-                if (!simpleSpriteAnimator.enabled) simpleSpriteAnimator.enabled = true
+                if (!simpleSpriteAnimator.enabled) simpleSpriteAnimator.enabled = true;
             }
             return true;
         }

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -400,12 +400,13 @@ public static partial class BuffsAPI
                     simpleSpriteAnimator.animation = simpleSpriteAnimation;
                     simpleSpriteAnimator.Tick();
                 }
+                if (!simpleSpriteAnimator.enabled) simpleSpriteAnimator.enabled = true
             }
             return true;
         }
         else
         {
-            if (_buffIconSimpleSpriteAnimator.TryGetValue(buffIcon, out SimpleSpriteAnimator simpleSpriteAnimator)) simpleSpriteAnimator.enabled = false;
+            if (_buffIconSimpleSpriteAnimator.TryGetValue(buffIcon, out SimpleSpriteAnimator simpleSpriteAnimator) && simpleSpriteAnimator.enabled) simpleSpriteAnimator.enabled = false;
             return false;
         }
     }

--- a/R2API.Buffs/BuffsAPI.cs
+++ b/R2API.Buffs/BuffsAPI.cs
@@ -395,7 +395,11 @@ public static partial class BuffsAPI
             }
             else
             {
-                simpleSpriteAnimator.animation = simpleSpriteAnimation;
+                if (simpleSpriteAnimator.animation != simpleSpriteAnimation)
+                {
+                    simpleSpriteAnimator.animation = simpleSpriteAnimation;
+                    simpleSpriteAnimator.Tick();
+                }
             }
             return true;
         }

--- a/R2API.Buffs/BuffsPlugin.cs
+++ b/R2API.Buffs/BuffsPlugin.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BepInEx;
+using BepInEx.Logging;
+
+namespace R2API;
+
+[BepInPlugin(BuffsAPI.PluginGUID, BuffsAPI.PluginName, BuffsAPI.PluginVersion)]
+public sealed class BuffsPlugin : BaseUnityPlugin
+{
+    internal static new ManualLogSource Logger { get; set; }
+
+    private void Awake()
+    {
+        Logger = base.Logger;
+        BuffsAPI.SetHooks();
+    }
+
+    private void OnDestroy()
+    {
+        BuffsAPI.UnsetHooks();
+    }
+}

--- a/R2API.Buffs/R2API.Buffs.csproj
+++ b/R2API.Buffs/R2API.Buffs.csproj
@@ -1,0 +1,6 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../R2API.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
+  </ItemGroup>
+</Project>

--- a/R2API.Buffs/README.md
+++ b/R2API.Buffs/README.md
@@ -1,0 +1,10 @@
+# R2API.Buffs - API for adding various stuff to BuffDef such as: Custom Stacking Display Method, Simple Sprite Animation Icon and Modded Buff Flag.
+
+## About
+
+R2API.Buffs is a submodule for R2API that currently adds Modded Buff Flags, Custom Stacking Display Method and support for Simple Sprite Animation to be used as animated icons for BuffDef.
+
+## Changelog
+
+### '1.0.0'
+* Create new module.

--- a/R2API.Buffs/thunderstore.toml
+++ b/R2API.Buffs/thunderstore.toml
@@ -1,0 +1,33 @@
+
+[config]
+schemaVersion = "0.0.1"
+
+[package]
+namespace = "RiskofThunder"
+name = "R2API_Buffs"
+versionNumber = "1.0.0"
+description = "API for adding various stuff to BuffDef such as: Custom Stacking Display Method, Simple Sprite Animation Icon and Modded Buff Flag"
+websiteUrl = "https://github.com/risk-of-thunder/R2API"
+containsNsfwContent = false
+
+[package.dependencies]
+RiskofThunder-HookGenPatcher = "1.2.9"
+RiskofThunder-R2API_Core = "5.3.0"
+
+[build]
+icon = "../icon.png"
+readme = "./README.md"
+outdir = "./build"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.Buffs.dll"
+target = "./plugins/R2API.Buffs/R2API.Buffs.dll"
+
+[[build.copy]]
+source = "./ReleaseOutput/R2API.Buffs.xml"
+target = "./plugins/R2API.Buffs/R2API.Buffs.xml"
+
+[publish]
+repository = "https://thunderstore.io"
+communities = ["riskofrain2"]
+categories = ["libraries"]

--- a/R2API.Core/AssemblyInfo.cs
+++ b/R2API.Core/AssemblyInfo.cs
@@ -47,3 +47,4 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
 [assembly: IVT("R2API.StringSerializerExtensions")]
 [assembly: IVT("R2API.CharacterBody")]
 [assembly: IVT("R2API.Teams")]
+[assembly: IVT("R2API.Buffs")]

--- a/R2API.sln
+++ b/R2API.sln
@@ -134,6 +134,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Teams.Patcher", "R2AP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Execute", "R2API.Execute\R2API.Execute.csproj", "{D2B567CF-1C69-0DD6-3F3B-0812A2498345}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "R2API.Buffs", "R2API.Buffs\R2API.Buffs.csproj", "{14500EB8-6F6A-48AD-9108-D1158E66E03F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -360,6 +362,10 @@ Global
 		{D2B567CF-1C69-0DD6-3F3B-0812A2498345}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2B567CF-1C69-0DD6-3F3B-0812A2498345}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2B567CF-1C69-0DD6-3F3B-0812A2498345}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14500EB8-6F6A-48AD-9108-D1158E66E03F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14500EB8-6F6A-48AD-9108-D1158E66E03F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14500EB8-6F6A-48AD-9108-D1158E66E03F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14500EB8-6F6A-48AD-9108-D1158E66E03F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
R2API.Buffs module brings these features:

---

Custom StackingDisplayMethod support for adding custom buff stacking text. Also adds reserved StackingDisplayMethod NoneStackingDisplayMethod to completely hide buff stacking text by disabling text component as if buff had canStack enabled

Custom StackingDisplayMethod
![custom-stacking-display-method](https://media.discordapp.net/attachments/562704639569428506/1466421678702592062/image.png?ex=697caf1d&is=697b5d9d&hm=2503c3659df061e12b2388ef4a313a09b7bcec67d44c5a70dfec4300d2811ce6&=&format=webp&quality=lossless&width=435&height=366)


NoneStackingDisplayMethod
![none-stacking-display-method](https://media.discordapp.net/attachments/562704639569428506/1466421679021621463/image.png?ex=697caf1d&is=697b5d9d&hm=3435299c09c8a1436dc91b3ee8540c1807ced118f1f3dc0b39daec3600d3ec7f&=&format=webp&quality=lossless&width=296&height=323)

---

ModdedBuffFlags. Custom buff flags. Have not found a use for them for proper example showcase but I have tested the feature using UnityExplorer so it should be fine

---

Usage of SimpleSpriteAnimation to make animated icon of your buffdef animated

https://github.com/user-attachments/assets/6b2c05eb-6f9d-4a39-a450-7fd3faae0a3e
