### PR TITLE
Add SpawnCardsCloningAPI to R2API.Director

### DIFF
--- a/R2API.Director/DirectorPlugin.cs
+++ b/R2API.Director/DirectorPlugin.cs
@@ -15,15 +15,18 @@ public sealed class DirectorPlugin : BaseUnityPlugin
         Logger = base.Logger;
 
         DirectorAPI.SetHooks();
+        SpawnCardCloning.SpawnCardCloningAPI.SetHooks();
     }
 
     private void OnEnable()
     {
         DirectorAPI.SetHooks();
+        SpawnCardCloning.SpawnCardCloningAPI.SetHooks();
     }
 
     private void OnDisable()
     {
         DirectorAPI.UnsetHooks();
+        SpawnCardCloning.SpawnCardCloningAPI.UnsetHooks();
     }
 }

--- a/R2API.Director/R2API.Director.csproj
+++ b/R2API.Director/R2API.Director.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../R2API.props" />
   <ItemGroup>
-    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false"/>
-    <ProjectReference Include="..\R2API.Addressables\R2API.Addressables.csproj" Private="false"/>
+    <ProjectReference Include="..\R2API.Core\R2API.Core.csproj" Private="false" />
+    <ProjectReference Include="..\R2API.Addressables\R2API.Addressables.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -14,9 +14,14 @@ R2API.Director is used for adding new Enemies and Interactables to the Director'
 
 Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which contains helper methods which greatly simplify interacting with the Events described above.
 
+Additionaly you can clone existing spawn cards and set new values for cloned spawn cards using CharacterSpawnCardClone, InteractableSpawnCardClone and MultiCharacterSpawnCardClone.
+
 ## Related Pages
 
 ## Changelog
+
+### `3.0.0`
+* Added SpawnCardCloningAPI for cloning existing spawn cards.
 
 ### '2.3.9'
 * Fix `AddressableDCCSPool` not adding "Included If Conditions Met" entries with 0 required expansions to the target DCCS pool.

