### PR TITLE
R2API.Director: Fix spawn card clones not applying for the same dccs on next run

### DIFF
--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -20,6 +20,9 @@ Additionaly you can clone existing spawn cards and set new values for cloned spa
 
 ## Changelog
 
+### `3.0.1`
+* Fix spawn card clones not being able to be applied more than once for the dccspool in a single game session.
+
 ### `3.0.0`
 * Added SpawnCardCloningAPI for cloning existing spawn cards.
 

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -16,24 +16,15 @@ public static partial class SpawnCardCloningAPI
     internal static Dictionary<SpawnCard, List<object>> spawnCardClonesFromOriginalSpawnCard = [];
     internal static Dictionary<GameObject, List<object>> spawnCardClonesFromPrefab = [];
     internal static GameObjectArrayDictionary<List<object>> multiCharacterSpawnCardClonesFromPrefab = new GameObjectArrayDictionary<List<object>>();
-    private static HashSet<DccsPool.Category> appliedDccsPoolCategories = [];
     private static bool handledMixEnemyMonsterCards;
     internal static void SetHooks()
     {
         On.RoR2.ClassicStageInfo.RebuildCards += ClassicStageInfo_RebuildCards;
-        On.RoR2.DccsPool.Category.OnBeforeSerialize += Category_OnBeforeSerialize;
-    }
-
-    private static void Category_OnBeforeSerialize(On.RoR2.DccsPool.Category.orig_OnBeforeSerialize orig, DccsPool.Category self)
-    {
-        orig(self);
-        if (appliedDccsPoolCategories.Contains(self)) appliedDccsPoolCategories.Remove(self);
     }
 
     internal static void UnsetHooks()
     {
         On.RoR2.ClassicStageInfo.RebuildCards -= ClassicStageInfo_RebuildCards;
-        On.RoR2.DccsPool.Category.OnBeforeSerialize -= Category_OnBeforeSerialize;
     }
     private static void ClassicStageInfo_RebuildCards(On.RoR2.ClassicStageInfo.orig_RebuildCards orig, ClassicStageInfo self, DirectorCardCategorySelection forcedMonsterCategory, DirectorCardCategorySelection forcedInteractableCategory)
     {
@@ -64,8 +55,7 @@ public static partial class SpawnCardCloningAPI
         rebuildCardsInfo.categories = categories;
         foreach (DccsPool.Category category in categories)
         {
-            if (category == null || appliedDccsPoolCategories.Contains(category)) return;
-            appliedDccsPoolCategories.Add(category);
+            if (category == null) return;
             rebuildCardsInfo.dccsPoolCategory = category;
             foreach (DccsPool.PoolEntry poolEntry in category.alwaysIncluded) HandlePoolEntry(poolEntry, rebuildCardsInfo);
             foreach (DccsPool.PoolEntry poolEntry in category.includedIfConditionsMet)HandlePoolEntry(poolEntry, rebuildCardsInfo);
@@ -120,6 +110,7 @@ public static partial class SpawnCardCloningAPI
                 ref DirectorCardCategorySelection.Category category = ref directorCardCategorySelection.categories[i];
                 if (category.name == pair.Value)
                 {
+                    if (category.cards.Contains(directorCard)) continue;
                     int length = category.cards.Length;
                     Array.Resize(ref category.cards, length + 1);
                     category.cards[length] = directorCard;
@@ -158,6 +149,7 @@ public static partial class SpawnCardCloningAPI
                     }
                     continue;
                 }
+                if (category.cards.Contains(clonedDirectorCard)) continue;
                 int length = category.cards.Length;
                 Array.Resize(ref category.cards, length + 1);
                 category.cards[length] = clonedDirectorCard;
@@ -194,6 +186,7 @@ public static partial class SpawnCardCloningAPI
                     }
                     continue;
                 }
+                if (category.cards.Contains(directorCard1)) continue;
                 int length = category.cards.Length;
                 Array.Resize(ref category.cards, length + 1);
                 category.cards[length] = directorCard1;

