### PR TITLE
DirectorAPI: Fix `AddressableDCCSPool` not adding "Included If Conditions Met" entries with 0 required expansions to the target DCCS pool.

### DIFF
--- a/R2API.Director/AddressableDCCSPool.cs
+++ b/R2API.Director/AddressableDCCSPool.cs
@@ -189,9 +189,6 @@ public class AddressableDCCSPool : ScriptableObject
                 if (!_conditionalPoolEntry.dccs)
                     continue;
 
-                if (_conditionalPoolEntry.requiredExpansions == null || _conditionalPoolEntry.requiredExpansions.Length == 0 || !_conditionalPoolEntry.requiredExpansions.Any())
-                    continue;
-
                 upgradedConditionalPoolEntries.Add(_conditionalPoolEntry);
             }
             resultCategory.includedIfConditionsMet = upgradedConditionalPoolEntries.ToArray();

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -18,6 +18,9 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 ## Changelog
 
+### '2.3.9'
+* Fix `AddressableDCCSPool` not adding "Included If Conditions Met" entries with 0 required expansions to the target DCCS pool.
+
 ### '2.3.8'
 * Backward compat fix for `mixEnemyMonsterCards` not being assigned as early as before due to a timing change from 1.4.0 Game Update.
 

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.8"
+versionNumber = "2.3.9"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Fix #672 