--- a/R2API.Director/SpawnCardCloning/BaseSpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/BaseSpawnCardClone.cs
@@ -148,12 +148,12 @@ public abstract class BaseSpawnCardClone<T> : ScriptableObject where T : SpawnCa
     }
     public virtual void UpdateValuesForClonedSpawnCard(T originalSpawnCard, T clonedSpawnCard)
     {
-        clonedSpawnCard.directorCreditCost = overrideCost ? cost : (int)(clonedSpawnCard.directorCreditCost * costMultiplier);
-        clonedSpawnCard.eliteRules = overrideEliteRules ? eliteRules : clonedSpawnCard.eliteRules;
-        clonedSpawnCard.requiredFlags = overrideRequiredFlags ? requiredFlags : clonedSpawnCard.requiredFlags;
-        clonedSpawnCard.hullSize = overrideHullSize ? hullSize : clonedSpawnCard.hullSize;
-        clonedSpawnCard.nodeGraphType = overrideNodeGraphType ? nodeGrapthType : clonedSpawnCard.nodeGraphType;
-        clonedSpawnCard.forbiddenFlags = overrideForbiddenFlags ? forbiddenFlags : clonedSpawnCard.forbiddenFlags;
+        clonedSpawnCard.directorCreditCost = overrideCost ? cost : (int)(originalSpawnCard.directorCreditCost * costMultiplier);
+        clonedSpawnCard.eliteRules = overrideEliteRules ? eliteRules : originalSpawnCard.eliteRules;
+        clonedSpawnCard.requiredFlags = overrideRequiredFlags ? requiredFlags : originalSpawnCard.requiredFlags;
+        clonedSpawnCard.hullSize = overrideHullSize ? hullSize : originalSpawnCard.hullSize;
+        clonedSpawnCard.nodeGraphType = overrideNodeGraphType ? nodeGrapthType : originalSpawnCard.nodeGraphType;
+        clonedSpawnCard.forbiddenFlags = overrideForbiddenFlags ? forbiddenFlags : originalSpawnCard.forbiddenFlags;
     }
     public enum CloningType
     {

--- a/R2API.Director/SpawnCardCloning/BaseSpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/BaseSpawnCardClone.cs
@@ -1,0 +1,164 @@
+﻿using RoR2;
+using RoR2.Navigation;
+using RoR2BepInExPack.GameAssetPaths;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+public abstract class BaseSpawnCardClone<T> : ScriptableObject where T : SpawnCard
+{
+    [Header("Base For Cloning")]
+    [Tooltip("If set to SpawnCard, it will try to match it directly for cloning. If set to Prefab, it will match spawncards with target prefab for cloning. If set to Prefabs, MultiCharacterSpawnCardClone will match spawncards with target prefabs")]
+    public CloningType cloningType;
+    [Tooltip("SpawnCard to use for matching")]
+    public AddressReferencedAssets.AddressReferencedSpawnCard targetSpawnCard;
+    [Tooltip("Set Spawn Card to return instead of cloned Spawn Cards")]
+    public AddressReferencedAssets.AddressReferencedSpawnCard overrideReturnSpawnCard;
+    [Tooltip("Prefab to use for matching the spawn card to clone")]
+    public AddressReferencedAssets.AddressReferencedPrefab targetPrefab;
+    [Tooltip("Prefab to override the original prefab of the cloned Spawn Card")]
+    public AddressReferencedAssets.AddressReferencedPrefab prefab;
+    [Tooltip("Override to which category cloned Spawn Card will go. Array incase if expected category name in some stage is slightly different than others. Breaks on first match")]
+    public string[] overrideCategory = [];
+    [Header("Cloning DirectorCard Settings")]
+    public float selectionWeightMultiplier = 1f;
+    public bool overrideSelectionWeight;
+    public int selectionWeight;
+    public bool overrideSpawnDistance;
+    public DirectorCore.MonsterSpawnDistance spawnDistance;
+    public bool overridePreventOverhead;
+    public bool preventOverhead;
+    public float minimumStageCompletionsMultiplier = 1f;
+    public bool overrideMinimumStageCompletions;
+    public int minimumStageCompletions;
+    public bool overrideRequiredUnlockableDef;
+    public AddressReferencedAssets.AddressReferencedUnlockableDef requiredUnlockableDef;
+    public bool overrideForbiddenUnlockableDef;
+    public AddressReferencedAssets.AddressReferencedUnlockableDef forbiddenUnlockableDef;
+    [Header("Cloning SpawnCard Settings")]
+    public float costMultiplier = 1f;
+    public bool overrideCost;
+    public int cost;
+    public bool overrideHullSize;
+    public HullClassification hullSize;
+    public bool overrideNodeGraphType;
+    public MapNodeGroup.GraphType nodeGrapthType;
+    public bool overrideRequiredFlags;
+    [EnumMask(typeof(NodeFlags))]
+    public NodeFlags requiredFlags;
+    public bool overrideForbiddenFlags;
+    [EnumMask(typeof(NodeFlags))]
+    public NodeFlags forbiddenFlags;
+    public bool overrideEliteRules;
+    [Tooltip("Default = default rules, ArtifactOnly = only elite when forced by the elite-only artifact, Lunar = special lunar elites only (+ regular w/ elite-only artifact)")]
+    public SpawnCard.EliteRules eliteRules;
+    public delegate bool CustomCondition(RebuildCardsInfo rebuildCardsInfo);
+    public CustomCondition customCondition;
+    public delegate void OnSpawnCardCloneAdded(RebuildCardsInfo rebuildCardsInfo);
+    public OnSpawnCardCloneAdded onSpawnCardCloneAdded;
+    private Dictionary<T, T> spawnCardOriginalToCloned = [];
+    private Dictionary<DirectorCard, DirectorCard> directorCardOriginalToCloned = [];
+    public virtual DirectorCard GetDirectorCard(DirectorCard originalDirectorCard)
+    {
+        if (!directorCardOriginalToCloned.TryGetValue(originalDirectorCard, out DirectorCard clonedDirectorCard))
+        {
+            clonedDirectorCard = new DirectorCard
+            {
+                selectionWeight = overrideSelectionWeight ? selectionWeight : (int)(originalDirectorCard.selectionWeight * selectionWeightMultiplier),
+                spawnDistance = overrideSpawnDistance ? spawnDistance : originalDirectorCard.spawnDistance,
+                preventOverhead = overridePreventOverhead ? preventOverhead : originalDirectorCard.preventOverhead,
+                minimumStageCompletions = overrideMinimumStageCompletions ? minimumStageCompletions : (int)(originalDirectorCard.minimumStageCompletions * minimumStageCompletionsMultiplier),
+                requiredUnlockableDef = overrideRequiredUnlockableDef ? requiredUnlockableDef.Asset : originalDirectorCard.requiredUnlockableDef,
+                forbiddenUnlockableDef = overrideForbiddenUnlockableDef ? forbiddenUnlockableDef.Asset : originalDirectorCard.forbiddenUnlockableDef
+            };
+            directorCardOriginalToCloned.Add(originalDirectorCard, clonedDirectorCard);
+        }
+        return clonedDirectorCard;
+    }
+    public virtual T GetSpawnCard(T originalSpawnCard)
+    {
+        if (overrideReturnSpawnCard.Asset && overrideReturnSpawnCard.Asset is T t) return t;
+        if (spawnCardOriginalToCloned.TryGetValue(originalSpawnCard, out T clonedSpawnCard)) return clonedSpawnCard;
+        clonedSpawnCard = CreateInstance<T>();
+        clonedSpawnCard.prefab = prefab.Asset;
+        (clonedSpawnCard as ScriptableObject).name = name;
+        UpdateValuesForClonedSpawnCard(originalSpawnCard, clonedSpawnCard);
+        return clonedSpawnCard;
+    }
+    public virtual void Register()
+    {
+        if (!SpawnCardCloningAPI.allSpawnCardClones.Contains(this)) SpawnCardCloningAPI.allSpawnCardClones.Add(this);
+        if (cloningType == CloningType.SpawnCard)
+        {
+            SpawnCard spawnCard = targetSpawnCard.Asset;
+            if (spawnCard)
+            {
+                if (SpawnCardCloningAPI.spawnCardClonesFromOriginalSpawnCard.TryGetValue(spawnCard, out List<object> list) && !list.Contains(this))
+                {
+                    list.Add(this);
+                }
+                else
+                {
+                    SpawnCardCloningAPI.spawnCardClonesFromOriginalSpawnCard.Add(spawnCard, [this]);
+                }
+            }
+        }
+        if (cloningType == CloningType.Prefab)
+        {
+            GameObject gameObject = targetPrefab.Asset;
+            if (gameObject)
+            {
+                if (SpawnCardCloningAPI.spawnCardClonesFromPrefab.TryGetValue(gameObject, out List<object> list) && !list.Contains(this))
+                {
+                    list.Add(this);
+                }
+                else
+                {
+                    SpawnCardCloningAPI.spawnCardClonesFromPrefab.Add(gameObject, [this]);
+                }
+            }
+        }
+    }
+    public virtual void Unregister()
+    {
+        if (SpawnCardCloningAPI.allSpawnCardClones.Contains(this)) SpawnCardCloningAPI.allSpawnCardClones.Remove(this);
+        SpawnCard spawnCard = targetSpawnCard.Asset;
+        if (spawnCard)
+        {
+            if (SpawnCardCloningAPI.spawnCardClonesFromOriginalSpawnCard.TryGetValue(spawnCard, out List<object> list) && list.Contains(this)) list.Remove(this); 
+        }
+        GameObject gameObject = targetPrefab.Asset;
+        if (gameObject)
+        {
+            if (SpawnCardCloningAPI.spawnCardClonesFromPrefab.TryGetValue(gameObject, out List<object> list) && list.Contains(this)) list.Remove(this);
+        }
+    }
+    public virtual void UpdateValuesForClonedSpawnCards()
+    {
+        foreach (var pair in spawnCardOriginalToCloned)
+        {
+            T originalSpawnCard = pair.Key;
+            T clonedSpawnCard = pair.Value;
+            if (!originalSpawnCard || !clonedSpawnCard) continue;
+            UpdateValuesForClonedSpawnCard(originalSpawnCard, clonedSpawnCard);
+        }
+    }
+    public virtual void UpdateValuesForClonedSpawnCard(T originalSpawnCard, T clonedSpawnCard)
+    {
+        clonedSpawnCard.directorCreditCost = overrideCost ? cost : (int)(clonedSpawnCard.directorCreditCost * costMultiplier);
+        clonedSpawnCard.eliteRules = overrideEliteRules ? eliteRules : clonedSpawnCard.eliteRules;
+        clonedSpawnCard.requiredFlags = overrideRequiredFlags ? requiredFlags : clonedSpawnCard.requiredFlags;
+        clonedSpawnCard.hullSize = overrideHullSize ? hullSize : clonedSpawnCard.hullSize;
+        clonedSpawnCard.nodeGraphType = overrideNodeGraphType ? nodeGrapthType : clonedSpawnCard.nodeGraphType;
+        clonedSpawnCard.forbiddenFlags = overrideForbiddenFlags ? forbiddenFlags : clonedSpawnCard.forbiddenFlags;
+    }
+    public enum CloningType
+    {
+        SpawnCard,
+        Prefab,
+        Prefabs
+    }
+}

--- a/R2API.Director/SpawnCardCloning/CharacterSpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/CharacterSpawnCardClone.cs
@@ -1,0 +1,37 @@
+﻿using JetBrains.Annotations;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+[CreateAssetMenu(fileName = "New CharacterSpawnCardClone", menuName = "R2API/DirectorAPI/SpawnCardCloning/CharacterSpawnCardClone")]
+public class CharacterSpawnCardClone : BaseSpawnCardClone<CharacterSpawnCard>
+{
+    [Header("Cloning CharacterSpawnCard Settings")]
+    public bool overrideNoElites;
+    public bool noElites;
+    public bool overrideForbiddenAsBoss;
+    public bool forbiddenAsBoss;
+    [CanBeNull]
+    [Tooltip("The loadout for any summoned character to use.")]
+    public SerializableLoadout loadout;
+    public bool overrideEquipmentToGrant;
+    [Tooltip("The set of equipment to grant to any summoned character, after inventory copy.")]
+    [NotNull]
+    public EquipmentDef[] equipmentToGrant = [];
+    public bool overrideItemsToGrant;
+    [NotNull]
+    [Tooltip("The set of items to grant to any summoned character, after inventory copy.")]
+    public ItemCountPair[] itemsToGrant = [];
+    public override void UpdateValuesForClonedSpawnCard(CharacterSpawnCard originalSpawnCard, CharacterSpawnCard clonedSpawnCard)
+    {
+        base.UpdateValuesForClonedSpawnCard(originalSpawnCard, clonedSpawnCard);
+        clonedSpawnCard.forbiddenAsBoss = overrideForbiddenAsBoss ? forbiddenAsBoss : originalSpawnCard.forbiddenAsBoss;
+        clonedSpawnCard.noElites = overrideNoElites ? noElites : originalSpawnCard.noElites;
+        clonedSpawnCard.equipmentToGrant = overrideEquipmentToGrant ? equipmentToGrant : originalSpawnCard.equipmentToGrant;
+        clonedSpawnCard.itemsToGrant = overrideItemsToGrant ? itemsToGrant : originalSpawnCard.itemsToGrant;
+
+    }
+}

--- a/R2API.Director/SpawnCardCloning/GameObjectArrayComparer.cs
+++ b/R2API.Director/SpawnCardCloning/GameObjectArrayComparer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+public class GameObjectArrayComparer : IEqualityComparer<GameObject[]>
+{
+    public bool Equals(GameObject[] x, GameObject[] y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null || x.Length != y.Length) return false;
+        for (int i = 0; i < x.Length; i++)
+        {
+            if (x[i] != y[i]) return false;
+        }
+        return true;
+    }
+    public int GetHashCode(GameObject[] obj)
+    {
+        if (obj == null) return 0;
+        int hash = 17;
+        foreach (var item in obj)
+        {
+            hash = hash * 31 + (item != null ? item.GetHashCode() : 0);
+        }
+        return hash;
+    }
+}

