### PR TITLE
R2API.Director: add enabling/disabling stage Combat Directors event

### DIFF
--- a/R2API.Director/DirectorAPIexternal.cs
+++ b/R2API.Director/DirectorAPIexternal.cs
@@ -29,6 +29,22 @@ public static partial class DirectorAPI
     public static bool Loaded => true;
 
     /// <summary>
+    /// Subscribe to this event to modify activity of stage combat directors. Fired during CombatDirector.FixedUpdate.
+    /// </summary>
+    public static event GetCombatDirectorActivityCountDelegate GetCombatDirectorActivityCount
+    {
+        add
+        {
+            SetHooks();
+            _getCombatDirectorActivityCount += value;
+        }
+        remove
+        {
+            _getCombatDirectorActivityCount -= value;
+        }
+    }
+
+    /// <summary>
     /// Event used to edit <see cref="StageSettings"/>.
     /// </summary>
     public static event Action<StageSettings, StageInfo>? StageSettingsActions;

--- a/R2API.Director/DirectorAPIexternal.cs
+++ b/R2API.Director/DirectorAPIexternal.cs
@@ -29,7 +29,7 @@ public static partial class DirectorAPI
     public static bool Loaded => true;
 
     /// <summary>
-    /// Subscribe to this event to modify activity of stage combat directors. Fired during CombatDirector.FixedUpdate.
+    /// Subscribe to this event to modify activity of combat directors. Fired during CombatDirector.FixedUpdate. If activityCount is higher than 0, Combat Director will remain running even when disabled. If activityCount is lower than 0, Combat Director will not run.
     /// </summary>
     public static event GetCombatDirectorActivityCountDelegate GetCombatDirectorActivityCount
     {
@@ -943,4 +943,6 @@ public static partial class DirectorAPI
         /// </summary>
         public string? SelectionChatString;
     }
+
+    public static bool IsStageCombatDirector(this CombatDirector combatDirector) => IsStageCombatDirectorInternal(combatDirector);
 }

--- a/R2API.Director/DirectorAPIinternal.cs
+++ b/R2API.Director/DirectorAPIinternal.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using HG;
+using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using R2API.Utils;
 using RoR2;
@@ -18,6 +19,11 @@ public static partial class DirectorAPI
 
     private static bool _hooksEnabled = false;
 
+    public delegate void GetCombatDirectorActivityCountDelegate(CombatDirector combatDirector, ref int activityCount);
+
+    private static event GetCombatDirectorActivityCountDelegate _getCombatDirectorActivityCount;
+
+    internal static HashSet<CombatDirector> currentStageCombatDirectorsHashSet = [];
     internal static void SetHooks()
     {
         if (_hooksEnabled)
@@ -41,6 +47,9 @@ public static partial class DirectorAPI
 
         On.RoR2.SceneCatalog.Init += InitStageEnumToSceneDefs;
 
+        On.RoR2.DirectorCore.OnEnable += AddRunCombatDirectorsFixedUpdateComponent;
+
+        IL.RoR2.CombatDirector.FixedUpdate += CombatDirector_FixedUpdate;
         _hooksEnabled = true;
     }
 
@@ -51,7 +60,49 @@ public static partial class DirectorAPI
 
         On.RoR2.SceneCatalog.Init -= InitStageEnumToSceneDefs;
 
+        On.RoR2.DirectorCore.OnEnable -= AddRunCombatDirectorsFixedUpdateComponent;
+
+        IL.RoR2.CombatDirector.FixedUpdate -= CombatDirector_FixedUpdate;
+
         _hooksEnabled = false;
+    }
+    private static void CombatDirector_FixedUpdate(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        ILLabel iLLabel = null;
+        if (!c.TryGotoNext(MoveType.After,
+               x => x.MatchCall(typeof(Run).GetPropertyGetter(nameof(Run.instance))),
+               x => x.MatchCall<UnityEngine.Object>("op_Implicit"),
+               x => x.MatchBrfalse(out iLLabel)
+            ))
+        {
+            DirectorPlugin.Logger.LogError(il.Method.Name + " IL Hook failed!");
+            return;
+        }
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(HandleCombatDirectorInactivity);
+        c.Emit(OpCodes.Brfalse_S, iLLabel);
+    }
+    private static bool HandleCombatDirectorInactivity(CombatDirector combatDirector)
+    {
+        if (!currentStageCombatDirectorsHashSet.Contains(combatDirector) || !combatDirector.enabled) return true;
+        int activityCount = 0;
+        _getCombatDirectorActivityCount?.Invoke(combatDirector, ref activityCount);
+        if (activityCount < 0) return false;
+        return true;
+    }
+    internal static bool HandleCombatDirectorActivity(CombatDirector combatDirector)
+    {
+        if (combatDirector.enabled) return false;
+        int activityCount = 0;
+        _getCombatDirectorActivityCount?.Invoke(combatDirector, ref activityCount);
+        if (activityCount > 0) return true;
+        return false;
+    }
+    private static void AddRunCombatDirectorsFixedUpdateComponent(On.RoR2.DirectorCore.orig_OnEnable orig, DirectorCore self)
+    {
+        orig(self);
+        RunCombatDirectorsFixedUpdate runCombatDirectorsFixedUdpate = self.gameObject.EnsureComponent<RunCombatDirectorsFixedUpdate>();
     }
 
     private static void ApplyChangesOnStart(On.RoR2.ClassicStageInfo.orig_Start orig, ClassicStageInfo classicStageInfo)