--- a/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
+++ b/R2API.Director/SpawnCardCloning/SpawnCardCloningAPI.cs
@@ -16,16 +16,24 @@ public static partial class SpawnCardCloningAPI
     internal static Dictionary<SpawnCard, List<object>> spawnCardClonesFromOriginalSpawnCard = [];
     internal static Dictionary<GameObject, List<object>> spawnCardClonesFromPrefab = [];
     internal static GameObjectArrayDictionary<List<object>> multiCharacterSpawnCardClonesFromPrefab = new GameObjectArrayDictionary<List<object>>();
-    private static HashSet<DccsPool> appliedDccsPools = [];
+    private static HashSet<DccsPool.Category> appliedDccsPoolCategories = [];
     private static bool handledMixEnemyMonsterCards;
     internal static void SetHooks()
     {
         On.RoR2.ClassicStageInfo.RebuildCards += ClassicStageInfo_RebuildCards;
+        On.RoR2.DccsPool.Category.OnBeforeSerialize += Category_OnBeforeSerialize;
+    }
+
+    private static void Category_OnBeforeSerialize(On.RoR2.DccsPool.Category.orig_OnBeforeSerialize orig, DccsPool.Category self)
+    {
+        orig(self);
+        if (appliedDccsPoolCategories.Contains(self)) appliedDccsPoolCategories.Remove(self);
     }
 
     internal static void UnsetHooks()
     {
         On.RoR2.ClassicStageInfo.RebuildCards -= ClassicStageInfo_RebuildCards;
+        On.RoR2.DccsPool.Category.OnBeforeSerialize -= Category_OnBeforeSerialize;
     }
     private static void ClassicStageInfo_RebuildCards(On.RoR2.ClassicStageInfo.orig_RebuildCards orig, ClassicStageInfo self, DirectorCardCategorySelection forcedMonsterCategory, DirectorCardCategorySelection forcedInteractableCategory)
     {
@@ -46,10 +54,9 @@ public static partial class SpawnCardCloningAPI
     }
     private static void HandlDccsPool(DccsPool dccsPool, RebuildCardsInfo rebuildCardsInfo)
     {
-        if (!dccsPool || appliedDccsPools.Contains(dccsPool)) return;
+        if (!dccsPool) return;
         rebuildCardsInfo.dccsPool = dccsPool;
         HandlePoolCategories(dccsPool.poolCategories, rebuildCardsInfo);
-        appliedDccsPools.Add(dccsPool);
     }
     private static void HandlePoolCategories(DccsPool.Category[] categories, RebuildCardsInfo rebuildCardsInfo)
     {
@@ -57,7 +64,8 @@ public static partial class SpawnCardCloningAPI
         rebuildCardsInfo.categories = categories;
         foreach (DccsPool.Category category in categories)
         {
-            if (category == null) return;
+            if (category == null || appliedDccsPoolCategories.Contains(category)) return;
+            appliedDccsPoolCategories.Add(category);
             rebuildCardsInfo.dccsPoolCategory = category;
             foreach (DccsPool.PoolEntry poolEntry in category.alwaysIncluded) HandlePoolEntry(poolEntry, rebuildCardsInfo);
             foreach (DccsPool.PoolEntry poolEntry in category.includedIfConditionsMet)HandlePoolEntry(poolEntry, rebuildCardsInfo);

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "3.0.0"
+versionNumber = "3.0.1"
 description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour and cloning Spawn Cards"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false


### PR DESCRIPTION
Changed `HashSet<DccsPool> appliedDccsPools`  to `HashSet<DccsPool.Category> appliedDccsPoolCategories` so that once dccpool updates its categories after resealization spawn card clones could apply their changes again... turns out by just holding category in a hashset it never resealizes, which still fixes the issue. However I am concerned about the memory issues of always keeping dccs pool category in a hashet. I don't know if it the issue has any effect