--- a/R2API.Director/SpawnCardCloning/GameObjectArrayDictionary.cs
+++ b/R2API.Director/SpawnCardCloning/GameObjectArrayDictionary.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+public class GameObjectArrayDictionary<T>
+{
+    private class Entry
+    {
+        public GameObject[] gameObjects;
+        public T t;
+        public Entry(GameObject[] gameObjects, T t)
+        {
+            this.gameObjects = gameObjects;
+            this.t = t;
+        }
+    }
+    private List<Entry> _entries = [];
+    public void Add(GameObject[] keys, T t)
+    {
+        if (keys == null) return;
+        _entries.Add(new Entry(keys, t));
+    }
+    public bool Remove(GameObject[] gameObjects, bool matchOrder, bool removeAllMatches = false)
+    {
+        if (gameObjects == null) return false;
+        if (removeAllMatches)
+        {
+            int removedCount = _entries.RemoveAll(entry => Match(entry.gameObjects, gameObjects, matchOrder));
+            return removedCount > 0;
+        }
+        else
+        {
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (Match(_entries[i].gameObjects, gameObjects, matchOrder))
+                {
+                    _entries.RemoveAt(i);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+    public void Clear() => _entries.Clear();
+    public bool ContainsKey(GameObject[] gameObjects, bool matchOrder)
+    {
+        foreach (var entry in _entries)
+        {
+            if (!Match(entry.gameObjects, gameObjects, matchOrder)) continue;
+            return true;
+        }
+        return false;
+    }
+    public bool TryGetValue(GameObject[] gameObjects, bool matchOrder, out T t)
+    {
+        foreach (Entry entry in _entries)
+        {
+            if (!Match(entry.gameObjects, gameObjects, matchOrder)) continue;
+            t = entry.t;
+            return true;
+        }
+        t = default;
+        return false;
+    }
+    private bool Match(GameObject[] entryGameObjects, GameObject[] inputGameObjects, bool matchOrder)
+    {
+        if (entryGameObjects == null || inputGameObjects == null || entryGameObjects.Length != inputGameObjects.Length) return false;
+        if (matchOrder)
+        {
+            for (int i = 0; i < entryGameObjects.Length; i++)
+            {
+                if (entryGameObjects[i] != inputGameObjects[i]) return false;
+            }
+            return true;
+        }
+        else
+        {
+            var entryGrameObejctsSorted = entryGameObjects.Select(go => go != null ? go.GetInstanceID() : 0).OrderBy(id => id);
+            var inputGameObjectsSorted = inputGameObjects.Select(go => go != null ? go.GetInstanceID() : 0).OrderBy(id => id);
+            return entryGrameObejctsSorted.SequenceEqual(inputGameObjectsSorted);
+        }
+    }
+}

--- a/R2API.Director/SpawnCardCloning/InteractableSpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/InteractableSpawnCardClone.cs
@@ -1,0 +1,45 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+[CreateAssetMenu(fileName = "New InteractableSpawnCardClone", menuName = "R2API/DirectorAPI/SpawnCardCloning/InteractableSpawnCardClone")]
+public class InteractableSpawnCardClone : BaseSpawnCardClone<InteractableSpawnCard>
+{
+    [Header("Cloning InteractableSpawnCard Settings")]
+    public bool overrideOrientToFloor;
+    [Tooltip("Whether or not to orient the object to the normal of the ground it spawns on.")]
+    public bool orientToFloor;
+    public bool overrideSlightlyRandomizeOrientation;
+    public bool slightlyRandomizeOrientation;
+    public bool overrideSkipSpawnWhenSacrificeArtifactEnabled;
+    public bool skipSpawnWhenSacrificeArtifactEnabled;
+    public float weightScalarWhenSacrificeArtifactEnabledMultiplier = 1f;
+    public bool overrideWeightScalarWhenSacrificeArtifactEnabled;
+    [Tooltip("When Sacrifice is enabled, this is multiplied by the card's weight")]
+    public float weightScalarWhenSacrificeArtifactEnabled = 1f;
+    public bool overrideSkipSpawnWhenDevotionArtifactEnabled;
+    public float maxSpawnsPerStageMultiplier = 1f;
+    public bool skipSpawnWhenDevotionArtifactEnabled;
+    public bool overrideMaxSpawnsPerStage;
+    [Tooltip("Won't spawn more than this many per stage.  If it's negative, there's no cap")]
+    public int maxSpawnsPerStage = -1;
+    public float prismaticTrialSpawnChanceMultiplier = 1f;
+    public bool overridePrismaticTrialSpawnChance;
+    [Range(0f, 1f)]
+    [Tooltip("When playing Primatic Trials, this interactable will have a required check to see if it is supposed to spawn. 0 is will not spawn, 1 will 100% spawn and will be default.")]
+    public float prismaticTrialSpawnChance = 1f;
+    public override void UpdateValuesForClonedSpawnCard(InteractableSpawnCard originalSpawnCard, InteractableSpawnCard clonedInteractableSpawnCard)
+    {
+        base.UpdateValuesForClonedSpawnCard(originalSpawnCard, clonedInteractableSpawnCard);
+        clonedInteractableSpawnCard.orientToFloor = overrideOrientToFloor ? orientToFloor : originalSpawnCard.orientToFloor;
+        clonedInteractableSpawnCard.slightlyRandomizeOrientation = overrideSlightlyRandomizeOrientation ? slightlyRandomizeOrientation : originalSpawnCard.slightlyRandomizeOrientation;
+        clonedInteractableSpawnCard.skipSpawnWhenSacrificeArtifactEnabled = overrideSkipSpawnWhenSacrificeArtifactEnabled ? skipSpawnWhenSacrificeArtifactEnabled : originalSpawnCard.skipSpawnWhenSacrificeArtifactEnabled;
+        clonedInteractableSpawnCard.weightScalarWhenSacrificeArtifactEnabled = overrideWeightScalarWhenSacrificeArtifactEnabled ? weightScalarWhenSacrificeArtifactEnabled : originalSpawnCard.weightScalarWhenSacrificeArtifactEnabled * weightScalarWhenSacrificeArtifactEnabledMultiplier;
+        clonedInteractableSpawnCard.skipSpawnWhenDevotionArtifactEnabled = overrideSkipSpawnWhenDevotionArtifactEnabled ? skipSpawnWhenDevotionArtifactEnabled : originalSpawnCard.skipSpawnWhenDevotionArtifactEnabled;
+        clonedInteractableSpawnCard.maxSpawnsPerStage = overrideMaxSpawnsPerStage ? maxSpawnsPerStage : (int)(originalSpawnCard.maxSpawnsPerStage * maxSpawnsPerStageMultiplier);
+        clonedInteractableSpawnCard.prismaticTrialSpawnChance = overridePrismaticTrialSpawnChance ? prismaticTrialSpawnChanceMultiplier : originalSpawnCard.prismaticTrialSpawnChance * prismaticTrialSpawnChanceMultiplier;
+    }
+}

--- a/R2API.Director/SpawnCardCloning/MultiCharacterSpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/MultiCharacterSpawnCardClone.cs
@@ -1,0 +1,88 @@
+﻿using JetBrains.Annotations;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+[CreateAssetMenu(fileName = "New MultiCharacterSpawnCardClone", menuName = "R2API/DirectorAPI/SpawnCardCloning/MultiCharacterSpawnCardClone")]
+internal class MultiCharacterSpawnCardClone : BaseSpawnCardClone<MultiCharacterSpawnCard>
+{
+    [Header("Base For Cloning")]
+    [Tooltip("Master prefabs to use for finding the spawn card to clone")]
+    public AddressReferencedAssets.AddressReferencedPrefab[] targetMasterPrefabs;
+    [Tooltip("If set to true, prefab order is respected. Otherwise order doesn't matter")]
+    public bool matchOrder;
+    [Tooltip("Master prefabs to override the original master prefabs of the spawn card")]
+    public AddressReferencedAssets.AddressReferencedPrefab[] masterPrefabs;
+    [Header("Cloning CharacterSpawnCard Settings")]
+    public bool overrideNoElites;
+    public bool noElites;
+    public bool overrideForbiddenAsBoss;
+    public bool forbiddenAsBoss;
+    [CanBeNull]
+    [Tooltip("The loadout for any summoned character to use.")]
+    public SerializableLoadout loadout;
+    public bool overrideEquipmentToGrant;
+    [Tooltip("The set of equipment to grant to any summoned character, after inventory copy.")]
+    [NotNull]
+    public EquipmentDef[] equipmentToGrant = [];
+    public bool overrideItemsToGrant;
+    [NotNull]
+    [Tooltip("The set of items to grant to any summoned character, after inventory copy.")]
+    public ItemCountPair[] itemsToGrant = [];
+    public override void UpdateValuesForClonedSpawnCard(MultiCharacterSpawnCard originalSpawnCard, MultiCharacterSpawnCard clonedMultiCharacterSpawnCard)
+    {
+        base.UpdateValuesForClonedSpawnCard(originalSpawnCard, clonedMultiCharacterSpawnCard);
+        List<GameObject> gameObjects = [];
+        foreach (AddressReferencedAssets.AddressReferencedPrefab addressReferencedPrefab in masterPrefabs) gameObjects.Add(addressReferencedPrefab.Asset);
+        clonedMultiCharacterSpawnCard.masterPrefabs = gameObjects.ToArray();
+        clonedMultiCharacterSpawnCard.forbiddenAsBoss = overrideForbiddenAsBoss ? forbiddenAsBoss : originalSpawnCard.forbiddenAsBoss;
+        clonedMultiCharacterSpawnCard.noElites = overrideNoElites ? noElites : originalSpawnCard.noElites;
+        clonedMultiCharacterSpawnCard.equipmentToGrant = overrideEquipmentToGrant ? equipmentToGrant : originalSpawnCard.equipmentToGrant;
+        clonedMultiCharacterSpawnCard.itemsToGrant = overrideItemsToGrant ? itemsToGrant : originalSpawnCard.itemsToGrant;
+    }
+    public override void Register()
+    {
+        base.Register();
+        if (cloningType != CloningType.Prefabs) return;
+        GameObject[] gameObjects = GetTargetMasterPrefabs();
+        if (gameObjects.Length == 0) return;
+        if (SpawnCardCloningAPI.multiCharacterSpawnCardClonesFromPrefab.TryGetValue(gameObjects, matchOrder, out List<object> list) && !list.Contains(this))
+        {
+            list.Add(this);
+        }
+        else
+        {
+            SpawnCardCloningAPI.multiCharacterSpawnCardClonesFromPrefab.Add(gameObjects, [this]);
+        }
+    }
+    public override void Unregister()
+    {
+        base.Unregister();
+        GameObject[] gameObjects = GetTargetMasterPrefabs();
+        if (gameObjects.Length == 0) return;
+        if (SpawnCardCloningAPI.multiCharacterSpawnCardClonesFromPrefab.TryGetValue(gameObjects, matchOrder, out List<object> list) && list.Contains(this)) list.Remove(this);
+    }
+    public GameObject[] GetTargetMasterPrefabs()
+    {
+        List<GameObject> gameObjects = [];
+        foreach (AddressReferencedAssets.AddressReferencedPrefab addressReferencedPrefab in targetMasterPrefabs)
+        {
+            GameObject gameObject = addressReferencedPrefab.Asset;
+            gameObjects.Add(gameObject);
+        }
+        return gameObjects.ToArray();
+    }
+    public GameObject[] GetMasterPrefabs()
+    {
+        List<GameObject> gameObjects = [];
+        foreach (AddressReferencedAssets.AddressReferencedPrefab addressReferencedPrefab in masterPrefabs)
+        {
+            GameObject gameObject = addressReferencedPrefab.Asset;
+            gameObjects.Add(gameObject);
+        }
+        return gameObjects.ToArray();
+    }
+}

--- a/R2API.Director/SpawnCardCloning/RebuildCardsInfo.cs
+++ b/R2API.Director/SpawnCardCloning/RebuildCardsInfo.cs
@@ -1,0 +1,23 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace R2API.SpawnCardCloning;
+public struct RebuildCardsInfo
+{
+    public ClassicStageInfo classicStageInfo;
+    public DirectorCardCategorySelection forcedMonsterCategory;
+    public DirectorCardCategorySelection forcedInteractableCategory;
+    public DccsPool dccsPool;
+    public DccsPool.Category[] categories;
+    public DccsPool.PoolEntry poolEntry;
+    public DirectorCardCategorySelection directorCardCategorySelection;
+    public DccsPool.Category dccsPoolCategory;
+    public DirectorCardCategorySelection.Category category;
+    public DirectorCard directorCard;
+    public SpawnCard spawnCard;
+    public object spawnCardClone;
+    public DirectorCard clonedDirectorCard;
+    public SpawnCard clonedSpawnCard;
+}

--- a/R2API.Director/SpawnCardCloning/SpawnCardClone.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardClone.cs
@@ -1,0 +1,12 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+[CreateAssetMenu(fileName = "New SpawnCardClone", menuName = "R2API/DirectorAPI/SpawnCardCloning/SpawnCardClone")]
+public class SpawnCardClone : BaseSpawnCardClone<SpawnCard>
+{
+
+}

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -1,0 +1,207 @@
+﻿using BepInEx;
+using MonoMod.RuntimeDetour;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+
+namespace R2API.SpawnCardCloning;
+public static partial class SpawnCardCloningAPI
+{
+    #region Internal
+    internal static List<object> allSpawnCardClones = [];
+    internal static Dictionary<SpawnCard, List<object>> spawnCardClonesFromOriginalSpawnCard = [];
+    internal static Dictionary<GameObject, List<object>> spawnCardClonesFromPrefab = [];
+    internal static GameObjectArrayDictionary<List<object>> multiCharacterSpawnCardClonesFromPrefab = new GameObjectArrayDictionary<List<object>>();
+    private static HashSet<DccsPool> appliedDccsPools = [];
+    private static Hook ClassicStageInfoRebuildCardsHook;
+    private static bool handledMixEnemyMonsterCards;
+    internal static void SetHooks()
+    {
+        ClassicStageInfoRebuildCardsHook = new Hook(typeof(ClassicStageInfo).GetMethod(nameof(ClassicStageInfo.RebuildCards), BindingFlags.NonPublic | BindingFlags.Instance), typeof(SpawnCardCloningAPI).GetMethod(nameof(ClassicStageInfo_RebuildCards), BindingFlags.NonPublic | BindingFlags.Static), new HookConfig { Priority = int.MaxValue });
+    }
+    internal static void UnsetHooks()
+    {
+        if (ClassicStageInfoRebuildCardsHook != null) ClassicStageInfoRebuildCardsHook.Undo();
+    }
+    private static void ClassicStageInfo_RebuildCards(On.RoR2.ClassicStageInfo.orig_RebuildCards orig, ClassicStageInfo self, DirectorCardCategorySelection forcedMonsterCategory, DirectorCardCategorySelection forcedInteractableCategory)
+    {
+        RebuildCardsInfo rebuildCardsInfo = new RebuildCardsInfo
+        {
+            classicStageInfo = self,
+            forcedInteractableCategory = forcedMonsterCategory,
+            forcedMonsterCategory = forcedInteractableCategory
+        };
+        if (!handledMixEnemyMonsterCards)
+        {
+            HandleDirectorCardCategorySelection(RoR2Content.mixEnemyMonsterCards, rebuildCardsInfo);
+            handledMixEnemyMonsterCards = true;
+        }
+        HandlDccsPool(self.monsterDccsPool, rebuildCardsInfo);
+        HandlDccsPool(self.interactableDccsPool, rebuildCardsInfo);
+        orig(self, forcedMonsterCategory, forcedInteractableCategory);
+    }
+    private static void HandlDccsPool(DccsPool dccsPool, RebuildCardsInfo rebuildCardsInfo)
+    {
+        rebuildCardsInfo.dccsPool = dccsPool;
+        if (!dccsPool || appliedDccsPools.Contains(dccsPool)) return;
+        try
+        {
+            HandlePoolCategories(dccsPool.poolCategories, rebuildCardsInfo);
+        }
+        catch (Exception e)
+        {
+            DirectorPlugin.Logger.LogError("Failed to setup cloned spawn cards for " + dccsPool.name);
+            DirectorPlugin.Logger.LogError(e);
+        }
+        appliedDccsPools.Add(dccsPool);
+    }
+    private static void HandlePoolCategories(DccsPool.Category[] categories, RebuildCardsInfo rebuildCardsInfo)
+    {
+        rebuildCardsInfo.categories = categories;
+        if (categories == null) return;
+        foreach (DccsPool.Category category in categories)
+        {
+            rebuildCardsInfo.dccsPoolCategory = category;
+            foreach (DccsPool.PoolEntry poolEntry in category.alwaysIncluded) HandlePoolEntry(poolEntry, rebuildCardsInfo);
+            foreach (DccsPool.PoolEntry poolEntry in category.includedIfConditionsMet)HandlePoolEntry(poolEntry, rebuildCardsInfo);
+            foreach (DccsPool.PoolEntry poolEntry in category.includedIfNoConditionsMet)HandlePoolEntry(poolEntry, rebuildCardsInfo);
+        }
+    }
+    private static void HandlePoolEntry(DccsPool.PoolEntry poolEntry, RebuildCardsInfo rebuildCardsInfo)
+    {
+        rebuildCardsInfo.poolEntry = poolEntry;
+        if (poolEntry == null) return;
+        DirectorCardCategorySelection directorCardCategorySelection = poolEntry.dccs;
+        if (!directorCardCategorySelection) return;
+        HandleDirectorCardCategorySelection(directorCardCategorySelection, rebuildCardsInfo);
+    }
+    private static void HandleDirectorCardCategorySelection(DirectorCardCategorySelection directorCardCategorySelection, RebuildCardsInfo rebuildCardsInfo)
+    {
+        rebuildCardsInfo.directorCardCategorySelection = directorCardCategorySelection;
+        Dictionary<DirectorCard, string> overrideCategories = [];
+        HashSet<string> validCategories = [];
+        foreach (DirectorCardCategorySelection.Category category in directorCardCategorySelection.categories)
+        {
+            if (category.name.IsNullOrWhiteSpace() || validCategories.Contains(category.name)) continue;
+            validCategories.Add(category.name);
+        }
+        for (int i = 0; i < directorCardCategorySelection.categories.Length; i++)
+        {
+            ref DirectorCardCategorySelection.Category category = ref directorCardCategorySelection.categories[i];
+            ref DirectorCard[] directorCards = ref category.cards;
+            rebuildCardsInfo.category = category;
+            if (directorCards == null || directorCards.Length == 0) continue;
+            HashSet<GameObject> appliedClonedSpawnCardPrefabs = [];
+            HashSet<GameObject[]> appliedClonedMultiCharacterSpawnCardPrefabs = new HashSet<GameObject[]>(new GameObjectArrayComparer());
+            foreach (DirectorCard directorCard in directorCards)
+            {
+                rebuildCardsInfo.directorCard = directorCard;
+                SpawnCard spawnCard = directorCard.spawnCard;
+                rebuildCardsInfo.spawnCard = spawnCard;
+                if (!spawnCard && directorCard.spawnCardReference != null) spawnCard = directorCard.spawnCardReference.Asset ? directorCard.spawnCardReference.Asset as SpawnCard : directorCard.spawnCardReference.LoadAssetAsync<SpawnCard>().WaitForCompletion();
+                if (!spawnCard || !spawnCard.prefab) continue;
+                if (spawnCard is CharacterSpawnCard characterSpawnCard) HandleSpawnCard<CharacterSpawnCardClone, CharacterSpawnCard>(ref category, appliedClonedSpawnCardPrefabs, directorCard, characterSpawnCard, overrideCategories, validCategories, rebuildCardsInfo);
+                if (spawnCard is InteractableSpawnCard interactableSpawnCard) HandleSpawnCard<InteractableSpawnCardClone, InteractableSpawnCard>(ref category, appliedClonedSpawnCardPrefabs, directorCard, interactableSpawnCard, overrideCategories, validCategories, rebuildCardsInfo);
+                if (spawnCard is MultiCharacterSpawnCard multiCharacterSpawnCard && !HandleMultiCharacterSpawnCard(ref category, appliedClonedMultiCharacterSpawnCardPrefabs, directorCard, multiCharacterSpawnCard, overrideCategories, validCategories, rebuildCardsInfo)) HandleSpawnCard<MultiCharacterSpawnCardClone, MultiCharacterSpawnCard>(ref category, appliedClonedSpawnCardPrefabs, directorCard, multiCharacterSpawnCard, overrideCategories, validCategories, rebuildCardsInfo);
+            }
+        }
+        foreach (var pair in overrideCategories)
+        {
+            DirectorCard directorCard = pair.Key;
+            if (directorCard == null) continue;
+            for (int i = 0; i < directorCardCategorySelection.categories.Length; i++)
+            {
+                ref DirectorCardCategorySelection.Category category = ref directorCardCategorySelection.categories[i];
+                if (category.name == pair.Value)
+                {
+                    int length = category.cards.Length;
+                    Array.Resize(ref category.cards, length + 1);
+                    category.cards[length] = directorCard;
+                    break;
+                }
+            }
+        }
+
+    }
+    private static void HandleSpawnCard<T1, T2>(ref DirectorCardCategorySelection.Category category, HashSet<GameObject> appliedClonedSpawnCardPrefabs, DirectorCard directorCard, T2 spawnCard, Dictionary<DirectorCard, string> overrideCategories, HashSet<string> validCategories, RebuildCardsInfo rebuildCardsInfo) where T1 : BaseSpawnCardClone<T2> where T2 : SpawnCard
+    {
+        if (spawnCardClonesFromPrefab.TryGetValue(spawnCard.prefab, out List<object> list) || spawnCardClonesFromOriginalSpawnCard.TryGetValue(spawnCard, out list))
+        {
+            if (list == null || list.Count == 0) return;
+            foreach (var item in list)
+            {
+                rebuildCardsInfo.spawnCardClone = item;
+                if (!(item is T1 spawnCardClone)) continue;
+                if (appliedClonedSpawnCardPrefabs.Contains(spawnCardClone.prefab)) continue;
+                appliedClonedSpawnCardPrefabs.Add(spawnCardClone.prefab);
+                DirectorCard clonedDirectorCard = spawnCardClone.GetDirectorCard(directorCard);
+                clonedDirectorCard.spawnCard = spawnCardClone.GetSpawnCard(spawnCard);
+                rebuildCardsInfo.clonedDirectorCard = clonedDirectorCard;
+                rebuildCardsInfo.clonedSpawnCard = clonedDirectorCard.spawnCard;
+                if (spawnCardClone.customCondition != null && !spawnCardClone.customCondition.Invoke(rebuildCardsInfo)) continue;
+                spawnCardClone.onSpawnCardCloneAdded?.Invoke(rebuildCardsInfo);
+                if (spawnCardClone.overrideCategory != null && spawnCardClone.overrideCategory.Length != 0)
+                {
+                    foreach (string categoryName in spawnCardClone.overrideCategory)
+                    {
+                        if (validCategories.Contains(categoryName))
+                        {
+                            overrideCategories.Add(clonedDirectorCard, categoryName);
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                int length = category.cards.Length;
+                Array.Resize(ref category.cards, length + 1);
+                category.cards[length] = clonedDirectorCard;
+            }
+        }
+    }
+    private static bool HandleMultiCharacterSpawnCard(ref DirectorCardCategorySelection.Category category, HashSet<GameObject[]> appliedClonedSpawnCardPrefabs, DirectorCard directorCard, MultiCharacterSpawnCard spawnCard, Dictionary<DirectorCard, string> overrideCategories, HashSet<string> validCategories, RebuildCardsInfo rebuildCardsInfo)
+    {
+        if (multiCharacterSpawnCardClonesFromPrefab.TryGetValue(spawnCard.masterPrefabs, false, out List<object> list))
+        {
+            if (list == null || list.Count == 0) return false;
+            foreach (var item in list)
+            {
+                rebuildCardsInfo.spawnCardClone = item;
+                if (!(item is MultiCharacterSpawnCardClone spawnCardClone)) continue;
+                GameObject[] gameObjects = spawnCardClone.GetMasterPrefabs();
+                if (appliedClonedSpawnCardPrefabs.Contains(gameObjects)) continue;
+                appliedClonedSpawnCardPrefabs.Add(gameObjects);
+                DirectorCard directorCard1 = spawnCardClone.GetDirectorCard(directorCard);
+                directorCard1.spawnCard = spawnCardClone.GetSpawnCard(spawnCard);
+                rebuildCardsInfo.clonedDirectorCard = directorCard1;
+                rebuildCardsInfo.clonedSpawnCard = directorCard1.spawnCard;
+                if (spawnCardClone.customCondition != null && !spawnCardClone.customCondition.Invoke(rebuildCardsInfo)) continue;
+                spawnCardClone.onSpawnCardCloneAdded?.Invoke(rebuildCardsInfo);
+                if (spawnCardClone.overrideCategory != null && spawnCardClone.overrideCategory.Length != 0)
+                {
+                    foreach (string categoryName in spawnCardClone.overrideCategory)
+                    {
+                        if (validCategories.Contains(categoryName))
+                        {
+                            overrideCategories.Add(directorCard1, categoryName);
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                int length = category.cards.Length;
+                Array.Resize(ref category.cards, length + 1);
+                category.cards[length] = directorCard1;
+            }
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    #endregion Internal
+}

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -69,12 +69,11 @@ public static partial class SpawnCardCloningAPI
         if (poolEntry == null) return;
         rebuildCardsInfo.poolEntry = poolEntry;
         DirectorCardCategorySelection directorCardCategorySelection = poolEntry.dccs;
-        if (!directorCardCategorySelection) return;
         HandleDirectorCardCategorySelection(directorCardCategorySelection, rebuildCardsInfo);
     }
     private static void HandleDirectorCardCategorySelection(DirectorCardCategorySelection directorCardCategorySelection, RebuildCardsInfo rebuildCardsInfo)
     {
-        if (directorCardCategorySelection.categories == null || directorCardCategorySelection.categories.Length == 0) return;
+        if (!directorCardCategorySelection || directorCardCategorySelection.categories == null || directorCardCategorySelection.categories.Length == 0) return;
         rebuildCardsInfo.directorCardCategorySelection = directorCardCategorySelection;
         Dictionary<DirectorCard, string> overrideCategories = [];
         HashSet<string> validCategories = [];

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -32,8 +32,8 @@ public static partial class SpawnCardCloningAPI
         RebuildCardsInfo rebuildCardsInfo = new RebuildCardsInfo
         {
             classicStageInfo = self,
-            forcedInteractableCategory = forcedMonsterCategory,
-            forcedMonsterCategory = forcedInteractableCategory
+            forcedInteractableCategory = forcedInteractableCategory,
+            forcedMonsterCategory = forcedMonsterCategory
         };
         if (!handledMixEnemyMonsterCards)
         {

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -17,15 +17,15 @@ public static partial class SpawnCardCloningAPI
     internal static Dictionary<GameObject, List<object>> spawnCardClonesFromPrefab = [];
     internal static GameObjectArrayDictionary<List<object>> multiCharacterSpawnCardClonesFromPrefab = new GameObjectArrayDictionary<List<object>>();
     private static HashSet<DccsPool> appliedDccsPools = [];
-    private static Hook ClassicStageInfoRebuildCardsHook;
     private static bool handledMixEnemyMonsterCards;
     internal static void SetHooks()
     {
-        ClassicStageInfoRebuildCardsHook = new Hook(typeof(ClassicStageInfo).GetMethod(nameof(ClassicStageInfo.RebuildCards), BindingFlags.NonPublic | BindingFlags.Instance), typeof(SpawnCardCloningAPI).GetMethod(nameof(ClassicStageInfo_RebuildCards), BindingFlags.NonPublic | BindingFlags.Static), new HookConfig { Priority = int.MaxValue });
+        On.RoR2.ClassicStageInfo.RebuildCards += ClassicStageInfo_RebuildCards;
     }
+
     internal static void UnsetHooks()
     {
-        if (ClassicStageInfoRebuildCardsHook != null) ClassicStageInfoRebuildCardsHook.Undo();
+        On.RoR2.ClassicStageInfo.RebuildCards -= ClassicStageInfo_RebuildCards;
     }
     private static void ClassicStageInfo_RebuildCards(On.RoR2.ClassicStageInfo.orig_RebuildCards orig, ClassicStageInfo self, DirectorCardCategorySelection forcedMonsterCategory, DirectorCardCategorySelection forcedInteractableCategory)
     {
@@ -46,25 +46,18 @@ public static partial class SpawnCardCloningAPI
     }
     private static void HandlDccsPool(DccsPool dccsPool, RebuildCardsInfo rebuildCardsInfo)
     {
-        rebuildCardsInfo.dccsPool = dccsPool;
         if (!dccsPool || appliedDccsPools.Contains(dccsPool)) return;
-        try
-        {
-            HandlePoolCategories(dccsPool.poolCategories, rebuildCardsInfo);
-        }
-        catch (Exception e)
-        {
-            DirectorPlugin.Logger.LogError("Failed to setup cloned spawn cards for " + dccsPool.name);
-            DirectorPlugin.Logger.LogError(e);
-        }
+        rebuildCardsInfo.dccsPool = dccsPool;
+        HandlePoolCategories(dccsPool.poolCategories, rebuildCardsInfo);
         appliedDccsPools.Add(dccsPool);
     }
     private static void HandlePoolCategories(DccsPool.Category[] categories, RebuildCardsInfo rebuildCardsInfo)
     {
-        rebuildCardsInfo.categories = categories;
         if (categories == null) return;
+        rebuildCardsInfo.categories = categories;
         foreach (DccsPool.Category category in categories)
         {
+            if (category == null) return;
             rebuildCardsInfo.dccsPoolCategory = category;
             foreach (DccsPool.PoolEntry poolEntry in category.alwaysIncluded) HandlePoolEntry(poolEntry, rebuildCardsInfo);
             foreach (DccsPool.PoolEntry poolEntry in category.includedIfConditionsMet)HandlePoolEntry(poolEntry, rebuildCardsInfo);
@@ -73,14 +66,15 @@ public static partial class SpawnCardCloningAPI
     }
     private static void HandlePoolEntry(DccsPool.PoolEntry poolEntry, RebuildCardsInfo rebuildCardsInfo)
     {
-        rebuildCardsInfo.poolEntry = poolEntry;
         if (poolEntry == null) return;
+        rebuildCardsInfo.poolEntry = poolEntry;
         DirectorCardCategorySelection directorCardCategorySelection = poolEntry.dccs;
         if (!directorCardCategorySelection) return;
         HandleDirectorCardCategorySelection(directorCardCategorySelection, rebuildCardsInfo);
     }
     private static void HandleDirectorCardCategorySelection(DirectorCardCategorySelection directorCardCategorySelection, RebuildCardsInfo rebuildCardsInfo)
     {
+        if (directorCardCategorySelection.categories == null || directorCardCategorySelection.categories.Length == 0) return;
         rebuildCardsInfo.directorCardCategorySelection = directorCardCategorySelection;
         Dictionary<DirectorCard, string> overrideCategories = [];
         HashSet<string> validCategories = [];
@@ -93,12 +87,13 @@ public static partial class SpawnCardCloningAPI
         {
             ref DirectorCardCategorySelection.Category category = ref directorCardCategorySelection.categories[i];
             ref DirectorCard[] directorCards = ref category.cards;
-            rebuildCardsInfo.category = category;
             if (directorCards == null || directorCards.Length == 0) continue;
+            rebuildCardsInfo.category = category;
             HashSet<GameObject> appliedClonedSpawnCardPrefabs = [];
             HashSet<GameObject[]> appliedClonedMultiCharacterSpawnCardPrefabs = new HashSet<GameObject[]>(new GameObjectArrayComparer());
             foreach (DirectorCard directorCard in directorCards)
             {
+                if (directorCard == null) continue;
                 rebuildCardsInfo.directorCard = directorCard;
                 SpawnCard spawnCard = directorCard.spawnCard;
                 rebuildCardsInfo.spawnCard = spawnCard;

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,8 +5,8 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "2.3.9"
-description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour"
+versionNumber = "3.0.0"
+description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour and cloning Spawn Cards"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 


### PR DESCRIPTION
Adds a system that allows for easy spawn cards cloning. For example if I want to add my own wisp that spawns alongside Lesser Wisp to all stages I create CharacterSpawnCardClone, set targetSpawnCard to Lesser Wisp spawn card, set my own wisp prefab, run register method and now all stages that use Lesser Wisp spawn card will also use cloned spawn card of Lesser Wisp with all of its values. Cloned Spawn Card values can be overridden individually. Also handles mix dccs

Tested most things except for MultiCharacterSpawnCardClone. Should work fine if GameObjectArrayDictionary and GameObjectArrayComparer work as expected. I don't think anyone would use MultiCharacterSpawnCardClone anyway