--- a/R2API.Director/DirectorAPIinternal.cs
+++ b/R2API.Director/DirectorAPIinternal.cs
@@ -23,7 +23,9 @@ public static partial class DirectorAPI
 
     private static event GetCombatDirectorActivityCountDelegate _getCombatDirectorActivityCount;
 
-    internal static HashSet<CombatDirector> currentStageCombatDirectorsHashSet = [];
+    internal static HashSet<CombatDirector> _currentStageCombatDirectorsHashSet = [];
+
+    internal static List<CombatDirector> _allCombatDirectors = [];
     internal static void SetHooks()
     {
         if (_hooksEnabled)
@@ -50,6 +52,9 @@ public static partial class DirectorAPI
         On.RoR2.DirectorCore.OnEnable += AddRunCombatDirectorsFixedUpdateComponent;
 
         IL.RoR2.CombatDirector.FixedUpdate += CombatDirector_FixedUpdate;
+
+        On.RoR2.CombatDirector.Awake += CombatDirector_Awake;
+
         _hooksEnabled = true;
     }
 
@@ -64,7 +69,14 @@ public static partial class DirectorAPI
 
         IL.RoR2.CombatDirector.FixedUpdate -= CombatDirector_FixedUpdate;
 
+        On.RoR2.CombatDirector.Awake -= CombatDirector_Awake;
+
         _hooksEnabled = false;
+    }
+    private static void CombatDirector_Awake(On.RoR2.CombatDirector.orig_Awake orig, CombatDirector self)
+    {
+        orig(self);
+        _allCombatDirectors.Add(self);
     }
     private static void CombatDirector_FixedUpdate(ILContext il)
     {
@@ -85,7 +97,7 @@ public static partial class DirectorAPI
     }
     private static bool HandleCombatDirectorInactivity(CombatDirector combatDirector)
     {
-        if (!currentStageCombatDirectorsHashSet.Contains(combatDirector) || !combatDirector.enabled) return true;
+        if (!combatDirector.enabled) return true;
         int activityCount = 0;
         _getCombatDirectorActivityCount?.Invoke(combatDirector, ref activityCount);
         if (activityCount < 0) return false;
@@ -93,7 +105,7 @@ public static partial class DirectorAPI
     }
     internal static bool HandleCombatDirectorActivity(CombatDirector combatDirector)
     {
-        if (combatDirector.enabled) return false;
+        if (combatDirector.enabled || combatDirector.moneyWaves == null) return false;
         int activityCount = 0;
         _getCombatDirectorActivityCount?.Invoke(combatDirector, ref activityCount);
         if (activityCount > 0) return true;
@@ -770,4 +782,6 @@ public static partial class DirectorAPI
             dccs.categories[i] = category;
         }
     }
+
+    private static bool IsStageCombatDirectorInternal(CombatDirector combatDirector) => _currentStageCombatDirectorsHashSet.Contains(combatDirector);
 }

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -16,14 +16,14 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 Additionaly you can clone existing spawn cards and set new values for cloned spawn cards using CharacterSpawnCardClone, InteractableSpawnCardClone and MultiCharacterSpawnCardClone.
 
-Also provides an event to easily enable/disable stage Combat Directors.
+Also provides an event to easily enable/disable Combat Directors. Provides an extension method IsStageCombatDirector to check is Combat Director part of stage Combat Directors
 
 ## Related Pages
 
 ## Changelog
 
 ## `3.1.0`
-* Added enabling/disabling stage Combat Directors event.
+* Added enabling/disabling Combat Directors event.
 
 ### `3.0.1`
 * Fix spawn card clones not being able to be applied more than once for the dccspool in a single game session.

--- a/R2API.Director/README.md
+++ b/R2API.Director/README.md
@@ -16,9 +16,14 @@ Alongside this, R2API.Director also comes bundled with DirectorAPIHelpers, which
 
 Additionaly you can clone existing spawn cards and set new values for cloned spawn cards using CharacterSpawnCardClone, InteractableSpawnCardClone and MultiCharacterSpawnCardClone.
 
