### PR TITLE
[SkinsAPI] Fixed idrs overrides causing freeze during loading

### DIFF
--- a/R2API.Skins/README.md
+++ b/R2API.Skins/README.md
@@ -8,6 +8,11 @@ Alongside the old skin creation methods from `R2API.Loadout`, R2API.Skins also c
 
 ## Changelog
 
+### `1.4.7`
+
+* Fix IDRS issues when adding skin-specific overrides under certain conditions.
+* Fix IDRS issues related to async skin application by refreshing item displays when a skin with a custom IDRS is applied.
+
 ### `1.4.6`
 
 * Fix IDRS issues related to async skin application by refreshing item displays when a skin with a custom IDRS is applied.

--- a/R2API.Skins/SkinIDRS.cs
+++ b/R2API.Skins/SkinIDRS.cs
@@ -1,4 +1,5 @@
-﻿using RoR2;
+﻿using HG.Coroutines;
+using RoR2;
 using RoR2.ContentManagement;
 using System.Collections;
 using System.Collections.Generic;
@@ -25,14 +26,12 @@ public static class SkinIDRS
         hooksSet = true;
 
         On.RoR2.ModelSkinController.ApplySkinAsync += SetCustomIDRS;
-        RoR2Application.onLoad += SystemInit;
     }
 
     internal static void UnsetHooks()
     {
         hooksSet = false;
         On.RoR2.ModelSkinController.ApplySkinAsync -= SetCustomIDRS;
-        RoR2Application.onLoad -= SystemInit;
     }
 
     /// <summary>
@@ -89,10 +88,13 @@ public static class SkinIDRS
         return true;
     }
 
+    //Some mods add idrs in RoR2Application.onLoad, this is currently the last moment of loading
+    [InitDuringStartupPhase(GameInitPhase.PostProgressBar, int.MaxValue - 100)]
     private static void SystemInit()
     {
         initialized = true;
 
+        var coroutine = new ParallelCoroutine();
         foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
         {
             if (!body ||
@@ -120,17 +122,47 @@ public static class SkinIDRS
                     skinToIDRS[skin] = idrs = baseIDRS ? UnityEngine.Object.Instantiate(baseIDRS) : ScriptableObject.CreateInstance<ItemDisplayRuleSet>();
                 }
 
-                foreach (var kvp in overrides)
-                {
-                    idrs.SetDisplayRuleGroup(kvp.Key, kvp.Value);
-                }
-
-                var async = idrs.GenerateRuntimeValuesAsync();
-                while (async.MoveNext()) ;
+                coroutine.Add(OverrideGroups(idrs, overrides));
             }
         }
 
+        SkinsPlugin.Instance.StartCoroutine(coroutine);
         skinIDRSOverrides.Clear();
+    }
+
+    private static IEnumerator OverrideGroups(ItemDisplayRuleSet idrs, Dictionary<UnityEngine.Object, DisplayRuleGroup> overrides)
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var foundNonInitialized = false;
+            foreach (var group in idrs.keyAssetRuleGroups)
+            {
+                if (!group.keyAsset && (group.keyAssetAddress?.RuntimeKeyIsValid() ?? false))
+                {
+                    //Some mod just added new idrs and still generating runtime values, delaying overrides
+                    foundNonInitialized = true;
+                    break;
+                }
+            }
+
+            if (!foundNonInitialized)
+            {
+                break;
+            }
+
+            yield return new WaitForSecondsRealtime(0.25f);
+        }
+
+        foreach (var kvp in overrides)
+        {
+            idrs.SetDisplayRuleGroup(kvp.Key, kvp.Value);
+        }
+
+        var enumerator = idrs.GenerateRuntimeValuesAsync();
+        while (enumerator.MoveNext())
+        {
+            yield return enumerator.Current;
+        }
     }
 
     private static IEnumerator SetCustomIDRS(On.RoR2.ModelSkinController.orig_ApplySkinAsync orig, ModelSkinController self, int skinIndex, AsyncReferenceHandleUnloadType unloadType)
@@ -141,15 +173,19 @@ public static class SkinIDRS
         if (!skin)
             return enumerator;
 
-        if (!skinToIDRS.TryGetValue(skin, out var idrs))
+        var characterModel = self.characterModel;
+        if (!skinToIDRS.TryGetValue(skin, out var idrs) || idrs == characterModel.itemDisplayRuleSet)
             return enumerator;
 
-        self.characterModel.itemDisplayRuleSet = idrs;
-
-        if (self.characterModel.body?.inventory is Inventory inventory)
+        characterModel.itemDisplayRuleSet = idrs;
+        if (characterModel.body && characterModel.body.inventory)
         {
-            self.characterModel.DisableAllItemDisplays();
-            self.characterModel.UpdateItemDisplay(inventory);
+            characterModel.DisableAllItemDisplays();
+            characterModel.SetEquipmentDisplay(EquipmentIndex.None);
+
+            characterModel.body.inventory.wasRecentlyCreated = true;
+            characterModel.UpdateItemDisplay(characterModel.body.inventory);
+            characterModel.SetEquipmentDisplay(characterModel.inventoryEquipmentIndex);
         }
 
         return enumerator;

--- a/R2API.Skins/SkinsPlugin.cs
+++ b/R2API.Skins/SkinsPlugin.cs
@@ -11,10 +11,12 @@ namespace R2API;
 public sealed class SkinsPlugin : BaseUnityPlugin
 {
     internal static new ManualLogSource Logger { get; set; }
+    internal static SkinsPlugin Instance { get; private set; }
 
     public static Harmony harmonyPatcher;
     private void Awake()
     {
+        Instance = this;
         Logger = base.Logger;
         harmonyPatcher = new Harmony(Skins.PluginGUID);
     }

--- a/R2API.Skins/thunderstore.toml
+++ b/R2API.Skins/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Skins"
-versionNumber = "1.4.6"
+versionNumber = "1.4.7"
 description = "R2API Submodule for adding custom Skins and Skin-related utilities to the game"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
When group override was applied to starstorm characters it would freeze the game because `idrs.GenerateRuntimeValueAsync()` now actually tried to do async work and `while` was locking the thread.
Also completed 1.4.6 fix by also reapplying equipment.