+Also provides an event to easily enable/disable stage Combat Directors.
+
 ## Related Pages
 
 ## Changelog
+
+## `3.1.0`
+* Added enabling/disabling stage Combat Directors event.
 
 ### `3.0.1`
 * Fix spawn card clones not being able to be applied more than once for the dccspool in a single game session.

--- a/R2API.Director/RunCombatDirectorsFixedUpdate.cs
+++ b/R2API.Director/RunCombatDirectorsFixedUpdate.cs
@@ -12,17 +12,23 @@ public class RunCombatDirectorsFixedUpdate : MonoBehaviour
     public CombatDirector[] combatDirectors;
     public void Awake()
     {
-        currentStageCombatDirectorsHashSet.Clear();
+        _currentStageCombatDirectorsHashSet.Clear();
         combatDirectors = GetComponents<CombatDirector>();
         if (combatDirectors == null) return;
-        foreach (CombatDirector combatDirector in combatDirectors) currentStageCombatDirectorsHashSet.Add(combatDirector);
+        foreach (CombatDirector combatDirector in combatDirectors) _currentStageCombatDirectorsHashSet.Add(combatDirector);
     }
     public void FixedUpdate()
     {
         if (combatDirectors == null) return;
-        foreach (CombatDirector combatDirector in combatDirectors)
+        for (int i = 0; i < _allCombatDirectors.Count; i++)
         {
-            if (!combatDirector || !HandleCombatDirectorActivity(combatDirector)) continue;
+            CombatDirector combatDirector = _allCombatDirectors[i];
+            if (!combatDirector)
+            {
+                _allCombatDirectors.RemoveAt(i);
+                continue;
+            }
+            if (!HandleCombatDirectorActivity(combatDirector)) continue;
             combatDirector.FixedUpdate();
         }
     }

--- a/R2API.Director/RunCombatDirectorsFixedUpdate.cs
+++ b/R2API.Director/RunCombatDirectorsFixedUpdate.cs
@@ -19,6 +19,7 @@ public class RunCombatDirectorsFixedUpdate : MonoBehaviour
     }
     public void FixedUpdate()
     {
+        if (combatDirectors == null) return;
         foreach (CombatDirector combatDirector in combatDirectors)
         {
             if (!combatDirector || !HandleCombatDirectorActivity(combatDirector)) continue;

--- a/R2API.Director/RunCombatDirectorsFixedUpdate.cs
+++ b/R2API.Director/RunCombatDirectorsFixedUpdate.cs
@@ -1,0 +1,28 @@
+﻿using RoR2;
+using RoR2BepInExPack.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using static R2API.DirectorAPI;
+
+namespace R2API;
+public class RunCombatDirectorsFixedUpdate : MonoBehaviour
+{
+    public CombatDirector[] combatDirectors;
+    public void Awake()
+    {
+        currentStageCombatDirectorsHashSet.Clear();
+        combatDirectors = GetComponents<CombatDirector>();
+        if (combatDirectors == null) return;
+        foreach (CombatDirector combatDirector in combatDirectors) currentStageCombatDirectorsHashSet.Add(combatDirector);
+    }
+    public void FixedUpdate()
+    {
+        foreach (CombatDirector combatDirector in combatDirectors)
+        {
+            if (!combatDirector || !HandleCombatDirectorActivity(combatDirector)) continue;
+            combatDirector.FixedUpdate();
+        }
+    }
+}

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -6,7 +6,7 @@ schemaVersion = "0.0.1"
 namespace = "RiskofThunder"
 name = "R2API_Director"
 versionNumber = "3.1.0"
-description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour, cloning Spawn Cards and enabling/disabling stage Combat Directors"
+description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour, cloning Spawn Cards and enabling/disabling Combat Directors"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 

--- a/R2API.Director/thunderstore.toml
+++ b/R2API.Director/thunderstore.toml
@@ -5,8 +5,8 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "RiskofThunder"
 name = "R2API_Director"
-versionNumber = "3.0.1"
-description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour and cloning Spawn Cards"
+versionNumber = "3.1.0"
+description = "API for easily modifiying the Director (RoR2 monster / interactable spawner) behaviour, cloning Spawn Cards and enabling/disabling stage Combat Directors"
 websiteUrl = "https://github.com/risk-of-thunder/R2API"
 containsNsfwContent = false
 


### PR DESCRIPTION
Adds an event that allows easily enabling or disabling stage Combat Directors for solving potential incompatibilities. Solution is a bit hacky but it works and shouldn't cause issues (Tested in big modpack).

If int activationCount from GetCombatDirectorActivityCountDelegate(CombatDirector combatDirector, ref int activityCount) _getCombatDirectorActivityCount event is higher than 0, then stage Combat Directors will always run even when they are disabled from something like teleporter, if less than 0 Combat Directors will never run and if equals 0 they will act as usual